### PR TITLE
Fix inf, CU labelling. Update default kernels for gfx94x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for TransferBench
 
+## v1.29
+### Added
+- a2a preset config now responds to USE_REMOTE_READ
+### Fixed
+- Race-condition during wall-clock initialization caused "inf" during single stream runs
+- CU numbering output after CU masking
+### Modified
+- Default number of warmups reverted to 3
+- Default unroll factor for gfx940/941 set to 6
+
 ## v1.28
 ### Added
 - Added A2A_DIRECT which only executes all-to-all only directly connected GPUs (on by default now)

--- a/src/include/TransferBench.hpp
+++ b/src/include/TransferBench.hpp
@@ -193,6 +193,5 @@ void RunAllToAllBenchmark(EnvVars const& ev, size_t const numBytesPerTransfer, i
 std::string GetLinkTypeDesc(uint32_t linkType, uint32_t hopCount);
 
 int RemappedIndex(int const origIdx, bool const isCpuType);
-int GetWallClockRate(int deviceId);
 void LogTransfers(FILE *fp, int const testNum, std::vector<Transfer> const& transfers);
 std::string PtrVectorToStr(std::vector<float*> const& strVector, int const initOffset);


### PR DESCRIPTION
## v1.29
### Added
- a2a preset config now responds to USE_REMOTE_READ
### Fixed
- Race-condition during wall-clock initialization caused "inf" during single stream runs
- CU numbering output after CU masking
### Modified
- Default number of warmups reverted to 3
- Default unroll factor for gfx940/941 set to 6