### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,10 @@
+# Global Owners
+* @ROCm/RCCL-Reviewers
+
 # Documentation files
 docs/* @saadrahim @LisaDelaney
 *.md  @saadrahim @LisaDelaney
 *.rst  @saadrahim @LisaDelaney
+
 # Header directory
 library/include/*  @saadrahim @LisaDelaney


### PR DESCRIPTION
Add RCCL-Reviewers as global owners.