### PR TITLE
v1.41 Adding schmoo benchmark, fixing timing reports for variable-iteration modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Documentation for TransferBench is available at
 
 ### Additions
 * Adding schmoo preset config benchmarks local/remote reads/writes/copies
-  * Usage: ./TransferBench schmoo <numBytes> <localIdx> <remoteIdx> <maxNumCUs>
+  * Usage: ./TransferBench schmoo <numBytes=64M> <localIdx=0> <remoteIdx=1> <maxNumCUs=32>
 
 ### Fixes
 * Fixing some misreported timings when running with non-fixed number of iterations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 Documentation for TransferBench is available at
 [https://rocm.docs.amd.com/projects/TransferBench](https://rocm.docs.amd.com/projects/TransferBench).
 
+## v1.41
+
+### Additions
+* Adding schmoo preset config benchmarks local/remote reads/writes/copies
+  * Usage: ./TransferBench schmoo <numBytes> <localIdx> <remoteIdx> <maxNumCUs>
+
+### Fixes
+* Fixing some misreported timings when running with non-fixed number of iterations
+
 ## v1.40
 
 ### Fixes

--- a/src/include/EnvVars.hpp
+++ b/src/include/EnvVars.hpp
@@ -29,18 +29,19 @@ THE SOFTWARE.
 #include "Compatibility.hpp"
 #include "Kernels.hpp"
 
-#define TB_VERSION "1.40"
+#define TB_VERSION "1.41"
 
 extern char const MemTypeStr[];
 extern char const ExeTypeStr[];
 
 enum ConfigModeEnum
 {
-  CFG_FILE  = 0,
-  CFG_P2P   = 1,
-  CFG_SWEEP = 2,
-  CFG_SCALE = 3,
-  CFG_A2A   = 4
+  CFG_FILE   = 0,
+  CFG_P2P    = 1,
+  CFG_SWEEP  = 2,
+  CFG_SCALE  = 3,
+  CFG_A2A    = 4,
+  CFG_SCHMOO = 5
 };
 
 enum BlockOrderEnum
@@ -726,6 +727,16 @@ public:
              std::string("Using ") + (useRemoteRead ? "DST" : "SRC") + " as executor");
 
     printf("\n");
+  }
+
+  void DisplaySchmooEnvVars() const
+  {
+    DisplayEnvVars();
+    if (hideEnv) return;
+    if (!outputToCsv)
+      printf("[Schmoo Related]\n");
+    PRINT_EV("USE_FINE_GRAIN", useFineGrain,
+             std::string("Using ") + (useFineGrain ? "fine" : "coarse") + "-grained memory");
   }
 
   // Helper function that gets parses environment variable or sets to default value

--- a/src/include/TransferBench.hpp
+++ b/src/include/TransferBench.hpp
@@ -100,31 +100,32 @@ ExeType inline CharToExeType(char const c)
 // then writes the summation to each of the specified destination memory location(s)
 struct Transfer
 {
-  int                        transferIndex;      // Transfer identifier (within a Test)
+  // Inputs
   ExeType                    exeType;            // Transfer executor type
   int                        exeIndex;           // Executor index (NUMA node for CPU / device ID for GPU)
   int                        exeSubIndex;        // Executor subindex
   int                        numSubExecs;        // Number of subExecutors to use for this Transfer
   size_t                     numBytes;           // # of bytes requested to Transfer (may be 0 to fallback to default)
-  size_t                     numBytesActual;     // Actual number of bytes to copy
-  double                     transferTime;       // Time taken in milliseconds
-
   int                        numSrcs;            // Number of sources
   std::vector<MemType>       srcType;            // Source memory types
   std::vector<int>           srcIndex;           // Source device indice
-  std::vector<float*>        srcMem;             // Source memory
-
   int                        numDsts;            // Number of destinations
   std::vector<MemType>       dstType;            // Destination memory type
   std::vector<int>           dstIndex;           // Destination device index
-  std::vector<float*>        dstMem;             // Destination memory
 
+  // Outputs
+  size_t                     numBytesActual;     // Actual number of bytes to copy
+  double                     transferTime;       // Time taken in milliseconds
+  std::vector<double>        perIterationTime;   // Per-iteration timing
+  std::vector<std::set<std::pair<int,int>>> perIterationCUs; // Per-iteration CU usage
+
+  // Internal
+  int                        transferIndex;      // Transfer identifier (within a Test)
+  std::vector<float*>        srcMem;             // Source memory
+  std::vector<float*>        dstMem;             // Destination memory
   std::vector<SubExecParam>  subExecParam;       // Defines subarrays assigned to each threadblock
   SubExecParam*              subExecParamGpuPtr; // Pointer to GPU copy of subExecParam
   std::vector<int>           subExecIdx;         // Indicies into subExecParamGpu
-
-  std::vector<double>        perIterationTime;   // Per-iteration timing
-  std::vector<std::set<std::pair<int,int>>> perIterationCUs; // Per-iteration CU usage
 
   // Prepares src/dst subarray pointers for each SubExecutor
   void PrepareSubExecParams(EnvVars const& ev);
@@ -190,6 +191,7 @@ void RunPeerToPeerBenchmarks(EnvVars const& ev, size_t N);
 void RunScalingBenchmark(EnvVars const& ev, size_t N, int const exeIndex, int const maxSubExecs);
 void RunSweepPreset(EnvVars const& ev, size_t const numBytesPerTransfer, int const numGpuSubExec, int const numCpuSubExec, bool const isRandom);
 void RunAllToAllBenchmark(EnvVars const& ev, size_t const numBytesPerTransfer, int const numSubExecs);
+void RunSchmooBenchmark(EnvVars const& ev, size_t const numBytesPerTransfer, int const localIdx, int const remoteIdx, int const maxSubExecs);
 
 std::string GetLinkTypeDesc(uint32_t linkType, uint32_t hopCount);
 


### PR DESCRIPTION
### Additions
* Adding schmoo preset config benchmarks local/remote reads/writes/copies
  * Usage: ./TransferBench schmoo <numBytes=64M> <localIdx=0> <remoteIdx=1> <maxNumCUs=32>

### Fixes
* Fixing some misreported timings when running with non-fixed number of iterations