### PR TITLE
Warp transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ Documentation for TransferBench is available at
 ### Added
 - Added warp-level dispatch support via GFX_SE_TYPE environment variable
   - GFX_SE_TYPE=0 (default): Threadblock-level dispatch, each subexecutor is a threadblock
-    - NUM_SUB_EXEC specifies number of threadblocks (e.g., NUM_SUB_EXEC=2 launches 2 threadblocks)
-  - GFX_SE_TYPE=1: Warp-level dispatch, each subexecutor is a single warp (e.g., NUM_SUB_EXEC specifies total number of warps across all threadblocks)
+  - GFX_SE_TYPE=1: Warp-level dispatch, each subexecutor is a single warp
 
 ## v1.64.00
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,15 @@
 Documentation for TransferBench is available at
 [https://rocm.docs.amd.com/projects/TransferBench](https://rocm.docs.amd.com/projects/TransferBench).
 
-## v1.64.00
+## v1.65.00
 ### Added
 - Added warp-level dispatch support via GFX_SE_TYPE environment variable
   - GFX_SE_TYPE=0 (default): Threadblock-level dispatch, each subexecutor is a threadblock
     - NUM_SUB_EXEC specifies number of threadblocks (e.g., NUM_SUB_EXEC=2 launches 2 threadblocks)
   - GFX_SE_TYPE=1: Warp-level dispatch, each subexecutor is a single warp (e.g., NUM_SUB_EXEC specifies total number of warps across all threadblocks)
+
+## v1.64.00
+### Added
 - Added BLOCKSIZES to a2asweep preset to allow also sweeping over threadblock sizes
 - Added FILL_COMPRESS to allow more control over input data pattern
   - FILL_COMPRESS takes in a comma-separated list of integer percentages (that must add up to 100)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Documentation for TransferBench is available at
 
 ## v1.64.00
 ### Added
+- Added warp-level dispatch support via GFX_SE_TYPE environment variable
+  - GFX_SE_TYPE=0 (default): Threadblock-level dispatch, each subexecutor is a threadblock
+    - NUM_SUB_EXEC specifies number of threadblocks (e.g., NUM_SUB_EXEC=2 launches 2 threadblocks)
+  - GFX_SE_TYPE=1: Warp-level dispatch, each subexecutor is a single warp (e.g., NUM_SUB_EXEC specifies total number of warps across all threadblocks)
 - Added BLOCKSIZES to a2asweep preset to allow also sweeping over threadblock sizes
 - Added FILL_COMPRESS to allow more control over input data pattern
   - FILL_COMPRESS takes in a comma-separated list of integer percentages (that must add up to 100)

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -89,6 +89,7 @@ public:
   int gfxBlockSize;                  // Size of each threadblock (must be multiple of 64)
   vector<uint32_t> cuMask;           // Bit-vector representing the CU mask
   vector<vector<int>> prefXccTable;  // Specifies XCC to use for given exe->dst pair
+  int gfxSeType;                     // GFX subexecutor type (0=threadblock, 1=warp)
   int gfxTemporal;                   // Non-temporal load/store mode (0=none, 1=load, 2=store, 3=both)
   int gfxUnroll;                     // GFX-kernel unroll factor
   int useHipEvents;                  // Use HIP events for timing GFX/DMA Executor
@@ -141,6 +142,7 @@ public:
     fillCompress      = GetEnvVarArray("FILL_COMPRESS"  , {});
     gfxBlockOrder     = GetEnvVar("GFX_BLOCK_ORDER"     , 0);
     gfxBlockSize      = GetEnvVar("GFX_BLOCK_SIZE"      , 256);
+    gfxSeType         = GetEnvVar("GFX_SE_TYPE"         , 0);
     gfxSingleTeam     = GetEnvVar("GFX_SINGLE_TEAM"     , 1);
     gfxTemporal       = GetEnvVar("GFX_TEMPORAL"        , 0);
     gfxUnroll         = GetEnvVar("GFX_UNROLL"          , defaultGfxUnroll);
@@ -320,6 +322,7 @@ public:
     printf(" FILL_PATTERN      - Big-endian pattern for source data, specified in hex digits. Must be even # of digits\n");
     printf(" GFX_BLOCK_ORDER   - How blocks for transfers are ordered. 0=sequential, 1=interleaved\n");
     printf(" GFX_BLOCK_SIZE    - # of threads per threadblock (Must be multiple of 64)\n");
+    printf(" GFX_SE_TYPE       - SubExecutor granularity type (0=threadblock, 1=warp)\n");
     printf(" GFX_TEMPORAL      - Use of non-temporal loads or stores (0=none 1=loads 2=stores 3=both)\n");
     printf(" GFX_UNROLL        - Unroll factor for GFX kernel (0=auto), must be less than %d\n", TransferBench::GetIntAttribute(ATR_GFX_MAX_UNROLL));
     printf(" GFX_SINGLE_TEAM   - Have subexecutors work together on full array instead of working on disjoint subarrays\n");
@@ -411,6 +414,8 @@ public:
           "Thread block ordering: %s", gfxBlockOrder == 0 ? "Sequential" : "Interleaved");
     Print("GFX_BLOCK_SIZE", gfxBlockSize,
           "Threadblock size of %d", gfxBlockSize);
+    Print("GFX_SE_TYPE", gfxSeType,
+          "SubExecutor granularity: %s", gfxSeType == 0 ? "Threadblock" : "Warp");
     Print("GFX_SINGLE_TEAM", gfxSingleTeam,
           "%s", (gfxSingleTeam ? "Combining CUs to work across entire data array" :
                                  "Each CUs operates on its own disjoint subarray"));
@@ -619,6 +624,7 @@ public:
     cfg.gfx.blockSize              = gfxBlockSize;
     cfg.gfx.cuMask                 = cuMask;
     cfg.gfx.prefXccTable           = prefXccTable;
+    cfg.gfx.seType                 = gfxSeType;
     cfg.gfx.unrollFactor           = gfxUnroll;
     cfg.gfx.temporalMode           = gfxTemporal;
     cfg.gfx.useHipEvents           = useHipEvents;

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -610,16 +610,16 @@ namespace {
   float constexpr MEMSET_VAL     = 13323083.0f;        // Value to memset (double)
 
   int GetWarpSize(std::vector<ErrResult>* errors = nullptr) {
-    hipDeviceProp_t prop;
-    hipError_t err = hipGetDeviceProperties(&prop, 0);
+    int warpSize = 0;
+    hipError_t err = hipDeviceGetAttribute(&warpSize, hipDeviceAttributeWarpSize, 0);
     if (err == hipSuccess) {
-      return prop.warpSize;
+      return warpSize;
     }
     
     // Query failed, report error and fall back to compile-time default
     if (errors) {
       errors->push_back({ERR_WARN,
-                        "Failed to query device warp size (hipGetDeviceProperties error: %d). "
+                        "Failed to query device warp size (hipDeviceGetAttribute error: %d). "
                         "Falling back to compile-time default", err});
     }
 #if defined(__NVCC__)

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -180,6 +180,7 @@ namespace TransferBench
     int                 blockSize      = 256;   ///< Size of each threadblock (must be multiple of 64)
     vector<uint32_t>    cuMask         = {};    ///< Bit-vector representing the CU mask
     vector<vector<int>> prefXccTable   = {};    ///< 2D table with preferred XCD to use for a specific [src][dst] GPU device
+    int                 seType         = 0;     ///< SubExecutor granularity type (0=threadblock, 1=warp)
     int                 temporalMode   = 0;     ///< Non-temporal load/store mode 0=none, 1=load, 2=store, 3=both
     int                 unrollFactor   = 4;     ///< GFX-kernel unroll factor
     int                 useHipEvents   = 1;     ///< Use HIP events for timing GFX Executor

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -629,6 +629,18 @@ namespace {
 #endif
   }
 
+  // Calculate grid Y dimension based on SE_TYPE
+  int CalculateGridY(int seType, int blockSize, int numSubExecs) {
+    // Warp-level: each subexecutor is a warp, pack warps into threadblocks
+    if (seType == 1) {
+      int warpsPerBlock = blockSize / GetWarpSize();
+      return (numSubExecs + warpsPerBlock - 1) / warpsPerBlock;
+    }
+
+    // Default: Threadblock-level, each subexecutor is a threadblock
+    return numSubExecs;
+  }
+
 // Parsing-related functions
 //========================================================================================
 
@@ -3238,18 +3250,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     auto cpuStart = std::chrono::high_resolution_clock::now();
 
     int numSubExecs = rss.subExecParamCpu.size();
-    
-    // Calculate grid dimensions based on SE_TYPE
-    int gridY;
-    if (cfg.gfx.seType == 0) {
-      // Threadblock-level: each subexecutor is a threadblock
-      gridY = numSubExecs;
-    } else {
-      // Warp-level: each subexecutor is a warp, pack warps into threadblocks
-      int warpsPerBlock = cfg.gfx.blockSize / GetWarpSize();
-      gridY = (numSubExecs + warpsPerBlock - 1) / warpsPerBlock;
-    }
-    
+    int gridY = CalculateGridY(cfg.gfx.seType, cfg.gfx.blockSize, numSubExecs);
     dim3 const gridSize(xccDim, gridY, 1);
     dim3 const blockSize(cfg.gfx.blockSize, 1);
 
@@ -3325,18 +3326,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     } else {
       // Combine all the Transfers into a single kernel launch
       int numSubExecs = exeInfo.totalSubExecs;
-      
-      // Calculate grid dimensions based on SE_TYPE
-      int gridY;
-      if (cfg.gfx.seType == 0) {
-        // Threadblock-level: each subexecutor is a threadblock
-        gridY = numSubExecs;
-      } else {
-        // Warp-level: each subexecutor is a warp, pack warps into threadblocks
-        int warpsPerBlock = cfg.gfx.blockSize / GetWarpSize();
-        gridY = (numSubExecs + warpsPerBlock - 1) / warpsPerBlock;
-      }
-      
+      int gridY = CalculateGridY(cfg.gfx.seType, cfg.gfx.blockSize, numSubExecs);
       dim3 const gridSize(xccDim, gridY, 1);
       dim3 const blockSize(cfg.gfx.blockSize, 1);
       hipStream_t stream = exeInfo.streams[0];

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -609,6 +609,26 @@ namespace {
   int   constexpr MEMSET_CHAR    = 75;                 // Value to memset (char)
   float constexpr MEMSET_VAL     = 13323083.0f;        // Value to memset (double)
 
+  int GetWarpSize(std::vector<ErrResult>* errors = nullptr) {
+    hipDeviceProp_t prop;
+    hipError_t err = hipGetDeviceProperties(&prop, 0);
+    if (err == hipSuccess) {
+      return prop.warpSize;
+    }
+    
+    // Query failed, report error and fall back to compile-time default
+    if (errors) {
+      errors->push_back({ERR_WARN,
+                        "Failed to query device warp size (hipGetDeviceProperties error: %d). "
+                        "Falling back to compile-time default", err});
+    }
+#if defined(__NVCC__)
+    return 32;
+#else
+    return 64;
+#endif
+  }
+
 // Parsing-related functions
 //========================================================================================
 
@@ -1304,11 +1324,17 @@ namespace {
       {
         // Check total number of subexecutors requested
         int numGpuSubExec = GetNumSubExecutors(exeDevice);
+        // For warp-level dispatch, multiply by warps per threadblock
+        if (cfg.gfx.seType == 1) {
+          int warpsPerBlock = cfg.gfx.blockSize / GetWarpSize(&errors);
+          numGpuSubExec *= warpsPerBlock;
+        }
         if (totalSubExecs[exeDevice] > numGpuSubExec)
           errors.push_back({ERR_WARN,
-                            "GPU %d requests %d total CUs however only %d available. "
+                            "GPU %d requests %d total %s however only %d available. "
                             "Serialization will occur",
-                            exeDevice.exeIndex, totalSubExecs[exeDevice], numGpuSubExec});
+                            exeDevice.exeIndex, totalSubExecs[exeDevice], 
+                            cfg.gfx.seType == 0 ? "CUs" : "warps", numGpuSubExec});
         // Check that if executor subindices are used, all Transfers specify executor subindices
         if (useSubIndexCount[exeDevice] > 0 && useSubIndexCount[exeDevice] != transferCount[exeDevice]) {
           errors.push_back({ERR_FATAL,
@@ -2976,14 +3002,31 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
   }
 
   // Kernel for GFX execution
-  template <typename PACKED_FLOAT, int BLOCKSIZE, int UNROLL, int TEMPORAL_MODE>
+  template <typename PACKED_FLOAT, int BLOCKSIZE, int UNROLL, int TEMPORAL_MODE, int SE_TYPE>
   __global__ void __launch_bounds__(BLOCKSIZE)
     GpuReduceKernel(SubExecParam* params, int waveOrder, int numSubIterations)
   {
     int64_t startCycle;
-    if (threadIdx.x == 0) startCycle = GetTimestamp();
+    // For warp-level, each warp's first thread records timing; for threadblock-level, only first thread of block
+    bool shouldRecordTiming = (SE_TYPE == 1) ? (threadIdx.x % warpSize == 0) : (threadIdx.x == 0);
+    if (shouldRecordTiming) startCycle = GetTimestamp();
 
-    SubExecParam& p = params[blockIdx.y];
+    // SE_TYPE: 0=threadblock, 1=warp
+    int subExecIdx;
+    if (SE_TYPE == 0) {
+      // Threadblock-level: each threadblock is a subexecutor
+      subExecIdx = blockIdx.y;
+    } else {
+      // Warp-level: each warp is a subexecutor
+      int warpIdx = threadIdx.x / warpSize;
+      int warpsPerBlock = BLOCKSIZE / warpSize;
+      subExecIdx = blockIdx.y * warpsPerBlock + warpIdx;
+    }
+
+    SubExecParam& p = params[subExecIdx];
+
+    // For warp-level dispatch, inactive warps should return early
+    if (SE_TYPE == 1 && p.N == 0) return;
 
     // Filter by XCC
 #if !defined(__NVCC__)
@@ -3003,8 +3046,16 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     // Operate on wavefront granularity
     int32_t const nTeams   = p.teamSize;             // Number of threadblocks working together on this subarray
     int32_t const teamIdx  = p.teamIdx;              // Index of this threadblock within the team
-    int32_t const nWaves   = BLOCKSIZE   / warpSize; // Number of wavefronts within this threadblock
-    int32_t const waveIdx  = threadIdx.x / warpSize; // Index of this wavefront within the threadblock
+    int32_t nWaves, waveIdx;
+    if (SE_TYPE == 0) {
+      // Threadblock-level: all wavefronts in block work together
+      nWaves  = BLOCKSIZE / warpSize;                // Number of wavefronts within this threadblock
+      waveIdx = threadIdx.x / warpSize;              // Index of this wavefront within the threadblock
+    } else {
+      // Warp-level: each warp works independently
+      nWaves  = 1;
+      waveIdx = 0;
+    }
     int32_t const tIdx     = threadIdx.x % warpSize; // Thread index within wavefront
 
     size_t  const numPackedFloat = p.N / (sizeof(PACKED_FLOAT)/sizeof(float));
@@ -3107,8 +3158,15 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
 
     // Wait for all threads to finish
-    __syncthreads();
-    if (threadIdx.x == 0) {
+    if (SE_TYPE == 1) {
+      // For warp-level, sync within warp only
+      __syncwarp();
+    } else {
+      // For threadblock-level, sync all threads
+      __syncthreads();
+    }
+    
+    if (shouldRecordTiming) {
       __threadfence_system();
       p.stopCycle  = GetTimestamp();
       p.startCycle = startCycle;
@@ -3117,11 +3175,15 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
   }
 
-#define GPU_KERNEL_TEMPORAL_DECL(BLOCKSIZE, UNROLL, DWORD)    \
-  {GpuReduceKernel<DWORD, BLOCKSIZE, UNROLL, TEMPORAL_NONE>,  \
-   GpuReduceKernel<DWORD, BLOCKSIZE, UNROLL, TEMPORAL_LOAD>,  \
-   GpuReduceKernel<DWORD, BLOCKSIZE, UNROLL, TEMPORAL_STORE>, \
-   GpuReduceKernel<DWORD, BLOCKSIZE, UNROLL, TEMPORAL_BOTH>}
+#define GPU_KERNEL_SE_TYPE_DECL(BLOCKSIZE, UNROLL, DWORD, TEMPORAL)    \
+  {GpuReduceKernel<DWORD, BLOCKSIZE, UNROLL, TEMPORAL, 0>,          \
+   GpuReduceKernel<DWORD, BLOCKSIZE, UNROLL, TEMPORAL, 1>}
+
+#define GPU_KERNEL_TEMPORAL_DECL(BLOCKSIZE, UNROLL, DWORD)           \
+  {GPU_KERNEL_SE_TYPE_DECL(BLOCKSIZE, UNROLL, DWORD, TEMPORAL_NONE), \
+   GPU_KERNEL_SE_TYPE_DECL(BLOCKSIZE, UNROLL, DWORD, TEMPORAL_LOAD), \
+   GPU_KERNEL_SE_TYPE_DECL(BLOCKSIZE, UNROLL, DWORD, TEMPORAL_STORE),\
+   GPU_KERNEL_SE_TYPE_DECL(BLOCKSIZE, UNROLL, DWORD, TEMPORAL_BOTH)}
 
 #define GPU_KERNEL_DWORD_DECL(BLOCKSIZE, UNROLL)        \
   {GPU_KERNEL_TEMPORAL_DECL(BLOCKSIZE, UNROLL, float),  \
@@ -3138,9 +3200,9 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
    GPU_KERNEL_DWORD_DECL(BLOCKSIZE, 7),      \
    GPU_KERNEL_DWORD_DECL(BLOCKSIZE, 8)}
 
-  // Table of all GPU Reduction kernel functions (templated blocksize / unroll / dword size)
+  // Table of all GPU Reduction kernel functions (templated blocksize / unroll / dword size / temporal / se_type)
   typedef void (*GpuKernelFuncPtr)(SubExecParam*, int, int);
-  GpuKernelFuncPtr GpuKernelTable[MAX_WAVEGROUPS][MAX_UNROLL][3][4] =
+  GpuKernelFuncPtr GpuKernelTable[MAX_WAVEGROUPS][MAX_UNROLL][3][4][2] =
   {
     GPU_KERNEL_UNROLL_DECL(64),
     GPU_KERNEL_UNROLL_DECL(128),
@@ -3162,6 +3224,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
   #undef GPU_KERNEL_UNROLL_DECL
   #undef GPU_KERNEL_DWORD_DECL
   #undef GPU_KERNEL_TEMPORAL_DECL
+  #undef GPU_KERNEL_SE_TYPE_DECL
 
   // Execute a single GPU Transfer (when using 1 stream per Transfer)
   static ErrResult ExecuteGpuTransfer(int           const  iteration,
@@ -3175,13 +3238,25 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     auto cpuStart = std::chrono::high_resolution_clock::now();
 
     int numSubExecs = rss.subExecParamCpu.size();
-    dim3 const gridSize(xccDim, numSubExecs, 1);
+    
+    // Calculate grid dimensions based on SE_TYPE
+    int gridY;
+    if (cfg.gfx.seType == 0) {
+      // Threadblock-level: each subexecutor is a threadblock
+      gridY = numSubExecs;
+    } else {
+      // Warp-level: each subexecutor is a warp, pack warps into threadblocks
+      int warpsPerBlock = cfg.gfx.blockSize / GetWarpSize();
+      gridY = (numSubExecs + warpsPerBlock - 1) / warpsPerBlock;
+    }
+    
+    dim3 const gridSize(xccDim, gridY, 1);
     dim3 const blockSize(cfg.gfx.blockSize, 1);
 
     int wordSizeIdx = cfg.gfx.wordSize == 1 ? 0 :
                       cfg.gfx.wordSize == 2 ? 1 :
                                               2;
-    auto gpuKernel = GpuKernelTable[cfg.gfx.blockSize/64 - 1][cfg.gfx.unrollFactor - 1][wordSizeIdx][cfg.gfx.temporalMode];
+    auto gpuKernel = GpuKernelTable[cfg.gfx.blockSize/64 - 1][cfg.gfx.unrollFactor - 1][wordSizeIdx][cfg.gfx.temporalMode][cfg.gfx.seType];
 
 #if defined(__NVCC__)
     if (startEvent != NULL)
@@ -3250,14 +3325,26 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     } else {
       // Combine all the Transfers into a single kernel launch
       int numSubExecs = exeInfo.totalSubExecs;
-      dim3 const gridSize(xccDim, numSubExecs, 1);
+      
+      // Calculate grid dimensions based on SE_TYPE
+      int gridY;
+      if (cfg.gfx.seType == 0) {
+        // Threadblock-level: each subexecutor is a threadblock
+        gridY = numSubExecs;
+      } else {
+        // Warp-level: each subexecutor is a warp, pack warps into threadblocks
+        int warpsPerBlock = cfg.gfx.blockSize / GetWarpSize();
+        gridY = (numSubExecs + warpsPerBlock - 1) / warpsPerBlock;
+      }
+      
+      dim3 const gridSize(xccDim, gridY, 1);
       dim3 const blockSize(cfg.gfx.blockSize, 1);
       hipStream_t stream = exeInfo.streams[0];
 
       int wordSizeIdx = cfg.gfx.wordSize == 1 ? 0 :
                         cfg.gfx.wordSize == 2 ? 1 :
                                                 2;
-      auto gpuKernel = GpuKernelTable[cfg.gfx.blockSize/64 - 1][cfg.gfx.unrollFactor - 1][wordSizeIdx][cfg.gfx.temporalMode];
+      auto gpuKernel = GpuKernelTable[cfg.gfx.blockSize/64 - 1][cfg.gfx.unrollFactor - 1][wordSizeIdx][cfg.gfx.temporalMode][cfg.gfx.seType];
 
 #if defined(__NVCC__)
       if (cfg.gfx.useHipEvents)


### PR DESCRIPTION
## Motivation

Add warp-level control for kernel dispatch.

## Technical Details
This PR adds support for warp-level dispatch via the GFX_SE_TYPE environment variable:
- Added GFX_SE_TYPE environment variable (0=threadblock, 1=warp) in EnvVars.hpp
- Extended `GpuReduceKernel` template with SE_TYPE parameter to support both dispatch modes
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
