### PR TITLE
Allowing NULL memory type in sweep preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Documentation for TransferBench is available at
 [https://rocm.docs.amd.com/projects/TransferBench](https://rocm.docs.amd.com/projects/TransferBench).
 
+## v1.53
+### Added
+- Added ability to specify NULL for sweep preset as source or destination memory type
+
 ## v1.52
 ### Added
 - Added USE_HSA_DMA env var to switch to using hsa_amd_memory_async_copy instead of hipMemcpyAsync for DMA execution

--- a/src/include/EnvVars.hpp
+++ b/src/include/EnvVars.hpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 #include "Compatibility.hpp"
 #include "Kernels.hpp"
 
-#define TB_VERSION "1.52"
+#define TB_VERSION "1.53"
 
 extern char const MemTypeStr[];
 extern char const ExeTypeStr[];


### PR DESCRIPTION
## v1.53
### Added
- Added ability to specify NULL for sweep preset as source or destination memory type