### PR TITLE
Add priority ordering for GID index detection for RoCEv2 and rewrite logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ Documentation for TransferBench is available at
 ### Added
 - Added a2a_n preset which conducts alltoall GPU-to-GPU tranfers over nearest NIC executors
 - Added a2asweep preset which tries various CU/unroll options for GFX-executed all-to-all
+- Rewrite main GID index detection logic
+- Show the GID index in the topology table. It is helpful for debugging purposes
 
 ### Fixed
 - Avoid build errors for CMake and Makefile if infiniband/verbs.h header is not present and disable NIC executor in such case
+- Have a priority list of which GID entry to go for instead of hardcoding choices based on underdocumented user input (such as RoCE version and IP address family)
+- Use link-local when it is the only choice (i.e. when routing information is not available beyond local link)
 
 ## v1.61.00
 ### Added

--- a/src/client/Topology.hpp
+++ b/src/client/Topology.hpp
@@ -41,9 +41,9 @@ static int RemappedCpuIndex(int origIdx)
 static void PrintNicToGPUTopo(bool outputToCsv)
 {
 #ifdef NIC_EXEC_ENABLED
-  printf(" NIC | Device Name | Active | PCIe Bus ID  | NUMA | Closest GPU(s)\n");
+  printf(" NIC | Device Name | Active | PCIe Bus ID  | NUMA | Closest GPU(s) | GID Index \n");
   if(!outputToCsv)
-    printf("-----+-------------+--------+--------------+------+---------------\n");
+    printf("-----+-------------+--------+--------------+------+----------------+-----------\n");
 
   int numGpus = TransferBench::GetNumExecutors(EXE_GPU_GFX);
   auto const& ibvDeviceList = GetIbvDeviceList();
@@ -57,12 +57,14 @@ static void PrintNicToGPUTopo(bool outputToCsv)
       }
     }
 
-    printf(" %-3d | %-11s | %-6s | %-12s | %-4d | %-20s\n",
+    printf(" %-3d | %-11s | %-6s | %-12s | %-4d | %-14s | %-9s\n",
            i, ibvDeviceList[i].name.c_str(),
            ibvDeviceList[i].hasActivePort ? "Yes" : "No",
            ibvDeviceList[i].busId.c_str(),
            ibvDeviceList[i].numaNode,
-           closestGpusStr.c_str());
+           closestGpusStr.c_str(),
+           ibvDeviceList[i].isRoce && ibvDeviceList[i].hasActivePort?  std::to_string(ibvDeviceList[i].gidIndex).c_str() : "N/A"
+          );
   }
   printf("\n");
 #endif

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1801,9 +1801,9 @@ namespace {
     return true;
   }
 
-  static bool LinkLocalGid(union ibv_gid* gid)
+  static bool LinkLocalGid(union ibv_gid const& gid)
   {
-    const struct in6_addr *a = (struct in6_addr *)gid->raw;
+    const struct in6_addr *a = (struct in6_addr *) gid.raw;
     if (a->s6_addr32[0] == htonl(0xfe800000) && a->s6_addr32[1] == 0UL) {
       return true;
     }
@@ -1843,9 +1843,19 @@ namespace {
     return ERR_NONE;
   }
 
-  static bool isIPv4MappedIPv6(const union ibv_gid &gid)
+  static bool IsIPv4MappedIPv6(const union ibv_gid &gid)
   {
-    return (gid.raw[10] == 0xff && gid.raw[11] == 0xff); // ::ffff:x.x.x.x format
+    // look for ::ffff:x.x.x.x format
+    // From Broadcom documentation
+    // https://techdocs.broadcom.com/us/en/storage-and-ethernet-connectivity/ethernet-nic-controllers/bcm957xxx/adapters/frequently-asked-questions1.html
+    // "The IPv4 address is really an IPv4 address mapped into the IPv6 address space.
+    // This can be identified by 80 “0” bits, followed by 16 “1” bits (“FFFF” in hexadecimal)"
+    // followed by the original 32-bit IPv4 address.
+    return (gid.global.subnet_prefix == 0    &&
+            gid.raw[8]               == 0    &&
+            gid.raw[9]               == 0    &&
+            gid.raw[10]              == 0xff &&
+            gid.raw[11]              == 0xff);
   }
 
   static ErrResult GetGidIndex(ConfigOptions const& cfg,
@@ -1867,13 +1877,13 @@ namespace {
       if (!IsConfiguredGid(&gid)) continue;
       int gidCurrRoceVersion;
       ERR_CHECK(GetRoceVersionNumber(context, cfg.nic.ibPort, i, gidCurrRoceVersion));
-      if (isIPv4MappedIPv6(gid)) {
+      if (IsIPv4MappedIPv6(gid)) {
         if (gidCurrRoceVersion == 2) {
           v2_ipv4_mapped_index = i;  // Highest priority
         } else {
           v1_ipv4_mapped_index = i;
         }
-      } else if (!LinkLocalGid(&gid)) {
+      } else if (!LinkLocalGid(gid)) {
         if (gidCurrRoceVersion == 2) {
           v2_ipv6_index = i;
         } else {

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1404,12 +1404,150 @@ namespace {
     std::string busId;
     bool        hasActivePort;
     int         numaNode;
+    int         gidIndex;
+    bool        isRoce;
   };
 #endif
 
 #ifdef NIC_EXEC_ENABLED
 // Function to collect information about IBV devices
 //========================================================================================
+static bool IsConfiguredGid(union ibv_gid* gid)
+  {
+    const struct in6_addr *a = (struct in6_addr *)gid->raw;
+    int trailer = (a->s6_addr32[1] | a->s6_addr32[2] | a->s6_addr32[3]);
+    if (((a->s6_addr32[0] | trailer) == 0UL) ||
+        ((a->s6_addr32[0] == htonl(0xfe800000)) && (trailer == 0UL))) {
+      return false;
+    }
+    return true;
+  }
+
+  static bool LinkLocalGid(union ibv_gid const& gid)
+  {
+    const struct in6_addr *a = (struct in6_addr *) gid.raw;
+    if (a->s6_addr32[0] == htonl(0xfe800000) && a->s6_addr32[1] == 0UL) {
+      return true;
+    }
+    return false;
+  }
+
+  static ErrResult GetRoceVersionNumber(struct ibv_context* const& context,
+                                        int const&  portNum,
+                                        int const&  gidIndex,
+                                        int&        version)
+  {
+    char const* deviceName = ibv_get_device_name(context->device);
+    char gidRoceVerStr[16]      = {};
+    char roceTypePath[PATH_MAX] = {};
+    sprintf(roceTypePath, "/sys/class/infiniband/%s/ports/%d/gid_attrs/types/%d",
+            deviceName, portNum, gidIndex);
+
+    int fd = open(roceTypePath, O_RDONLY);
+    if (fd == -1)
+      return {ERR_FATAL, "Failed while opening RoCE file path (%s)", roceTypePath};
+
+    int ret = read(fd, gidRoceVerStr, 15);
+    close(fd);
+
+    if (ret == -1)
+      return {ERR_FATAL, "Failed while reading RoCE version"};
+
+    if (strlen(gidRoceVerStr)) {
+      if (strncmp(gidRoceVerStr, "IB/RoCE v1", strlen("IB/RoCE v1")) == 0
+          || strncmp(gidRoceVerStr, "RoCE v1", strlen("RoCE v1")) == 0) {
+        version = 1;
+      }
+      else if (strncmp(gidRoceVerStr, "RoCE v2", strlen("RoCE v2")) == 0) {
+        version = 2;
+      }
+    }
+    return ERR_NONE;
+  }
+
+  static bool IsIPv4MappedIPv6(const union ibv_gid &gid)
+  {
+    // look for ::ffff:x.x.x.x format
+    // From Broadcom documentation
+    // https://techdocs.broadcom.com/us/en/storage-and-ethernet-connectivity/ethernet-nic-controllers/bcm957xxx/adapters/frequently-asked-questions1.html
+    // "The IPv4 address is really an IPv4 address mapped into the IPv6 address space.
+    // This can be identified by 80 “0” bits, followed by 16 “1” bits (“FFFF” in hexadecimal)
+    // followed by the original 32-bit IPv4 address."
+    return (gid.global.subnet_prefix == 0    &&
+            gid.raw[8]               == 0    &&
+            gid.raw[9]               == 0    &&
+            gid.raw[10]              == 0xff &&
+            gid.raw[11]              == 0xff);
+  }
+
+  static ErrResult GetGidIndex(struct ibv_context* context,
+                               int const& gidTblLen,
+                               int const& portNum,
+                               int& gidIndex)
+  {
+    if(gidIndex >= 0) return ERR_NONE; // honor user choice
+    union ibv_gid gid;
+    int roceV2Ipv4MappedIndex = -1;
+    int roceV1Ipv4MappedIndex = -1;
+    int roceV2Ipv6Index = -1;
+    int roceV1Ipv6Index = -1;
+    int rocev2LinkLocalIndex = -1;
+    int rocev1LinkLocalIndex = -1;
+
+    for (int i = 0; i < gidTblLen; ++i) {
+      IBV_CALL(ibv_query_gid, context, portNum, i, &gid);
+      if (!IsConfiguredGid(&gid)) continue;
+      int gidCurrRoceVersion;
+      ERR_CHECK(GetRoceVersionNumber(context, portNum, i, gidCurrRoceVersion));
+      if (IsIPv4MappedIPv6(gid)) {
+        if (gidCurrRoceVersion == 2) {
+          roceV2Ipv4MappedIndex = i;  // Highest priority
+        } else {
+          roceV1Ipv4MappedIndex = i;
+        }
+      } else if (!LinkLocalGid(gid)) {
+        if (gidCurrRoceVersion == 2) {
+          roceV2Ipv6Index = i;
+        } else {
+          roceV1Ipv6Index = i;
+        }
+      } else {
+        if (gidCurrRoceVersion == 2) {
+          rocev2LinkLocalIndex = i;
+        } else {
+          rocev1LinkLocalIndex = i;
+        }
+      }
+    }
+
+    // Select the best available GID based on priority
+    // * Priority Order:
+    // * 1. RoCE v2 (IPv4-mapped): ::ffff:192.168.x.x
+    // * 2. RoCE v2 (Not IPv4-mapped)
+    // * 3. RoCE v1 (IPv4-mapped)
+    // * 4. RoCE v1 (Not IPv4-mapped)
+    // * 5. RoCE v2 (Link-local): fe80::/10
+    // * 6. RoCE v1 (Link-local)
+
+    if (roceV2Ipv4MappedIndex != -1) {
+      gidIndex = roceV2Ipv4MappedIndex;
+    } else if (roceV2Ipv6Index != -1) {
+      gidIndex = roceV2Ipv6Index;
+    } else if (roceV1Ipv4MappedIndex != -1) {
+      gidIndex = roceV1Ipv4MappedIndex;
+    } else if (roceV1Ipv6Index != -1) {
+      gidIndex = roceV1Ipv6Index;
+    } else if (rocev2LinkLocalIndex != -1) {
+      gidIndex = rocev2LinkLocalIndex;
+    } else if (rocev1LinkLocalIndex != -1) {
+      gidIndex = rocev1LinkLocalIndex;
+    } else {
+      gidIndex = -1;
+      return {ERR_FATAL, "Failed to auto-detect a valid GID index. Try setting it manually through IB_GID_INDEX"};
+    }
+    return ERR_NONE;
+  }
+
   static vector<IbvDevice>& GetIbvDeviceList()
   {
     static bool isInitialized = false;
@@ -1434,12 +1572,24 @@ namespace {
             if (context) {
               struct ibv_device_attr deviceAttr;
               if (!ibv_query_device(context, &deviceAttr)) {
+                int activePort;
+                ibvDevice.gidIndex = -1;
                 for (int port = 1; port <= deviceAttr.phys_port_cnt; ++port) {
                   struct ibv_port_attr portAttr;
                   if (ibv_query_port(context, port, &portAttr)) continue;
-                  if (portAttr.state == IBV_PORT_ACTIVE)
+                  if (portAttr.state == IBV_PORT_ACTIVE) {
+                    activePort = port;
                     ibvDevice.hasActivePort = true;
-                  break;
+                    if(portAttr.link_layer == IBV_LINK_LAYER_ETHERNET) {
+                      ibvDevice.isRoce = true;
+                      int gidIndex = -1;
+                      auto res = GetGidIndex(context, portAttr.gid_tbl_len, activePort, gidIndex);
+                      if (res.errType == ERR_NONE) {
+                        ibvDevice.gidIndex = gidIndex;
+                      }
+                    }
+                    break;
+                  }
                 }
               }
               ibv_close_device(context);
@@ -1790,142 +1940,6 @@ namespace {
     return ERR_NONE;
   }
 
-  static bool IsConfiguredGid(union ibv_gid* gid)
-  {
-    const struct in6_addr *a = (struct in6_addr *)gid->raw;
-    int trailer = (a->s6_addr32[1] | a->s6_addr32[2] | a->s6_addr32[3]);
-    if (((a->s6_addr32[0] | trailer) == 0UL) ||
-        ((a->s6_addr32[0] == htonl(0xfe800000)) && (trailer == 0UL))) {
-      return false;
-    }
-    return true;
-  }
-
-  static bool LinkLocalGid(union ibv_gid const& gid)
-  {
-    const struct in6_addr *a = (struct in6_addr *) gid.raw;
-    if (a->s6_addr32[0] == htonl(0xfe800000) && a->s6_addr32[1] == 0UL) {
-      return true;
-    }
-    return false;
-  }
-
-  static ErrResult GetRoceVersionNumber(struct ibv_context* const& context,
-                                        int const&  portNum,
-                                        int const&  gidIndex,
-                                        int&        version)
-  {
-    char const* deviceName = ibv_get_device_name(context->device);
-    char gidRoceVerStr[16]      = {};
-    char roceTypePath[PATH_MAX] = {};
-    sprintf(roceTypePath, "/sys/class/infiniband/%s/ports/%d/gid_attrs/types/%d",
-            deviceName, portNum, gidIndex);
-
-    int fd = open(roceTypePath, O_RDONLY);
-    if (fd == -1)
-      return {ERR_FATAL, "Failed while opening RoCE file path (%s)", roceTypePath};
-
-    int ret = read(fd, gidRoceVerStr, 15);
-    close(fd);
-
-    if (ret == -1)
-      return {ERR_FATAL, "Failed while reading RoCE version"};
-
-    if (strlen(gidRoceVerStr)) {
-      if (strncmp(gidRoceVerStr, "IB/RoCE v1", strlen("IB/RoCE v1")) == 0
-          || strncmp(gidRoceVerStr, "RoCE v1", strlen("RoCE v1")) == 0) {
-        version = 1;
-      }
-      else if (strncmp(gidRoceVerStr, "RoCE v2", strlen("RoCE v2")) == 0) {
-        version = 2;
-      }
-    }
-    return ERR_NONE;
-  }
-
-  static bool IsIPv4MappedIPv6(const union ibv_gid &gid)
-  {
-    // look for ::ffff:x.x.x.x format
-    // From Broadcom documentation
-    // https://techdocs.broadcom.com/us/en/storage-and-ethernet-connectivity/ethernet-nic-controllers/bcm957xxx/adapters/frequently-asked-questions1.html
-    // "The IPv4 address is really an IPv4 address mapped into the IPv6 address space.
-    // This can be identified by 80 “0” bits, followed by 16 “1” bits (“FFFF” in hexadecimal)
-    // followed by the original 32-bit IPv4 address."
-    return (gid.global.subnet_prefix == 0    &&
-            gid.raw[8]               == 0    &&
-            gid.raw[9]               == 0    &&
-            gid.raw[10]              == 0xff &&
-            gid.raw[11]              == 0xff);
-  }
-
-  static ErrResult GetGidIndex(ConfigOptions const& cfg,
-                               struct ibv_context* context,
-                               const int& gidTblLen,
-                               int& gidIndex)
-  {
-    if(gidIndex >= 0) return ERR_NONE; // honor user choice
-    union ibv_gid gid;
-    int roceV2Ipv4MappedIndex = -1;
-    int roceV1Ipv4MappedIndex = -1;
-    int roceV2Ipv6Index = -1;
-    int roceV1Ipv6Index = -1;
-    int rocev2LinkLocalIndex = -1;
-    int rocev1LinkLocalIndex = -1;
-
-    for (int i = 0; i < gidTblLen; ++i) {
-      IBV_CALL(ibv_query_gid, context, cfg.nic.ibPort , i, &gid);
-      if (!IsConfiguredGid(&gid)) continue;
-      int gidCurrRoceVersion;
-      ERR_CHECK(GetRoceVersionNumber(context, cfg.nic.ibPort, i, gidCurrRoceVersion));
-      if (IsIPv4MappedIPv6(gid)) {
-        if (gidCurrRoceVersion == 2) {
-          roceV2Ipv4MappedIndex = i;  // Highest priority
-        } else {
-          roceV1Ipv4MappedIndex = i;
-        }
-      } else if (!LinkLocalGid(gid)) {
-        if (gidCurrRoceVersion == 2) {
-          roceV2Ipv6Index = i;
-        } else {
-          roceV1Ipv6Index = i;
-        }
-      } else {
-        if (gidCurrRoceVersion == 2) {
-          rocev2LinkLocalIndex = i;
-        } else {
-          rocev1LinkLocalIndex = i;
-        }
-      }
-    }
-
-    // Select the best available GID based on priority
-    // * Priority Order:
-    // * 1. RoCE v2 (IPv4-mapped): ::ffff:192.168.x.x
-    // * 2. RoCE v2 (Not IPv4-mapped)
-    // * 3. RoCE v1 (IPv4-mapped)
-    // * 4. RoCE v1 (Not IPv4-mapped)
-    // * 5. RoCE v2 (Link-local): fe80::/10
-    // * 6. RoCE v1 (Link-local)
-
-    if (roceV2Ipv4MappedIndex != -1) {
-      gidIndex = roceV2Ipv4MappedIndex;
-    } else if (roceV2Ipv6Index != -1) {
-      gidIndex = roceV2Ipv6Index;
-    } else if (roceV1Ipv4MappedIndex != -1) {
-      gidIndex = roceV1Ipv4MappedIndex;
-    } else if (roceV1Ipv6Index != -1) {
-      gidIndex = roceV1Ipv6Index;
-    } else if (rocev2LinkLocalIndex != -1) {
-      gidIndex = rocev2LinkLocalIndex;
-    } else if (rocev1LinkLocalIndex != -1) {
-      gidIndex = rocev1LinkLocalIndex;
-    } else {
-      gidIndex = -1;
-      return {ERR_FATAL, "Failed to auto-detect a valid GID index. Try setting it manually through IB_GID_INDEX"};
-    }
-    return ERR_NONE;
-  }
-
   static ErrResult PrepareNicTransferResources(ConfigOptions const& cfg,
                                                ExeDevice     const& srcExeDevice,
                                                Transfer      const& t,
@@ -1999,8 +2013,8 @@ namespace {
     bool isRoCE = (rss.srcPortAttr.link_layer == IBV_LINK_LAYER_ETHERNET);
     if (isRoCE) {
       // Try to auto-detect the GID index
-      ERR_CHECK(GetGidIndex(cfg, rss.srcContext, rss.srcPortAttr.gid_tbl_len, srcGidIndex));
-      ERR_CHECK(GetGidIndex(cfg, rss.dstContext, rss.dstPortAttr.gid_tbl_len, dstGidIndex));
+      ERR_CHECK(GetGidIndex(rss.srcContext, rss.srcPortAttr.gid_tbl_len, cfg.nic.ibPort, srcGidIndex));
+      ERR_CHECK(GetGidIndex(rss.dstContext, rss.dstPortAttr.gid_tbl_len, cfg.nic.ibPort, dstGidIndex));
       IBV_CALL(ibv_query_gid, rss.srcContext, port, srcGidIndex, &rss.srcGid);
       IBV_CALL(ibv_query_gid, rss.dstContext, port, dstGidIndex, &rss.dstGid);
     }

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1865,12 +1865,12 @@ namespace {
   {
     if(gidIndex >= 0) return ERR_NONE; // honor user choice
     union ibv_gid gid;
-    int v2_ipv4_mapped_index = -1;
-    int v1_ipv4_mapped_index = -1;
-    int v2_ipv6_index = -1;
-    int v1_ipv6_index = -1;
-    int v2_link_local_index = -1;
-    int v1_link_local_index = -1;
+    int roceV2Ipv4MappedIndex = -1;
+    int roceV1Ipv4MappedIndex = -1;
+    int roceV2Ipv6Index = -1;
+    int roceV1Ipv6Index = -1;
+    int rocev2LinkLocalIndex = -1;
+    int rocev1LinkLocalIndex = -1;
 
     for (int i = 0; i < gidTblLen; ++i) {
       IBV_CALL(ibv_query_gid, context, cfg.nic.ibPort , i, &gid);
@@ -1879,21 +1879,21 @@ namespace {
       ERR_CHECK(GetRoceVersionNumber(context, cfg.nic.ibPort, i, gidCurrRoceVersion));
       if (IsIPv4MappedIPv6(gid)) {
         if (gidCurrRoceVersion == 2) {
-          v2_ipv4_mapped_index = i;  // Highest priority
+          roceV2Ipv4MappedIndex = i;  // Highest priority
         } else {
-          v1_ipv4_mapped_index = i;
+          roceV1Ipv4MappedIndex = i;
         }
       } else if (!LinkLocalGid(gid)) {
         if (gidCurrRoceVersion == 2) {
-          v2_ipv6_index = i;
+          roceV2Ipv6Index = i;
         } else {
-          v1_ipv6_index = i;
+          roceV1Ipv6Index = i;
         }
       } else {
         if (gidCurrRoceVersion == 2) {
-          v2_link_local_index = i;
+          rocev2LinkLocalIndex = i;
         } else {
-          v1_link_local_index = i;
+          rocev1LinkLocalIndex = i;
         }
       }
     }
@@ -1907,18 +1907,18 @@ namespace {
     // * 5. RoCE v2 (Link-local): fe80::/10
     // * 6. RoCE v1 (Link-local)
 
-    if (v2_ipv4_mapped_index != -1) {
-      gidIndex = v2_ipv4_mapped_index;
-    } else if (v2_ipv6_index != -1) {
-      gidIndex = v2_ipv6_index;
-    } else if (v1_ipv4_mapped_index != -1) {
-      gidIndex = v1_ipv4_mapped_index;
-    } else if (v1_ipv6_index != -1) {
-      gidIndex = v1_ipv6_index;
-    } else if (v2_link_local_index != -1) {
-      gidIndex = v2_link_local_index;
-    } else if (v1_link_local_index != -1) {
-      gidIndex = v1_link_local_index;
+    if (roceV2Ipv4MappedIndex != -1) {
+      gidIndex = roceV2Ipv4MappedIndex;
+    } else if (roceV2Ipv6Index != -1) {
+      gidIndex = roceV2Ipv6Index;
+    } else if (roceV1Ipv4MappedIndex != -1) {
+      gidIndex = roceV1Ipv4MappedIndex;
+    } else if (roceV1Ipv6Index != -1) {
+      gidIndex = roceV1Ipv6Index;
+    } else if (rocev2LinkLocalIndex != -1) {
+      gidIndex = rocev2LinkLocalIndex;
+    } else if (rocev1LinkLocalIndex != -1) {
+      gidIndex = rocev1LinkLocalIndex;
     } else {
       gidIndex = -1;
       return {ERR_FATAL, "Failed to auto-detect a valid GID index. Try setting it manually through IB_GID_INDEX"};

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1849,8 +1849,8 @@ namespace {
     // From Broadcom documentation
     // https://techdocs.broadcom.com/us/en/storage-and-ethernet-connectivity/ethernet-nic-controllers/bcm957xxx/adapters/frequently-asked-questions1.html
     // "The IPv4 address is really an IPv4 address mapped into the IPv6 address space.
-    // This can be identified by 80 “0” bits, followed by 16 “1” bits (“FFFF” in hexadecimal)"
-    // followed by the original 32-bit IPv4 address.
+    // This can be identified by 80 “0” bits, followed by 16 “1” bits (“FFFF” in hexadecimal)
+    // followed by the original 32-bit IPv4 address."
     return (gid.global.subnet_prefix == 0    &&
             gid.raw[8]               == 0    &&
             gid.raw[9]               == 0    &&

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1810,67 +1810,10 @@ namespace {
     return false;
   }
 
-  static bool IsValidGid(union ibv_gid* gid)
-  {
-    return (IsConfiguredGid(gid) && !LinkLocalGid(gid));
-  }
-
-  static sa_family_t GetGidAddressFamily(union ibv_gid* gid)
-  {
-    const struct in6_addr *a = (struct in6_addr *)gid->raw;
-    bool isIpV4Mapped = ((a->s6_addr32[0] | a->s6_addr32[1]) |
-                         (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL;
-    bool isIpV4MappedMulticast = (a->s6_addr32[0] == htonl(0xff0e0000) &&
-                                  ((a->s6_addr32[1] |
-                                    (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL));
-    return (isIpV4Mapped || isIpV4MappedMulticast) ? AF_INET : AF_INET6;
-  }
-
-  static bool MatchGidAddressFamily(sa_family_t const& af,
-                                    void*              prefix,
-                                    int                prefixLen,
-                                    union ibv_gid*     gid)
-  {
-    struct in_addr  *base  = NULL;
-    struct in6_addr *base6 = NULL;
-    struct in6_addr *addr6 = NULL;;
-    if (af == AF_INET) {
-      base = (struct in_addr *)prefix;
-    } else {
-      base6 = (struct in6_addr *)prefix;
-    }
-    addr6 = (struct in6_addr *)gid->raw;
-#define NETMASK(bits) (htonl(0xffffffff ^ ((1 << (32 - bits)) - 1)))
-    int i = 0;
-    while (prefixLen > 0 && i < 4) {
-      if (af == AF_INET) {
-        int mask = NETMASK(prefixLen);
-        if ((base->s_addr & mask) ^ (addr6->s6_addr32[3] & mask))
-          break;
-        prefixLen = 0;
-        break;
-      } else {
-        if (prefixLen >= 32) {
-          if (base6->s6_addr32[i] ^ addr6->s6_addr32[i])
-            break;
-          prefixLen -= 32;
-          ++i;
-        } else {
-          int mask = NETMASK(prefixLen);
-          if ((base6->s6_addr32[i] & mask) ^ (addr6->s6_addr32[i] & mask))
-            break;
-          prefixLen = 0;
-        }
-      }
-    }
-    return (prefixLen == 0) ? true : false;
-#undef NETMASK
-  }
-
   static ErrResult GetRoceVersionNumber(struct ibv_context* const& context,
                                         int const&  portNum,
                                         int const&  gidIndex,
-                                        int*        version)
+                                        int&        version)
   {
     char const* deviceName = ibv_get_device_name(context->device);
     char gidRoceVerStr[16]      = {};
@@ -1891,60 +1834,85 @@ namespace {
     if (strlen(gidRoceVerStr)) {
       if (strncmp(gidRoceVerStr, "IB/RoCE v1", strlen("IB/RoCE v1")) == 0
           || strncmp(gidRoceVerStr, "RoCE v1", strlen("RoCE v1")) == 0) {
-        *version = 1;
+        version = 1;
       }
       else if (strncmp(gidRoceVerStr, "RoCE v2", strlen("RoCE v2")) == 0) {
-        *version = 2;
+        version = 2;
       }
     }
     return ERR_NONE;
   }
 
-  static ErrResult GetGidIndex(ConfigOptions const& cfg,
-                               struct ibv_context*  context,
-                               int const&           gidTblLen,
-                               int&                 gidIndex)
+  static bool isIPv4MappedIPv6(const union ibv_gid &gid)
   {
-    // Use GID index if user specified
-    if (gidIndex >= 0) return ERR_NONE;
+    return (gid.raw[10] == 0xff && gid.raw[11] == 0xff); // ::ffff:x.x.x.x format
+  }
 
-    // Try to find the best GID index
-    int         port          = cfg.nic.ibPort;
-    sa_family_t targetAddrFam = (cfg.nic.ipAddressFamily == 6)? AF_INET6 : AF_INET;
-    int         targetRoCEVer = cfg.nic.roceVersion;
+  static ErrResult GetGidIndex(ConfigOptions const& cfg,
+                               struct ibv_context* context,
+                              const int& gidTblLen,
+                              int& gidIndex)
+  {
+    if(gidIndex >= 0) return ERR_NONE; // honor user choice
+    union ibv_gid gid;
+    int v2_ipv4_mapped_index = -1;
+    int v1_ipv4_mapped_index = -1;
+    int v2_ipv6_index = -1;
+    int v1_ipv6_index = -1;
+    int v2_link_local_index = -1;
+    int v1_link_local_index = -1;
 
-    // Initially assume gidIndex = 0
-    int gidIndexCurr = 0;
-    union ibv_gid gidCurr;
-    IBV_CALL(ibv_query_gid, context, port, gidIndexCurr, &gidCurr);
-    sa_family_t gidCurrFam = GetGidAddressFamily(&gidCurr);
-    bool gidCurrIsValid = IsValidGid(&gidCurr);
-    int  gidCurrRoceVersion;
-    ERR_CHECK(GetRoceVersionNumber(context, port, gidIndexCurr, &gidCurrRoceVersion));
-
-    // Loop over GID table to find the best match
-    for (int gidIndexTest = 1; gidIndexTest < gidTblLen; ++gidIndexTest) {
-      union ibv_gid gidTest;
-      IBV_CALL(ibv_query_gid, context, cfg.nic.ibPort, gidIndexTest, &gidTest);
-      if (!IsValidGid(&gidTest)) continue;
-
-      sa_family_t gidTestFam = GetGidAddressFamily(&gidTest);
-      bool gidTestMatchSubnet = MatchGidAddressFamily(targetAddrFam, NULL, 0, &gidTest);
-      int  gidTestRoceVersion;
-      ERR_CHECK(GetRoceVersionNumber(context, port, gidIndexTest, &gidTestRoceVersion));
-
-      if (!gidCurrIsValid ||
-          (gidTestFam == targetAddrFam && gidTestMatchSubnet &&
-           (gidCurrFam != targetAddrFam || gidTestRoceVersion == targetRoCEVer))) {
-        // Switch to better match
-        gidIndexCurr       = gidIndexTest;
-        gidCurrFam         = gidTestFam;
-        gidCurrIsValid     = true;
-        gidCurrRoceVersion = gidTestRoceVersion;
+    for (int i = 0; i < gidTblLen; ++i) {
+      IBV_CALL(ibv_query_gid, context, cfg.nic.ibPort , i, &gid);
+      if (!IsConfiguredGid(&gid)) continue;
+      int gidCurrRoceVersion;
+      ERR_CHECK(GetRoceVersionNumber(context, cfg.nic.ibPort, i, gidCurrRoceVersion));
+      if (isIPv4MappedIPv6(gid)) {
+        if (gidCurrRoceVersion == 2) {
+          v2_ipv4_mapped_index = i;  // Highest priority
+        } else {
+          v1_ipv4_mapped_index = i;
+        }
+      } else if (!LinkLocalGid(&gid)) {
+        if (gidCurrRoceVersion == 2) {
+          v2_ipv6_index = i;
+        } else {
+          v1_ipv6_index = i;
+        }
+      } else {
+        if (gidCurrRoceVersion == 2) {
+          v2_link_local_index = i;
+        } else {
+          v1_link_local_index = i;
+        }
       }
     }
 
-    gidIndex = gidIndexCurr;
+    // Select the best available GID based on priority
+    // * Priority Order:
+    // * 1. RoCE v2 (IPv4-mapped): ::ffff:192.168.x.x
+    // * 2. RoCE v2 (Not IPv4-mapped)
+    // * 3. RoCE v1 (IPv4-mapped)
+    // * 4. RoCE v1 (Not IPv4-mapped)
+    // * 5. RoCE v2 (Link-local): fe80::/10
+    // * 6. RoCE v1 (Link-local)
+
+    if (v2_ipv4_mapped_index != -1) {
+      gidIndex = v2_ipv4_mapped_index;
+    } else if (v2_ipv6_index != -1) {
+      gidIndex = v2_ipv6_index;
+    } else if (v1_ipv4_mapped_index != -1) {
+      gidIndex = v1_ipv4_mapped_index;
+    } else if (v1_ipv6_index != -1) {
+      gidIndex = v1_ipv6_index;
+    } else if (v2_link_local_index != -1) {
+      gidIndex = v2_link_local_index;
+    } else if (v1_link_local_index != -1) {
+      gidIndex = v1_link_local_index;
+    } else {
+      gidIndex = -1;
+      return {ERR_FATAL, "Failed to auto-detect a valid GID index. Try setting it manually through IB_GID_INDEX"};
+    }
     return ERR_NONE;
   }
 

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1860,8 +1860,8 @@ namespace {
 
   static ErrResult GetGidIndex(ConfigOptions const& cfg,
                                struct ibv_context* context,
-                              const int& gidTblLen,
-                              int& gidIndex)
+                               const int& gidTblLen,
+                               int& gidIndex)
   {
     if(gidIndex >= 0) return ERR_NONE; // honor user choice
     union ibv_gid gid;


### PR DESCRIPTION
### Fixed:
- Have a priority list of which GID entry to go for instead of hardcoding choices based on underdocumented user input (such as RoCE version and IP address family)
- Use link-local when it is the only choice (i.e. when routing information is not available beyond local link)

### Changed:
- Introduce maintainable and reusable code for main logic and IPv4-mapped addresses.
- Show the GID index in the topology table. It is helpful for debugging purposes. 




