### PR TITLE
Enumerating missing DMA engines in topology display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Documentation for TransferBench is available at
 [https://rocm.docs.amd.com/projects/TransferBench](https://rocm.docs.amd.com/projects/TransferBench).
 
+## v1.49
+
+### Fixes
+* Enumerating previously missed DMA engines used only for CPU traffic in topology display
+
 ## v1.48
 
 ### Fixes

--- a/src/include/EnvVars.hpp
+++ b/src/include/EnvVars.hpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 #include "Compatibility.hpp"
 #include "Kernels.hpp"
 
-#define TB_VERSION "1.48"
+#define TB_VERSION "1.49"
 
 extern char const MemTypeStr[];
 extern char const ExeTypeStr[];


### PR DESCRIPTION
### Fixes
* Enumerating previously missed DMA engines used only for CPU traffic in topology display