### PR TITLE
Add runtime dependencies to generated packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ set(LIBRARY_NAME TransferBench)
 
 rocm_install(TARGETS TransferBench)
 
+rocm_package_add_dependencies(DEPENDS libnuma1 hsa-rocr)
+
 rocm_create_package(
     NAME ${LIBRARY_NAME}
     DESCRIPTION "TransferBench package"


### PR DESCRIPTION
As Transferbench has runtime dependencies on the HSA runtime and NUMA shared libraries, these dependencies should be added to its package.