### PR TITLE
Fixing bug with non-default cpu memory types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for TransferBench
 
+## v1.07
+### Changed
+- Fix bug with allocations involving non-default CPU memory types
+
 ## v1.06
 ### Added
 - Added unpinned CPU memory type ('U').  May require HSA_XNACK=1 in order to access via GPU executors

--- a/EnvVars.hpp
+++ b/EnvVars.hpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include <algorithm>
 #include <random>
 #include <time.h>
-#define TB_VERSION "1.06"
+#define TB_VERSION "1.07"
 
 extern char const MemTypeStr[];
 

--- a/TransferBench.cpp
+++ b/TransferBench.cpp
@@ -546,7 +546,7 @@ int RemappedIndex(int const origIdx, MemType const memType)
   static std::vector<int> remapping;
 
   // No need to re-map CPU devices
-  if (memType == MEM_CPU) return origIdx;
+  if (IsCpuType(memType)) return origIdx;
 
   // Build remapping on first use
   if (remapping.empty())


### PR DESCRIPTION
Forgot to fix remapping code after adding additional CPU memory types.