### PR TITLE
Removing C++20 dependencies, modified how version is reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Documentation for TransferBench is available at
 [https://rocm.docs.amd.com/projects/TransferBench](https://rocm.docs.amd.com/projects/TransferBench).
 
+## v1.57.00
+### Modified
+- Removing use of default starship operator / C++20 requirement to enable compilation of more OSs
+- Changing how version is reported.  Client version is now just last two digits, and increments only if
+  no changes are made to the backend header-only library file, and resets to 0 when header is updated
+
 ## v1.56
 ### Fixed
 - Fixed bug when using interactive mode.  Interactive mode now starts prior to all warmup iterations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Documentation for TransferBench is available at
 - Removing use of default starship operator / C++20 requirement to enable compilation of more OSs
 - Changing how version is reported.  Client version is now just last two digits, and increments only if
   no changes are made to the backend header-only library file, and resets to 0 when header is updated
+- GFX_SINGLE_TEAM=0 is set by default
 
 ## v1.56
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 cmake_minimum_required(VERSION 3.5)
 
-project(TransferBench VERSION 1.56.0 LANGUAGES CXX)
+project(TransferBench VERSION 1.57.0 LANGUAGES CXX)
 
 # Default GPU architectures to build
 #==================================================================================================
@@ -54,7 +54,7 @@ endforeach()
 list(JOIN static_link_flags " " flags_str)
 set( CMAKE_CXX_FLAGS "${flags_str}${CMAKE_CXX_FLAGS}")
 
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 --std=c++20 -L${ROCM_PATH}/lib")
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -L${ROCM_PATH}/lib")
 include_directories(${ROCM_PATH}/include)
 link_libraries(numa hsa-runtime64 pthread)
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY .)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 CXXFLAGS = -I$(ROCM_PATH)/include -lnuma -L$(ROCM_PATH)/lib -lhsa-runtime64
 NVFLAGS  = -x cu -lnuma -arch=native
-COMMON_FLAGS = -O3 --std=c++20 -I./src/header -I./src/client -I./src/client/Presets
+COMMON_FLAGS = -O3 -I./src/header -I./src/client -I./src/client/Presets
 LDFLAGS += -lpthread
 
 all: $(EXE)

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -172,11 +172,10 @@ int main(int argc, char **argv) {
 
 void DisplayUsage(char const* cmdName)
 {
-  printf("TransferBench Client v%s (Backend v%s)\n", CLIENT_VERSION, TransferBench::VERSION);
+  printf("TransferBench v%s.%s\n", TransferBench::VERSION, CLIENT_VERSION);
   printf("========================================\n");
 
-  if (numa_available() == -1)
-  {
+  if (numa_available() == -1) {
     printf("[ERROR] NUMA library not supported. Check to see if libnuma has been installed on this system\n");
     exit(1);
   }

--- a/src/client/Client.hpp
+++ b/src/client/Client.hpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #pragma once
 
 // TransferBench client version
-#define CLIENT_VERSION "1.56.00"
+#define CLIENT_VERSION "00"
 
 #include "TransferBench.hpp"
 #include "EnvVars.hpp"

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -128,7 +128,7 @@ public:
     blockBytes        = GetEnvVar("BLOCK_BYTES"         , 256);
     byteOffset        = GetEnvVar("BYTE_OFFSET"         , 0);
     gfxBlockSize      = GetEnvVar("GFX_BLOCK_SIZE"      , 256);
-    gfxSingleTeam     = GetEnvVar("GFX_SINGLE_TEAM"     , 1);
+    gfxSingleTeam     = GetEnvVar("GFX_SINGLE_TEAM"     , 0);
     gfxUnroll         = GetEnvVar("GFX_UNROLL"          , defaultGfxUnroll);
     gfxWaveOrder      = GetEnvVar("GFX_WAVE_ORDER"      , 0);
     hideEnv           = GetEnvVar("HIDE_ENV"            , 0);

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -172,7 +172,7 @@ namespace TransferBench
     int                 unrollFactor   = 4;     ///< GFX-kernel unroll factor
     int                 useHipEvents   = 1;     ///< Use HIP events for timing GFX Executor
     int                 useMultiStream = 0;     ///< Use multiple streams for GFX
-    int                 useSingleTeam  = 1;     ///< Team all subExecutors across the data array
+    int                 useSingleTeam  = 0;     ///< Team all subExecutors across the data array
     int                 waveOrder      = 0;     ///< GFX-kernel wavefront ordering
   };
 

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -49,7 +49,7 @@ namespace TransferBench
   using std::set;
   using std::vector;
 
-  constexpr char VERSION[] = "1.56";
+  constexpr char VERSION[] = "1.57";
 
   /**
    * Enumeration of supported Executor types
@@ -76,8 +76,9 @@ namespace TransferBench
     ExeType exeType;                            ///< Executor type
     int32_t exeIndex;                           ///< Executor index
 
-    // Default comparison operator
-    auto operator<=>(const ExeDevice&) const = default;
+    bool operator<(ExeDevice const& other) const {
+      return (exeType < other.exeType) || (exeType == other.exeType && exeIndex < other.exeIndex);
+    }
   };
 
   /**
@@ -106,7 +107,10 @@ namespace TransferBench
   {
     MemType memType;                            ///< Memory type
     int32_t memIndex;                           ///< Device index
-    auto operator<=>(const MemDevice&) const = default;
+
+    bool operator<(MemDevice const& other) const {
+      return (memType < other.memType) || (memType == other.memType && memIndex < other.memIndex);
+    }
   };
 
   /**


### PR DESCRIPTION
## v1.57.00
### Modified
- Removing use of default starship operator / C++20 requirement to enable compilation of more OSs
- Changing how version is reported.  Client version is now just last two digits, and increments only if
  no changes are made to the backend header-only library file, and resets to 0 when header is updated