### PR TITLE
Check nvidia-smi output instead of just searching nvcc bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GPU_TARGETS ?= native
 DEBUG ?= 0
 
 ifeq ($(filter clean,$(MAKECMDGOALS)),)
-  # Compile TransferBenchCuda if nvidia-smi returns successfully
+  # Compile TransferBenchCuda if nvidia-smi returns successfully and nvcc detected
   ifeq ("$(shell nvidia-smi > /dev/null 2>&1 && test -e $(NVCC) && echo found)", "found")
     EXE=TransferBenchCuda
     CXX=$(NVCC)

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ DEBUG ?= 0
 
 ifeq ($(filter clean,$(MAKECMDGOALS)),)
   # Compile TransferBenchCuda if nvidia-smi returns successfully
-  ifeq ("$(shell nvidia-smi > /dev/null 2>&1 && echo found)", "found")
+  ifeq ("$(shell nvidia-smi > /dev/null 2>&1 && test -e $(NVCC) && echo found)", "found")
     EXE=TransferBenchCuda
     CXX=$(NVCC)
   else

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ GPU_TARGETS ?= native
 DEBUG ?= 0
 
 ifeq ($(filter clean,$(MAKECMDGOALS)),)
-  # Compile TransferBenchCuda if nvcc detected
-  ifeq ("$(shell test -e $(NVCC) && echo found)", "found")
+  # Compile TransferBenchCuda if nvidia-smi returns successfully
+  ifeq ("$(shell nvidia-smi > /dev/null 2>&1 && echo found)", "found")
     EXE=TransferBenchCuda
     CXX=$(NVCC)
   else
@@ -47,6 +47,7 @@ ifeq ($(filter clean,$(MAKECMDGOALS)),)
 
   LDFLAGS += -lpthread
 
+  NIC_ENABLED = 0
   # Compile RDMA executor if
   # 1) DISABLE_NIC_EXEC is not set to 1
   # 2) IBVerbs is found in the Dynamic Linker cache


### PR DESCRIPTION
## Motivation

`make` thinks it is on NVIDIA hw when `nvcc` is found. Example: `nvcc` is found on an internal cluster with AMD hw because it happens to be on this path `/usr/local/cuda/bin/`

## Technical Details
Add an additional check:
If `nvidia-smi` is found and exited with 0 error code, the condition evaluates to true.
If `nvidia-smi` is not found, or found and exited with non-zero error code, the condition evaluates to false.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
