### PR TITLE
Minor changes to p2p, a2a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog for TransferBench
 
+## v1.28
+### Added
+- Added A2A_DIRECT which only executes all-to-all only directly connected GPUs (on by default now)
+- Added average statistics for p2p and a2a benchmarks
+- Added USE_FINE_GRAIN for p2p benchmark.
+  - With older devices, p2p performance with default coarse grain device memory stops timing as soon as request sent to data fabric,
+    not actually when it arrives remotely, which may artificially inflate bandwidth numbers, especially when sending small amounts of data
+### Modified
+- Modified P2P output to help distinguish between CPU / GPU devices
+### Fixed
+- Fixed Makefile target to prevent unnecessary re-compilation
+
 ## v1.27
 ### Added
 - Adding cmdline preset to allow specify simple tests on command line

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,9 +7,9 @@ NVCC=$(CUDA_PATH)/bin/nvcc
 
 # Compile TransferBenchCuda if nvcc detected
 ifeq ("$(shell test -e $(NVCC) && echo found)", "found")
-	EXE=TransferBenchCuda
+	EXE=../TransferBenchCuda
 else
-	EXE=TransferBench
+	EXE=../TransferBench
 endif
 
 CXXFLAGS = -O3 -Iinclude -I$(ROCM_PATH)/include -lnuma -L$(ROCM_PATH)/lib -lhsa-runtime64
@@ -17,11 +17,11 @@ NVFLAGS = -O3 -g -Iinclude -x cu -lnuma -gencode=arch=compute_80,code=sm_80 -gen
 LDFLAGS    += -lpthread
 all: $(EXE)
 
-TransferBench: TransferBench.cpp $(shell find -regex ".*\.\hpp")
-	$(HIPCC) $(CXXFLAGS) $< -o ../$@ $(LDFLAGS)
+../TransferBench: TransferBench.cpp $(shell find -regex ".*\.\hpp")
+	$(HIPCC) $(CXXFLAGS) $< -o $@ $(LDFLAGS)
 
-TransferBenchCuda: TransferBench.cpp $(shell find -regex ".*\.\hpp")
-	$(NVCC) $(NVFLAGS) $< -o ../$@ $(LDFLAGS)
+../TransferBenchCuda: TransferBench.cpp $(shell find -regex ".*\.\hpp")
+	$(NVCC) $(NVFLAGS) $< -o $@ $(LDFLAGS)
 
 clean:
 	rm -f *.o ../TransferBench ../TransferBenchCuda

--- a/src/include/Kernels.hpp
+++ b/src/include/Kernels.hpp
@@ -219,8 +219,8 @@ GpuReduceKernel(SubExecParam* params)
   __syncthreads();
   if (threadIdx.x == 0)
   {
-    p.startCycle = startCycle;
     p.stopCycle  = wall_clock64();
+    p.startCycle = startCycle;
     __trace_hwreg();
   }
 }


### PR DESCRIPTION
### Added
- Added A2A_DIRECT which only executes all-to-all only directly connected GPUs (on by default now)
- Added average statistics for p2p and a2a benchmarks
- Added USE_FINE_GRAIN for p2p benchmark.
  - With older devices, p2p performance with default coarse grain device memory stops timing as soon as request sent to data fabric,
    not actually when it arrives remotely, which may artificially inflate bandwidth numbers, especially when sending small amounts of data
### Modified
- Modified P2P output to help distinguish between CPU / GPU devices
### Fixed
- Fixed Makefile target to prevent unnecessary re-compilation