### PR TITLE
Fixing SAMPLING_FACTOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for TransferBench
 
+## v1.21
+### Fixed
+- Fixed bug with SAMPLING_FACTOR
+
 ## v1.20
 ### Fixed
 - VALIDATE_DIRECT can now be used with USE_PREP_KERNEL

--- a/src/TransferBench.cpp
+++ b/src/TransferBench.cpp
@@ -129,11 +129,11 @@ int main(int argc, char **argv)
       // Otherwise generate a range of values
       for (int N = 256; N <= (1<<27); N *= 2)
       {
-        int delta = std::max(32, N / ev.samplingFactor);
+        int delta = std::max(1, N / ev.samplingFactor);
         int curr = N;
         while (curr < N * 2)
         {
-          ExecuteTransfers(ev, ++testNum, N, transfers);
+          ExecuteTransfers(ev, ++testNum, curr, transfers);
           curr += delta;
         }
       }

--- a/src/include/EnvVars.hpp
+++ b/src/include/EnvVars.hpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 #include "Compatibility.hpp"
 #include "Kernels.hpp"
 
-#define TB_VERSION "1.20"
+#define TB_VERSION "1.21"
 
 extern char const MemTypeStr[];
 extern char const ExeTypeStr[];


### PR DESCRIPTION
- Fixing SAMPLING_FACTOR (used only when sweeping byte size)