### PR TITLE
Fixing large Transfers, more mismatch debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog for TransferBench
 
+## v1.15
+### Fixed
+- Fixed a bug that prevented single Transfers > 8GB
+### Changed
+- Removed "check for latest ROCm" warning when allocating too much memory
+- Printing off source memory value as well when mis-match is detected
+
 ## v1.14
 ### Added
 - Added documentation
 - Added pthread linking in src/Makefile and CMakeLists.txt
 - Added printing off the hex value of the floats for output and reference
- 
+
 ## v1.13
 ### Added
 - Added support for cmake

--- a/src/include/EnvVars.hpp
+++ b/src/include/EnvVars.hpp
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #include <time.h>
 #include "Kernels.hpp"
 
-#define TB_VERSION "1.14"
+#define TB_VERSION "1.15"
 
 extern char const MemTypeStr[];
 extern char const ExeTypeStr[];


### PR DESCRIPTION
- Fixing a bug with large transfers > 8GB
- Adding additional debug information when mismatch occurs
- Removing misleading error warning on host memory allocation error