### PR TITLE
Adding preset scaling benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for TransferBench
 
+## v1.23
+### Added
+- New GPU subexec scaling benchmark accessed by preset "scaling"
+  - Tests GPU-GFX copy performance based on # of CUs used
+
 ## v1.22
 ### Modified
 - Switching kernel timing function to wall_clock64

--- a/src/include/EnvVars.hpp
+++ b/src/include/EnvVars.hpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 #include "Compatibility.hpp"
 #include "Kernels.hpp"
 
-#define TB_VERSION "1.22"
+#define TB_VERSION "1.23"
 
 extern char const MemTypeStr[];
 extern char const ExeTypeStr[];
@@ -38,7 +38,8 @@ enum ConfigModeEnum
 {
   CFG_FILE  = 0,
   CFG_P2P   = 1,
-  CFG_SWEEP = 2
+  CFG_SWEEP = 2,
+  CFG_SCALE = 3
 };
 
 // This class manages environment variable that affect TransferBench

--- a/src/include/TransferBench.hpp
+++ b/src/include/TransferBench.hpp
@@ -182,6 +182,7 @@ void DeallocateMemory(MemType memType, void* memPtr, size_t const size = 0);
 void CheckPages(char* byteArray, size_t numBytes, int targetId);
 void RunTransfer(EnvVars const& ev, int const iteration, ExecutorInfo& exeInfo, int const transferIdx);
 void RunPeerToPeerBenchmarks(EnvVars const& ev, size_t N);
+void RunScalingBenchmark(EnvVars const& ev, size_t N, int const exeIndex, int const maxSubExecs);
 void RunSweepPreset(EnvVars const& ev, size_t const numBytesPerTransfer, int const numGpuSubExec, int const numCpuSubExec, bool const isRandom);
 
 // Return the maximum bandwidth measured for given (src/dst) pair


### PR DESCRIPTION
Adding new preset benchmark "scaling".
- This preset benchmark measures copy performance using GPU_GFX to other devices with varying # of SubExecutors

Example output:
```
GPU-GFX Scaling benchmark:
==========================
- Copying 67108864 bytes from GPU 0 to other devices
- All numbers reported as GB/sec

NumCUs   CPU00        CPU01        GPU00        GPU01        GPU02        GPU03
   1     14.11        14.02        20.30        20.25        20.17        20.38
   2     14.11        14.02        38.94        33.26        33.42        32.49
   3     14.08        14.01        56.06        33.43        33.63        32.65
   4     14.06        13.99        72.15        33.48        33.68        32.67
   5     14.04        13.94        87.87        33.53        33.61        32.70
   6     13.88        13.83       103.18        33.52        33.66        32.65
   7     13.70        13.64       117.85        33.49        33.69        32.62
   8     13.50        13.44       132.32        33.52        33.62        32.65
   9     13.41        13.38       144.45        33.46        33.60        32.57
  10     13.24        13.26       156.36        33.47        33.55        32.60
  11     13.17        13.21       165.78        33.44        33.54        32.55
  12     13.09        13.07       175.03        33.43        33.49        32.55
  13     13.10        13.06       183.27        33.31        33.42        32.49
  14     13.04        13.01       192.40        33.43        33.48        32.50
  15     12.96        12.94       202.25        33.35        33.44        32.42
  16     12.89        12.88       207.05        33.32        33.41        32.32
  17     12.90        12.89       219.98        33.29        33.32        32.37
  18     12.90        12.88       226.87        33.27        33.33        32.42
  19     12.87        12.84       229.85        33.33        33.33        32.38
  20     12.88        12.84       239.96        33.36        33.35        32.42
  21     12.86        12.85       248.70        33.34        33.31        32.35
  22     12.84        12.83       254.20        33.25        33.24        32.32
  23     12.83        12.82       259.97        33.14        33.23        32.30
  24     12.83        12.80       260.55        33.27        33.27        32.35
  25     12.77        12.77       267.20        33.16        33.22        32.23
  26     12.78        12.80       273.67        33.21        33.22        32.21
  27     12.79        12.77       278.32        33.22        33.14        32.30
  28     12.80        12.79       285.60        33.11        33.17        32.28
  29     12.80        12.79       283.04        33.17        33.17        32.23
  30     12.75        12.75       292.02        33.16        33.22        32.21
  31     12.78        12.78       296.42        33.11        33.14        32.10
  32     12.84        12.80       284.49        33.08        33.06        32.13
 Best    14.11(  1)   14.02(  2)  296.42( 31)   33.53(  5)   33.69(  7)   32.70(  5)
```
