### PR TITLE
v1.44 Adding rwrite preset benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Documentation for TransferBench is available at
 [https://rocm.docs.amd.com/projects/TransferBench](https://rocm.docs.amd.com/projects/TransferBench).
 
+## v1.44
+
+### Additions
+* Adding rwrite preset to benchmark remote parallel writes
+ * Usage: ./TransferBench rwrite <numBytes=64M> <#CUs=8> <srcGpu=0> <minGpus=1> <maxGpus=3>
+
 ## v1.43
 
 ### Changes

--- a/src/include/EnvVars.hpp
+++ b/src/include/EnvVars.hpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 #include "Compatibility.hpp"
 #include "Kernels.hpp"
 
-#define TB_VERSION "1.43"
+#define TB_VERSION "1.44"
 
 extern char const MemTypeStr[];
 extern char const ExeTypeStr[];
@@ -41,7 +41,8 @@ enum ConfigModeEnum
   CFG_SWEEP  = 2,
   CFG_SCALE  = 3,
   CFG_A2A    = 4,
-  CFG_SCHMOO = 5
+  CFG_SCHMOO = 5,
+  CFG_RWRITE = 6
 };
 
 enum BlockOrderEnum
@@ -738,6 +739,17 @@ public:
     PRINT_EV("USE_FINE_GRAIN", useFineGrain,
              std::string("Using ") + (useFineGrain ? "fine" : "coarse") + "-grained memory");
   }
+
+  void DisplayRemoteWriteEnvVars() const
+  {
+    DisplayEnvVars();
+    if (hideEnv) return;
+    if (!outputToCsv)
+      printf("[Remote-Write Related]\n");
+    PRINT_EV("USE_FINE_GRAIN", useFineGrain,
+             std::string("Using ") + (useFineGrain ? "fine" : "coarse") + "-grained memory");
+  }
+
 
   // Helper function that gets parses environment variable or sets to default value
   static int GetEnvVar(std::string const& varname, int defaultValue)

--- a/src/include/TransferBench.hpp
+++ b/src/include/TransferBench.hpp
@@ -194,6 +194,7 @@ void RunScalingBenchmark(EnvVars const& ev, size_t N, int const exeIndex, int co
 void RunSweepPreset(EnvVars const& ev, size_t const numBytesPerTransfer, int const numGpuSubExec, int const numCpuSubExec, bool const isRandom);
 void RunAllToAllBenchmark(EnvVars const& ev, size_t const numBytesPerTransfer, int const numSubExecs);
 void RunSchmooBenchmark(EnvVars const& ev, size_t const numBytesPerTransfer, int const localIdx, int const remoteIdx, int const maxSubExecs);
+void RunRemoteWriteBenchmark(EnvVars const& ev, size_t const numBytesPerTransfer, int numSubExecs, int const srcIdx, int minGpus, int maxGpus);
 
 std::string GetLinkTypeDesc(uint32_t linkType, uint32_t hopCount);
 


### PR DESCRIPTION
### Additions
* Adding rwrite preset to benchmark remote parallel writes
 * Usage: ./TransferBench rwrite <numBytes=64M> <#CUs=8> <srcGpu=0> <minGpus=1> <maxGpus=3>