### PR TITLE
External CI: enable CI triggers

### DIFF
--- a/.azuredevops/rocm-ci.yml
+++ b/.azuredevops/rocm-ci.yml
@@ -1,0 +1,42 @@
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - develop
+    - mainline
+  paths:
+    exclude:
+    - .github
+    - docs
+    - '.*.y*ml'
+    - '*.md'
+    - LICENSE
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - develop
+    - mainline
+  paths:
+    exclude:
+    - .github
+    - docs
+    - '.*.y*ml'
+    - '*.md'
+    - LICENSE
+  drafts: false
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/TransferBench.yml@pipelines_repo

--- a/.azuredevops/rocm-ci.yml
+++ b/.azuredevops/rocm-ci.yml
@@ -19,7 +19,8 @@ trigger:
     exclude:
     - .github
     - docs
-    - '.*.y*ml'
+    - '.*.yaml'
+    - '.*.yml'
     - '*.md'
     - LICENSE
 
@@ -33,7 +34,8 @@ pr:
     exclude:
     - .github
     - docs
-    - '.*.y*ml'
+    - '.*.yaml'
+    - '.*.yml'
     - '*.md'
     - LICENSE
   drafts: false


### PR DESCRIPTION
Enables `develop`, `mainline`, and PR triggers for public-facing Azure CI: https://dev.azure.com/ROCm-CI/ROCm-CI/_build