### PR TITLE
Avoid per-transfer thread creation for NIC executor

### DIFF
--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -2636,32 +2636,17 @@ namespace {
   static ErrResult ExecuteNicTransfer(int           const  iteration,
                                       ConfigOptions const& cfg,
                                       int           const  exeIndex,
-                                      TransferResources&   rss,
-                                      bool          const  postSends,
-                                      uint8_t&             qpTransfersCompleted)
+                                      TransferResources&   rss)
   {
 
-    if(postSends) {
-      // Loop over each of the queue pairs and post the send
-      ibv_send_wr* badWorkReq;
-      for (int qpIndex = 0; qpIndex < rss.qpCount; qpIndex++) {
-        int error = ibv_post_send(rss.srcQueuePairs[qpIndex], &rss.sendWorkRequests[qpIndex], &badWorkReq);
-        if (error)
-          return {ERR_FATAL, "Transfer %d: Error when calling ibv_post_send for QP %d Error code %d\n",
-            rss.transferIdx, qpIndex, error};
-      }
-    }
-    // Poll the completion queue until all queue pairs are complete
-    // The order of completion doesn't matter because this completion queue is dedicated to this Transfer
-    ibv_wc wc;
-    int nc = ibv_poll_cq(rss.srcCompQueue, 1, &wc);
-    if (nc > 0) {
-      qpTransfersCompleted++;
-      if (wc.status != IBV_WC_SUCCESS) {
-        return {ERR_FATAL, "Transfer %d: Received unsuccessful work completion", rss.transferIdx};
-      }
-    } else if (nc < 0) {
-      return {ERR_FATAL, "Transfer %d: Received negative work completion", rss.transferIdx};
+
+    // Loop over each of the queue pairs and post the send
+    ibv_send_wr* badWorkReq;
+    for (int qpIndex = 0; qpIndex < rss.qpCount; qpIndex++) {
+      int error = ibv_post_send(rss.srcQueuePairs[qpIndex], &rss.sendWorkRequests[qpIndex], &badWorkReq);
+      if (error)
+        return {ERR_FATAL, "Transfer %d: Error when calling ibv_post_send for QP %d Error code %d\n",
+          rss.transferIdx, qpIndex, error};
     }
     return ERR_NONE;
   }
@@ -2685,13 +2670,28 @@ namespace {
       auto transferCount = exeInfo.resources.size();
       std::vector<uint8_t> receivedQPs(transferCount);
       std::vector<std::chrono::high_resolution_clock::time_point> transferTimers(transferCount);
-      bool postSends = true;
+      // post the sends
+      for (auto i = 0; i < transferCount; i++) {
+        transferTimers[i] = std::chrono::high_resolution_clock::now();
+        ERR_CHECK(ExecuteNicTransfer(iteration, cfg, exeIndex, exeInfo.resources[i]));
+      }
+      // poll for completions
       do {
-        for (int i = 0; i < transferCount; i++) {
-          if(postSends) transferTimers[i] = std::chrono::high_resolution_clock::now();
+        for (auto i = 0; i < transferCount; i++) {
           if(receivedQPs[i] < exeInfo.resources[i].qpCount) {
             auto& rss = exeInfo.resources[i];
-            ERR_CHECK(ExecuteNicTransfer(iteration, cfg, exeIndex, rss, postSends, receivedQPs[i]));
+            // Poll the completion queue until all queue pairs are complete
+            // The order of completion doesn't matter because this completion queue is dedicated to this Transfer
+            ibv_wc wc;
+            int nc = ibv_poll_cq(rss.srcCompQueue, 1, &wc);
+            if (nc > 0) {
+              receivedQPs[i]++;
+              if (wc.status != IBV_WC_SUCCESS) {
+                return {ERR_FATAL, "Transfer %d: Received unsuccessful work completion", rss.transferIdx};
+              }
+            } else if (nc < 0) {
+              return {ERR_FATAL, "Transfer %d: Received negative work completion", rss.transferIdx};
+            }
             if(receivedQPs[i] == rss.qpCount) {
               auto cpuDelta = std::chrono::high_resolution_clock::now() - transferTimers[i];
               double deltaMsec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() * 1000.0;
@@ -2704,7 +2704,6 @@ namespace {
             }
           }
         }
-        if(postSends) postSends = false;
       } while(completedTransfers < transferCount);
       auto cpuDelta = std::chrono::high_resolution_clock::now() - cpuStart;
       double deltaMsec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() * 1000.0;

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -2684,16 +2684,17 @@ namespace {
       size_t completedTransfers = 0;
       auto transferCount = exeInfo.resources.size();
       std::vector<uint8_t> receivedQPs(transferCount);
-      std::vector<double> transferTimers(transferCount);
+      std::vector<std::chrono::high_resolution_clock::time_point> transferTimers(transferCount);
       bool postSends = true;
       do {
         for (int i = 0; i < transferCount; i++) {
-          if(postSends) transferTimers[i] = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+          if(postSends) transferTimers[i] = std::chrono::high_resolution_clock::now();
           if(receivedQPs[i] < exeInfo.resources[i].qpCount) {
             auto& rss = exeInfo.resources[i];
             ERR_CHECK(ExecuteNicTransfer(iteration, cfg, exeIndex, rss, postSends, receivedQPs[i]));
             if(receivedQPs[i] == rss.qpCount) {
-              double deltaMsec = (std::chrono::high_resolution_clock::now().time_since_epoch().count() - transferTimers[i]) / 1e6;
+              auto cpuDelta = std::chrono::high_resolution_clock::now() - transferTimers[i];
+              double deltaMsec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() * 1000.0;
               if (iteration >= 0) {
                 rss.totalDurationMsec += deltaMsec;
                 if (cfg.general.recordPerIteration)

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -2636,19 +2636,12 @@ namespace {
   static ErrResult ExecuteNicTransfer(int           const  iteration,
                                       ConfigOptions const& cfg,
                                       int           const  exeIndex,
-                                      TransferResources&   rss)
+                                      TransferResources&   rss,
+                                      bool          const  postSends,
+                                      uint8_t&             qpTransfersCompleted)
   {
-    auto cpuStart = std::chrono::high_resolution_clock::now();
 
-    // Switch to the closest NUMA node to this NIC
-    if (cfg.nic.useNuma) {
-      int numaNode = GetIbvDeviceList()[exeIndex].numaNode;
-      if (numaNode != -1)
-        numa_run_on_node(numaNode);
-    }
-
-    int subIteration = 0;
-    do {
+    if(postSends) {
       // Loop over each of the queue pairs and post the send
       ibv_send_wr* badWorkReq;
       for (int qpIndex = 0; qpIndex < rss.qpCount; qpIndex++) {
@@ -2657,31 +2650,18 @@ namespace {
           return {ERR_FATAL, "Transfer %d: Error when calling ibv_post_send for QP %d Error code %d\n",
             rss.transferIdx, qpIndex, error};
       }
-
-      // Poll the completion queue until all queue pairs are complete
-      // The order of completion doesn't matter because this completion queue is dedicated to this Transfer
-      int numComplete = 0;
-      ibv_wc wc;
-      while (numComplete < rss.qpCount) {
-        int nc = ibv_poll_cq(rss.srcCompQueue, 1, &wc);
-        if (nc > 0) {
-          numComplete++;
-          if (wc.status != IBV_WC_SUCCESS) {
-            return {ERR_FATAL, "Transfer %d: Received unsuccessful work completion", rss.transferIdx};
-          }
-        } else if (nc < 0) {
-          return {ERR_FATAL, "Transfer %d: Received negative work completion", rss.transferIdx};
-        }
+    }
+    // Poll the completion queue until all queue pairs are complete
+    // The order of completion doesn't matter because this completion queue is dedicated to this Transfer
+    ibv_wc wc;
+    int nc = ibv_poll_cq(rss.srcCompQueue, 1, &wc);
+    if (nc > 0) {
+      qpTransfersCompleted++;
+      if (wc.status != IBV_WC_SUCCESS) {
+        return {ERR_FATAL, "Transfer %d: Received unsuccessful work completion", rss.transferIdx};
       }
-    } while (++subIteration != cfg.general.numSubIterations);
-
-    auto cpuDelta = std::chrono::high_resolution_clock::now() - cpuStart;
-    double deltaMsec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() * 1000.0;
-
-    if (iteration >= 0) {
-      rss.totalDurationMsec += deltaMsec;
-      if (cfg.general.recordPerIteration)
-        rss.perIterMsec.push_back(deltaMsec);
+    } else if (nc < 0) {
+      return {ERR_FATAL, "Transfer %d: Received negative work completion", rss.transferIdx};
     }
     return ERR_NONE;
   }
@@ -2692,26 +2672,44 @@ namespace {
                                   int           const  exeIndex,
                                   ExeInfo&             exeInfo)
   {
-    vector<std::future<ErrResult>> asyncTransfers;
-
-    auto cpuStart = std::chrono::high_resolution_clock::now();
-    for (int i = 0; i < exeInfo.resources.size(); i++) {
-      asyncTransfers.emplace_back(std::async(std::launch::async,
-                                             ExecuteNicTransfer,
-                                             iteration,
-                                             std::cref(cfg),
-                                             exeIndex,
-                                             std::ref(exeInfo.resources[i])));
+    // Switch to the closest NUMA node to this NIC
+    if (cfg.nic.useNuma) {
+      int numaNode = GetIbvDeviceList()[exeIndex].numaNode;
+      if (numaNode != -1)
+        numa_run_on_node(numaNode);
     }
-    for (auto& asyncTransfer : asyncTransfers)
-      ERR_CHECK(asyncTransfer.get());
-
-    auto cpuDelta = std::chrono::high_resolution_clock::now() - cpuStart;
-    double deltaMsec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() * 1000.0;
-
-    if (iteration >= 0)
-      exeInfo.totalDurationMsec += deltaMsec;
-
+    int subIterations = 0;
+    do {
+      auto cpuStart = std::chrono::high_resolution_clock::now();
+      size_t completedTransfers = 0;
+      auto transferCount = exeInfo.resources.size();
+      std::vector<uint8_t> receivedQPs(transferCount);
+      std::vector<double> transferTimers(transferCount);
+      bool postSends = true;
+      do {
+        for (int i = 0; i < transferCount; i++) {
+          if(postSends) transferTimers[i] = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+          if(receivedQPs[i] < exeInfo.resources[i].qpCount) {
+            auto& rss = exeInfo.resources[i];
+            ERR_CHECK(ExecuteNicTransfer(iteration, cfg, exeIndex, rss, postSends, receivedQPs[i]));
+            if(receivedQPs[i] == rss.qpCount) {
+              double deltaMsec = (std::chrono::high_resolution_clock::now().time_since_epoch().count() - transferTimers[i]) / 1e6;
+              if (iteration >= 0) {
+                rss.totalDurationMsec += deltaMsec;
+                if (cfg.general.recordPerIteration)
+                  rss.perIterMsec.push_back(deltaMsec);
+              }
+              completedTransfers++;
+            }
+          }
+        }
+        if(postSends) postSends = false;
+      } while(completedTransfers < transferCount);
+      auto cpuDelta = std::chrono::high_resolution_clock::now() - cpuStart;
+      double deltaMsec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() * 1000.0;
+      if (iteration >= 0)
+        exeInfo.totalDurationMsec += deltaMsec;
+    } while(++subIterations < cfg.general.numSubIterations);
     return ERR_NONE;
   }
 #endif


### PR DESCRIPTION
### Fixed

Avoid thread overhead which became a bottleneck when doing NIC alltoall preset. This will be checked for other execs like DMA. Threads are now only created at the executor level. Also, misaligned transfers caused small message BW to be higher than theoretical for alltoall NIC preset


### 1MB message size Before (left) and After (right) 
![image](https://github.com/user-attachments/assets/7b8cfc88-ff26-47a4-9950-0dfc86308f29)

### 256M (default) message size Before (left) and After (right)
![image](https://github.com/user-attachments/assets/28bc6f39-8af8-4c64-9cd6-31dd6b2f7ad3)

### 1GB message size Before (left) and After (right)
![image](https://github.com/user-attachments/assets/f74c4655-8587-4633-ac4b-fcb9fd29913f)
