### PR TITLE
v1.27 CU Masking, cmdline preset, CUDA fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog for TransferBench
 
+## v1.27
+### Added
+- Adding cmdline preset to allow specify simple tests on command line
+- E.g. ./TransferBench cmdline 64M "1 4 G0->G0->G1"
+- Adding environment variable HIDE_ENV, which skips printing of environment variable values
+- Adding environment variable CU_MASK, which allows selection of which CUs to execute on
+- CU_MASK is specified in CU indices (0-#CUs-1), and '-' can be used to denote ranges of values
+  - E.g.: CU_MASK=3-8,16 would request Transfer be executed only CUs 3,4,5,6,7,8,16
+  - NOTE: This is somewhat experimental and may not work on all hardware
+- SHOW_ITERATIONS now shows CU usage for that iteration (experimental)
+### Modified
+- Adding extra comments on commonly missing includes with details on how to install them
+### Fixed
+- CUDA compilation should work again (wall_clock64 CUDA alias was not defined)
+
 ## v1.26
 ### Added
 - Setting SHOW_ITERATIONS=1 provides additional information about per-iteration timing for file and p2p configs

--- a/src/TransferBench.cpp
+++ b/src/TransferBench.cpp
@@ -1372,7 +1372,6 @@ void RunPeerToPeerBenchmarks(EnvVars const& ev, size_t N)
     printf("\n");
 
     ExeType const gpuExeType = ev.useDmaCopy ? EXE_GPU_DMA : EXE_GPU_GFX;
-
     // Loop over all possible src/dst pairs
     for (int src = 0; src < numDevices; src++)
     {
@@ -1506,7 +1505,6 @@ void RunPeerToPeerBenchmarks(EnvVars const& ev, size_t N)
           // minBw
           printf("%5s %02d %3s", (srcType == MEM_CPU) ? "CPU" : "GPU", srcIndex, "min");
           if (ev.outputToCsv) printf(",");
-
           for (int i = 0; i < numDevices; i++)
           {
             double const minBw = minBandwidth[dir][i];

--- a/src/TransferBench.cpp
+++ b/src/TransferBench.cpp
@@ -313,8 +313,13 @@ void ExecuteTransfers(EnvVars const& ev,
       {
         // Allocate one contiguous chunk of GPU memory for threadblock parameters
         // This allows support for executing one transfer per stream, or all transfers in a single stream
+#if !defined(__NVCC__)
         AllocateMemory(MEM_GPU, exeIndex, exeInfo.totalSubExecs * sizeof(SubExecParam),
                        (void**)&exeInfo.subExecParamGpu);
+#else
+        AllocateMemory(MEM_CPU, exeIndex, exeInfo.totalSubExecs * sizeof(SubExecParam),
+                       (void**)&exeInfo.subExecParamGpu);
+#endif
       }
     }
   }
@@ -663,7 +668,11 @@ cleanup:
 
       if (exeType == EXE_GPU_GFX)
       {
+#if !defined(__NVCC__)
         DeallocateMemory(MEM_GPU, exeInfo.subExecParamGpu);
+#else
+        DeallocateMemory(MEM_CPU, exeInfo.subExecParamGpu);
+#endif
       }
     }
   }

--- a/src/TransferBench.cpp
+++ b/src/TransferBench.cpp
@@ -297,7 +297,9 @@ void ExecuteTransfers(EnvVars const& ev,
       {
         if (ev.cuMask.size())
         {
+#if !defined(__NVCC__)
           HIP_CALL(hipExtStreamCreateWithCUMask(&exeInfo.streams[i], ev.cuMask.size(), ev.cuMask.data()));
+#endif
         }
         else
         {

--- a/src/include/Compatibility.hpp
+++ b/src/include/Compatibility.hpp
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include <cuda_runtime.h>
 
 // ROCm specific
-#define __builtin_amdgcn_s_memrealtime                     clock64
+#define wall_clock64                                       clock64
 #define gcnArchName                                        name
 
 // Datatypes

--- a/src/include/EnvVars.hpp
+++ b/src/include/EnvVars.hpp
@@ -262,6 +262,9 @@ public:
     char* cuMaskStr = getenv("CU_MASK");
     if (cuMaskStr != NULL)
     {
+#if defined(__NVCC__)
+      printf("[WARN] CU_MASK is not supported in CUDA\n");
+#else
       std::vector<std::pair<int, int>> ranges;
       int maxCU = 0;
       char* token = strtok(cuMaskStr, ",");
@@ -294,6 +297,7 @@ public:
           cuMask[i / 32] |= (1 << (i % 32));
         }
       }
+#endif
     }
 
     // Perform some basic validation

--- a/src/include/Kernels.hpp
+++ b/src/include/Kernels.hpp
@@ -41,7 +41,17 @@ struct SubExecParam
   float*    dst[MAX_DSTS];                      // Destination array pointers
   long long startCycle;                         // Start timestamp for in-kernel timing (GPU-GFX executor)
   long long stopCycle;                          // Stop  timestamp for in-kernel timing (GPU-GFX executor)
+  uint32_t  hwId;                               // Hardware ID
 };
+
+// Macro for collecting HW_REG_HW_ID
+#if defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || defined(__NVCC__)
+#define __trace_hwreg() \
+  p.hwId = 0
+#else
+#define __trace_hwreg() \
+  asm volatile ("s_getreg_b32 %0, hwreg(HW_REG_HW_ID)" : "=s" (p.hwId));
+#endif
 
 void CpuReduceKernel(SubExecParam const& p)
 {
@@ -211,6 +221,7 @@ GpuReduceKernel(SubExecParam* params)
   {
     p.startCycle = startCycle;
     p.stopCycle  = wall_clock64();
+    __trace_hwreg();
   }
 }
 

--- a/src/include/TransferBench.hpp
+++ b/src/include/TransferBench.hpp
@@ -81,7 +81,7 @@ char const ExeTypeName[3][4] = {"CPU", "GPU", "DMA"};
 MemType inline CharToMemType(char const c)
 {
   char const* val = strchr(MemTypeStr, toupper(c));
-  if (*val) return (MemType)(val - MemTypeStr);
+  if (val) return (MemType)(val - MemTypeStr);
   printf("[ERROR] Unexpected memory type (%c)\n", c);
   exit(1);
 }
@@ -89,7 +89,7 @@ MemType inline CharToMemType(char const c)
 ExeType inline CharToExeType(char const c)
 {
   char const* val = strchr(ExeTypeStr, toupper(c));
-  if (*val) return (ExeType)(val - ExeTypeStr);
+  if (val) return (ExeType)(val - ExeTypeStr);
   printf("[ERROR] Unexpected executor type (%c)\n", c);
   exit(1);
 }
@@ -98,28 +98,29 @@ ExeType inline CharToExeType(char const c)
 // then writes the summation to each of the specified destination memory location(s)
 struct Transfer
 {
-  int                       transferIndex;      // Transfer identifier (within a Test)
-  ExeType                   exeType;            // Transfer executor type
-  int                       exeIndex;           // Executor index (NUMA node for CPU / device ID for GPU)
-  int                       numSubExecs;        // Number of subExecutors to use for this Transfer
-  size_t                    numBytes;           // # of bytes requested to Transfer (may be 0 to fallback to default)
-  size_t                    numBytesActual;     // Actual number of bytes to copy
-  double                    transferTime;       // Time taken in milliseconds
+  int                        transferIndex;      // Transfer identifier (within a Test)
+  ExeType                    exeType;            // Transfer executor type
+  int                        exeIndex;           // Executor index (NUMA node for CPU / device ID for GPU)
+  int                        numSubExecs;        // Number of subExecutors to use for this Transfer
+  size_t                     numBytes;           // # of bytes requested to Transfer (may be 0 to fallback to default)
+  size_t                     numBytesActual;     // Actual number of bytes to copy
+  double                     transferTime;       // Time taken in milliseconds
 
-  int                       numSrcs;            // Number of sources
-  std::vector<MemType>      srcType;            // Source memory types
-  std::vector<int>          srcIndex;           // Source device indice
-  std::vector<float*>       srcMem;             // Source memory
+  int                        numSrcs;            // Number of sources
+  std::vector<MemType>       srcType;            // Source memory types
+  std::vector<int>           srcIndex;           // Source device indice
+  std::vector<float*>        srcMem;             // Source memory
 
-  int                       numDsts;            // Number of destinations
-  std::vector<MemType>      dstType;            // Destination memory type
-  std::vector<int>          dstIndex;           // Destination device index
-  std::vector<float*>       dstMem;             // Destination memory
+  int                        numDsts;            // Number of destinations
+  std::vector<MemType>       dstType;            // Destination memory type
+  std::vector<int>           dstIndex;           // Destination device index
+  std::vector<float*>        dstMem;             // Destination memory
 
-  std::vector<SubExecParam> subExecParam;       // Defines subarrays assigned to each threadblock
-  SubExecParam*             subExecParamGpuPtr; // Pointer to GPU copy of subExecParam
+  std::vector<SubExecParam>  subExecParam;       // Defines subarrays assigned to each threadblock
+  SubExecParam*              subExecParamGpuPtr; // Pointer to GPU copy of subExecParam
 
-  std::vector<double>       perIterationTime;   // Per-iteration timing
+  std::vector<double>        perIterationTime;   // Per-iteration timing
+  std::vector<std::set<int>> perIterationCUs;    // Per-iteration CU usage
 
   // Prepares src/dst subarray pointers for each SubExecutor
   void PrepareSubExecParams(EnvVars const& ev);


### PR DESCRIPTION
## v1.27
### Added
- Adding cmdline preset to allow specify simple tests on command line
- E.g. ./TransferBench cmdline 64M "1 4 G0->G0->G1"
- Adding environment variable HIDE_ENV, which skips printing of environment variable values
- Adding environment variable CU_MASK, which allows selection of which CUs to execute on
- CU_MASK is specified in CU indices (0-#CUs-1), and '-' can be used to denote ranges of values
  - E.g.: CU_MASK=3-8,16 would request Transfer be executed only CUs 3,4,5,6,7,8,16
  - NOTE: This is somewhat experimental and may not work on all hardware
- SHOW_ITERATIONS now shows CU usage for that iteration (experimental)
### Modified
- Adding extra comments on commonly missing includes with details on how to install them
### Fixed
- CUDA compilation should work again (wall_clock64 CUDA alias was not defined)
