### PR TITLE
Update rtd config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,9 +6,15 @@ version: 2
 sphinx:
    configuration: docs/conf.py
 
-formats: [htmlzip]
+formats: [htmlzip, pdf, epub]
 
 python:
-   version: "3.8"
    install:
    - requirements: docs/.sphinx/requirements.txt
+
+build:
+   os: ubuntu-20.04
+   tools:
+      python: "3.8"
+   apt_packages:
+     - "doxygen"


### PR DESCRIPTION
use build.os in the .readthedocs.yaml config

https://docs.readthedocs.io/en/stable/config-file/v2.html

build.image (which is what is currently used implicitly) will be deprecated in October 2023