### PR TITLE
Adding SHOW_ITERATIONS to provide additional per-iteration timing info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## v1.26
 ### Added
 - Setting SHOW_ITERATIONS=1 provides additional information about per-iteration timing for file and p2p configs
-- For p2p, min/max/standard deviation is shown for each direction.
+  - For file configs, iterations are sorted from min to max bandwidth and displayed with standard deviation
+  - For p2p, min/max/standard deviation is shown for each direction.
 
 ### Changed
 - P2P benchmark formatting changed.  Now reports bidirectional bandwidth in each direction (as well as sum) for clarity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog for TransferBench
 
+## v1.26
+### Added
+- Setting SHOW_ITERATIONS=1 provides additional information about per-iteration timing for file and p2p configs
+- For p2p, min/max/standard deviation is shown for each direction.
+
+### Changed
+- P2P benchmark formatting changed.  Now reports bidirectional bandwidth in each direction (as well as sum) for clarity
+
 ## v1.25
 ### Fixed
 - Fixed bug in P2P bidirectional benchmark using incorrect number of subExecutors for CPU<->GPU tests

--- a/src/include/EnvVars.hpp
+++ b/src/include/EnvVars.hpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 #include "Compatibility.hpp"
 #include "Kernels.hpp"
 
-#define TB_VERSION "1.25"
+#define TB_VERSION "1.26"
 
 extern char const MemTypeStr[];
 extern char const ExeTypeStr[];
@@ -75,6 +75,7 @@ public:
   int outputToCsv;       // Output in CSV format
   int samplingFactor;    // Affects how many different values of N are generated (when N set to 0)
   int sharedMemBytes;    // Amount of shared memory to use per threadblock
+  int showIterations;    // Show per-iteration timing info
   int useInteractive;    // Pause for user-input before starting transfer loop
   int usePcieIndexing;   // Base GPU indexing on PCIe address instead of HIP device
   int usePrepSrcKernel;  // Use GPU kernel to prepare source data instead of copy (can't be used with fillPattern)
@@ -155,6 +156,7 @@ public:
     outputToCsv       = GetEnvVar("OUTPUT_TO_CSV"       , 0);
     samplingFactor    = GetEnvVar("SAMPLING_FACTOR"     , DEFAULT_SAMPLING_FACTOR);
     sharedMemBytes    = GetEnvVar("SHARED_MEM_BYTES"    , defaultSharedMemBytes);
+    showIterations    = GetEnvVar("SHOW_ITERATIONS"     , 0);
     useInteractive    = GetEnvVar("USE_INTERACTIVE"     , 0);
     usePcieIndexing   = GetEnvVar("USE_PCIE_INDEX"      , 0);
     usePrepSrcKernel  = GetEnvVar("USE_PREP_KERNEL"     , 0);
@@ -164,10 +166,10 @@ public:
     gpuKernel         = GetEnvVar("GPU_KERNEL"          , defaultGpuKernel);
 
     // P2P Benchmark related
-    useRemoteRead    = GetEnvVar("USE_REMOTE_READ"      , 0);
-    useDmaCopy       = GetEnvVar("USE_GPU_DMA"          , 0);
-    numGpuSubExecs   = GetEnvVar("NUM_GPU_SE"           , useDmaCopy ? 1 : numDeviceCUs);
-    numCpuSubExecs   = GetEnvVar("NUM_CPU_SE"           , DEFAULT_P2P_NUM_CPU_SE);
+    useRemoteRead     = GetEnvVar("USE_REMOTE_READ"     , 0);
+    useDmaCopy        = GetEnvVar("USE_GPU_DMA"         , 0);
+    numGpuSubExecs    = GetEnvVar("NUM_GPU_SE"          , useDmaCopy ? 1 : numDeviceCUs);
+    numCpuSubExecs    = GetEnvVar("NUM_CPU_SE"          , DEFAULT_P2P_NUM_CPU_SE);
 
     // Sweep related
     sweepMin          = GetEnvVar("SWEEP_MIN"           , DEFAULT_SWEEP_MIN);
@@ -382,6 +384,7 @@ public:
     printf(" OUTPUT_TO_CSV          - Outputs to CSV format if set\n");
     printf(" SAMPLING_FACTOR=F      - Add F samples (when possible) between powers of 2 when auto-generating data sizes\n");
     printf(" SHARED_MEM_BYTES=X     - Use X shared mem bytes per threadblock, potentially to avoid multiple threadblocks per CU\n");
+    printf(" SHOW_ITERATIONS        - Show per-iteration timing info\n");
     printf(" USE_INTERACTIVE        - Pause for user-input before starting transfer loop\n");
     printf(" USE_PCIE_INDEX         - Index GPUs by PCIe address-ordering instead of HIP-provided indexing\n");
     printf(" USE_PREP_KERNEL        - Use GPU kernel to initialize source data array pattern\n");
@@ -429,6 +432,8 @@ public:
              std::string("Running " + std::to_string(numWarmups) + " warmup iteration(s) per Test"));
     PRINT_EV("SHARED_MEM_BYTES", sharedMemBytes,
              std::string("Using " + std::to_string(sharedMemBytes) + " shared mem per threadblock"));
+    PRINT_EV("SHOW_ITERATIONS", showIterations,
+             std::string(showIterations ? "Showing" : "Hiding") + " per-iteration timing");
     PRINT_EV("USE_INTERACTIVE", useInteractive,
              std::string("Running in ") + (useInteractive ? "interactive" : "non-interactive") + " mode");
     PRINT_EV("USE_PCIE_INDEX", usePcieIndexing,

--- a/src/include/TransferBench.hpp
+++ b/src/include/TransferBench.hpp
@@ -119,6 +119,8 @@ struct Transfer
   std::vector<SubExecParam> subExecParam;       // Defines subarrays assigned to each threadblock
   SubExecParam*             subExecParamGpuPtr; // Pointer to GPU copy of subExecParam
 
+  std::vector<double>       perIterationTime;   // Per-iteration timing
+
   // Prepares src/dst subarray pointers for each SubExecutor
   void PrepareSubExecParams(EnvVars const& ev);
 

--- a/src/include/TransferBench.hpp
+++ b/src/include/TransferBench.hpp
@@ -189,12 +189,6 @@ void RunScalingBenchmark(EnvVars const& ev, size_t N, int const exeIndex, int co
 void RunSweepPreset(EnvVars const& ev, size_t const numBytesPerTransfer, int const numGpuSubExec, int const numCpuSubExec, bool const isRandom);
 void RunAllToAllBenchmark(EnvVars const& ev, size_t const numBytesPerTransfer, int const numSubExecs);
 
-// Return the maximum bandwidth measured for given (src/dst) pair
-double GetPeakBandwidth(EnvVars const& ev, size_t  const  N,
-                        int     const  isBidirectional,
-                        MemType const  srcType, int const srcIndex,
-                        MemType const  dstType, int const dstIndex);
-
 std::string GetLinkTypeDesc(uint32_t linkType, uint32_t hopCount);
 
 int RemappedIndex(int const origIdx, bool const isCpuType);


### PR DESCRIPTION
For configFile runs, setting SHOW_ITERATIONS will show per-iteration timing (sorted from fastest to slowest)
```
Test 1:
 Transfer 00      |  33.520 GB/s |    2.002 ms |     67108864 bytes | G0 -> GPU00:004 -> G1
      Iter 006    |  33.616 GB/s |    1.996 ms |
      Iter 010    |  33.573 GB/s |    1.999 ms |
      Iter 008    |  33.573 GB/s |    1.999 ms |
      Iter 009    |  33.549 GB/s |    2.000 ms |
      Iter 002    |  33.546 GB/s |    2.000 ms |
      Iter 003    |  33.544 GB/s |    2.001 ms |
      Iter 004    |  33.522 GB/s |    2.002 ms |
      Iter 007    |  33.517 GB/s |    2.002 ms |
      Iter 005    |  33.458 GB/s |    2.006 ms |
      Iter 001    |  33.307 GB/s |    2.015 ms |
      StandardDev |    4.887e-03 |
 Aggregate (CPU)  |  29.349 GB/s |    2.287 ms |     67108864 bytes | Overhead: 0.285 ms

```
For peer to peer benchmark, additional min/max/standard deviation is shown:

```
Unidirectional copy peak bandwidth GB/s [Local read / Remote write] (GPU-Executor: GFX)
 SRC+EXE\DST    CPU 00    CPU 01    GPU 00    GPU 01    GPU 02    GPU 03
  CPU 00  ->     15.54     19.80      9.88      8.77      9.65      6.87
  CPU 00 min     14.24     18.77      9.82      8.72      9.46      6.78
  CPU 00 max     17.95     20.63      9.95      8.83      9.77      6.92
  CPU 00  sd   3.3e-01   9.6e-02   3.4e-02   2.6e-02   6.3e-02   5.7e-02
  CPU 01  ->     19.71     15.58      9.89      8.75      9.64      6.88
  CPU 01 min     18.79     14.08      9.80      8.63      9.51      6.85
  CPU 01 max     20.62     18.06      9.99      8.86      9.77      6.91
  CPU 01  sd   1.2e-01   3.8e-01   4.6e-02   5.8e-02   5.3e-02   2.5e-02
  GPU 00  ->     12.74     12.63    299.38     32.78     32.77     31.83
  GPU 00 min     12.69     12.55    239.81     32.73     32.72     31.79
  GPU 00 max     12.78     12.72    316.31     32.81     32.81     31.88
  GPU 00  sd   1.0e-02   2.6e-02   1.9e-02   1.4e-03   1.6e-03   1.6e-03
  GPU 01  ->     12.55     12.58     32.78    306.29     31.83     32.77
  GPU 01 min     12.20     12.31     32.69    298.95     31.69     32.64
  GPU 01 max     12.75     12.71     32.81    319.44     31.87     32.80
  GPU 01  sd   7.0e-02   4.7e-02   2.0e-03   4.1e-03   3.1e-03   2.8e-03
  GPU 02  ->     12.70     12.66     32.26     31.70    310.83     32.21
  GPU 02 min     12.64     12.59     32.17     31.65    300.45     32.14
  GPU 02 max     12.76     12.74     32.33     31.74    324.89     32.27
  GPU 02  sd   1.8e-02   1.8e-02   2.6e-03   1.6e-03   4.3e-03   2.7e-03
  GPU 03  ->     10.73     10.47     31.33     32.25     32.21    305.69
  GPU 03 min     10.56     10.27     31.28     32.23     32.16    289.86
  GPU 03 max     10.80     10.87     31.38     32.29     32.27    317.99
  GPU 03  sd   2.4e-02   1.0e-01   1.8e-03   1.2e-03   1.7e-03   5.8e-03

Bidirectional copy peak bandwidth GB/s [Local read / Remote write] (GPU-Executor: GFX)
     SRC\DST    CPU 00    CPU 01    GPU 00    GPU 01    GPU 02    GPU 03
  CPU 00  ->       N/A     15.41      9.51      8.72      9.51      6.84
  CPU 00 min       N/A     12.31      9.39      8.60      9.28      6.78
  CPU 00 max       N/A     17.74      9.59      8.82      9.59      6.90
  CPU 00  sd       N/A   4.1e-01   3.3e-02   5.2e-02   6.6e-02   4.5e-02
  CPU 00 <-        N/A     15.82     12.54     11.92     12.55     10.60
  CPU 00 min       N/A     15.08     12.48     11.83     12.48     10.23
  CPU 00 max       N/A     18.81     12.62     11.99     12.63     10.87
  CPU 00  sd       N/A   2.6e-01   1.7e-02   2.0e-02   2.2e-02   1.2e-01
  CPU 00 <->       N/A     31.23     22.05     20.65     22.06     17.44

  CPU 01  ->     16.02       N/A      9.70      8.76      9.57      6.88
  CPU 01 min     15.62       N/A      9.54      8.67      9.37      6.82
  CPU 01 max     16.90       N/A      9.85      8.86      9.68      6.93
  CPU 01  sd   9.6e-02       N/A   5.5e-02   5.3e-02   6.5e-02   4.8e-02
  CPU 01 <-      15.67       N/A      7.59      7.04      7.56      5.69
  CPU 01 min     14.94       N/A      7.51      6.99      7.48      5.65
  CPU 01 max     16.92       N/A      7.68      7.10      7.62      5.72
  CPU 01  sd   1.7e-01       N/A   5.9e-02   4.6e-02   5.2e-02   4.8e-02
  CPU 01 <->     31.69       N/A     17.30     15.80     17.13     12.56

  GPU 00  ->     12.52      7.58       N/A     31.01     31.26     12.27
  GPU 00 min     12.38      7.49       N/A     30.95     31.20     12.06
  GPU 00 max     12.60      7.64       N/A     31.08     31.31     12.61
  GPU 00  sd   1.9e-02   5.5e-02       N/A   3.1e-03   1.9e-03   7.6e-02
  GPU 00 <-       9.57      9.68       N/A     31.03     30.76     11.62
  GPU 00 min      9.46      9.55       N/A     30.99     30.72     11.42
  GPU 00 max      9.63      9.81       N/A     31.07     30.87     11.95
  GPU 00  sd   3.9e-02   5.5e-02       N/A   1.4e-03   3.0e-03   8.0e-02
  GPU 00 <->     22.09     17.26       N/A     62.05     62.02     23.89

  GPU 01  ->     11.92      7.04     31.02       N/A     12.19     31.27
  GPU 01 min     11.85      7.02     30.97       N/A     11.99     31.07
  GPU 01 max     12.00      7.11     31.07       N/A     12.53     31.36
  GPU 01  sd   2.3e-02   3.8e-02   2.0e-03       N/A   6.8e-02   5.1e-03
  GPU 01 <-       8.74      8.74     31.01       N/A     11.55     30.80
  GPU 01 min      8.60      8.67     30.73       N/A     11.36     30.74
  GPU 01 max      8.79      8.83     31.12       N/A     11.84     30.88
  GPU 01  sd   4.7e-02   3.1e-02   7.4e-03       N/A   7.0e-02   2.9e-03
  GPU 01 <->     20.66     15.78     62.03       N/A     23.74     62.06

  GPU 02  ->     12.51      7.53     30.77     11.58       N/A     30.80
  GPU 02 min     12.33      7.50     30.64     11.37       N/A     30.75
  GPU 02 max     12.63      7.63     30.85     11.82       N/A     30.85
  GPU 02  sd   2.6e-02   4.3e-02   2.8e-03   6.8e-02       N/A   2.3e-03
  GPU 02 <-       9.42      9.60     31.26     12.23       N/A     30.80
  GPU 02 min      9.13      9.49     31.22     12.04       N/A     30.71
  GPU 02 max      9.62      9.67     31.30     12.49       N/A     30.85
  GPU 02  sd   9.1e-02   4.0e-02   1.6e-03   6.5e-02       N/A   3.0e-03
  GPU 02 <->     21.93     17.14     62.03     23.81       N/A     61.60

  GPU 03  ->     10.55      5.66     11.57     30.78     30.77       N/A
  GPU 03 min     10.10      5.62     11.40     30.61     30.68       N/A
  GPU 03 max     10.85      5.72     11.71     30.89     30.84       N/A
  GPU 03  sd   9.1e-02   5.5e-02   4.7e-02   5.2e-03   2.6e-03       N/A
  GPU 03 <-       6.84      6.86     12.21     31.26     30.78       N/A
  GPU 03 min      6.80      6.81     12.01     31.15     30.75       N/A
  GPU 03 max      6.88      6.92     12.36     31.34     30.83       N/A
  GPU 03  sd   3.0e-02   4.2e-02   4.9e-02   4.1e-03   1.9e-03       N/A
  GPU 03 <->     17.39     12.53     23.79     62.04     61.56       N/A
```