### PR TITLE
Add NUM_SRCS/NUM_DSTS template parameters to GpuReduceKernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Documentation for TransferBench is available at
 - Added warp-level dispatch support via GFX_SE_TYPE environment variable
   - GFX_SE_TYPE=0 (default): Threadblock-level dispatch, each subexecutor is a threadblock
   - GFX_SE_TYPE=1: Warp-level dispatch, each subexecutor is a single warp
+- Added compile-time template specialization for numSrcs/numDsts in GpuReduceKernel
+  - Instantiates optimized kernels for common cases: (0,1), (1,0), (1,1)
 
 ## v1.64.00
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ Documentation for TransferBench is available at
   - GFX_SE_TYPE=0 (default): Threadblock-level dispatch, each subexecutor is a threadblock
   - GFX_SE_TYPE=1: Warp-level dispatch, each subexecutor is a single warp
 - Added compile-time template specialization for numSrcs/numDsts in GpuReduceKernel
-  - Instantiates optimized kernels for common cases: (0,1), (1,0), (1,1)
+  - Instantiates optimized kernels for common Transfer types:
+    - Copy (1 src → 1 dst): Optimized single-source data copy
+    - Read-only (1 src → 0 dst): Optimized memory read validation
+    - Write-only (0 src → 1 dst): Optimized memory write/initialization
+  - Compiler eliminates dead code loops for these specialized cases, improving performance by ~6% to 7% on MI3xx machines 
 
 ## v1.64.00
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Documentation for TransferBench is available at
     - Copy (1 src → 1 dst): Optimized single-source data copy
     - Read-only (1 src → 0 dst): Optimized memory read validation
     - Write-only (0 src → 1 dst): Optimized memory write/initialization
-  - Compiler eliminates dead code loops for these specialized cases, improving performance by ~6% to 7% on MI3xx machines 
+  - Compiler eliminates dead code loops for these specialized cases, improving performance by up to 7% for all-to-all workloads on MI3xx machines
 
 ## v1.64.00
 ### Added

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3049,9 +3049,9 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     if (p.preferredXccId != -1 && xccId != p.preferredXccId) return;
 #endif
 
-    // Use template values if non-zero, otherwise use runtime arguments
-    int32_t const numSrcs = (NUM_SRCS != 0) ? NUM_SRCS : numSrcsArg;
-    int32_t const numDsts = (NUM_DSTS != 0) ? NUM_DSTS : numDstsArg;
+    // Use template values if >= 0, otherwise use runtime arguments (NUM_SRCS/NUM_DSTS == -1)
+    int32_t const numSrcs = (NUM_SRCS >= 0) ? NUM_SRCS : numSrcsArg;
+    int32_t const numDsts = (NUM_DSTS >= 0) ? NUM_DSTS : numDstsArg;
     PACKED_FLOAT const* __restrict__ srcFloatPacked[MAX_SRCS];
     PACKED_FLOAT*       __restrict__ dstFloatPacked[MAX_DSTS];
     for (int i = 0; i < numSrcs; i++) srcFloatPacked[i] = (PACKED_FLOAT const*)p.src[i];
@@ -3202,24 +3202,20 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     if (numSrcs == 1 && numDsts == 1) {
       GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 1, 1>
         (params, seType, warpSize, waveOrder, numSubIterations, numSrcs, numDsts);
-      return;
     }
-    
-    if (numSrcs == 0 && numDsts == 1) {
+    else if (numSrcs == 0 && numDsts == 1) {
       GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 0, 1>
         (params, seType, warpSize, waveOrder, numSubIterations, numSrcs, numDsts);
-      return;
     }
-    
-    if (numSrcs == 1 && numDsts == 0) {
+    else if (numSrcs == 1 && numDsts == 0) {
       GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 1, 0>
         (params, seType, warpSize, waveOrder, numSubIterations, numSrcs, numDsts);
-      return;
     }
-    
-    // Fallback: Use (0,0) template which uses runtime arguments for any combination
-    GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 0, 0>
-      (params, seType, warpSize, waveOrder, numSubIterations, numSrcs, numDsts);
+    else {
+      // Fallback: Use (-1,-1) template which uses runtime arguments for any combination
+      GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, -1, -1>
+        (params, seType, warpSize, waveOrder, numSubIterations, numSrcs, numDsts);
+    }
   }
 
 #define GPU_KERNEL_TEMPORAL_DECL(BLOCKSIZE, UNROLL, DWORD)           \

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3014,7 +3014,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
   }
 
-  // Kernel for GFX execution (Implementation with templated NUM_SRCS and NUM_DSTS)
+  // Kernel for GFX execution
   template <typename PACKED_FLOAT, int BLOCKSIZE, int UNROLL, int TEMPORAL_MODE,
             int NUM_SRCS, int NUM_DSTS>
   __device__ void GpuReduceKernelImpl(SubExecParam* params, int seType, int warpSize, int waveOrder, int numSubIterations)
@@ -3048,7 +3048,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     if (p.preferredXccId != -1 && xccId != p.preferredXccId) return;
 #endif
 
-    // Collect data information (now compile-time constants via templates)
+    // Collect data information
     constexpr int32_t numSrcs = NUM_SRCS;
     constexpr int32_t numDsts = NUM_DSTS;
     PACKED_FLOAT const* __restrict__ srcFloatPacked[MAX_SRCS];
@@ -3197,8 +3197,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     int const numSrcs = params[blockIdx.y].numSrcs;
     int const numDsts = params[blockIdx.y].numDsts;
     
-    // Dispatch to specialized implementation
-    
+    // Dispatch to specialized implementation based on numSrcs and numDsts
     if (numSrcs == 1 && numDsts == 1) {
       GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 1, 1>
         (params, seType, warpSize, waveOrder, numSubIterations);

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3014,10 +3014,10 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
   }
 
-  // Kernel for GFX execution
-  template <typename PACKED_FLOAT, int BLOCKSIZE, int UNROLL, int TEMPORAL_MODE>
-  __global__ void __launch_bounds__(BLOCKSIZE)
-    GpuReduceKernel(SubExecParam* params, int seType, int warpSize, int waveOrder, int numSubIterations)
+  // Kernel for GFX execution (Implementation with templated NUM_SRCS and NUM_DSTS)
+  template <typename PACKED_FLOAT, int BLOCKSIZE, int UNROLL, int TEMPORAL_MODE,
+            int NUM_SRCS, int NUM_DSTS>
+  __device__ void GpuReduceKernelImpl(SubExecParam* params, int seType, int warpSize, int waveOrder, int numSubIterations)
   {
     int64_t startCycle;
     // For warp-level, each warp's first thread records timing; for threadblock-level, only first thread of block
@@ -3048,9 +3048,9 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     if (p.preferredXccId != -1 && xccId != p.preferredXccId) return;
 #endif
 
-    // Collect data information
-    int32_t const  numSrcs  = p.numSrcs;
-    int32_t const  numDsts  = p.numDsts;
+    // Collect data information (now compile-time constants via templates)
+    constexpr int32_t numSrcs = NUM_SRCS;
+    constexpr int32_t numDsts = NUM_DSTS;
     PACKED_FLOAT const* __restrict__ srcFloatPacked[MAX_SRCS];
     PACKED_FLOAT*       __restrict__ dstFloatPacked[MAX_DSTS];
     for (int i = 0; i < numSrcs; i++) srcFloatPacked[i] = (PACKED_FLOAT const*)p.src[i];
@@ -3186,6 +3186,74 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       GetHwId(p.hwId);
       GetXccId(p.xccId);
     }
+  }
+
+  // Dispatch wrapper: Selects specialized kernel based on runtime numSrcs/numDsts
+  template <typename PACKED_FLOAT, int BLOCKSIZE, int UNROLL, int TEMPORAL_MODE>
+  __global__ void __launch_bounds__(BLOCKSIZE)
+    GpuReduceKernel(SubExecParam* params, int seType, int warpSize, int waveOrder, int numSubIterations)
+  {
+    // Read numSrcs and numDsts from first subexec param (consistent across all subexecs in this kernel)
+    int const numSrcs = params[blockIdx.y].numSrcs;
+    int const numDsts = params[blockIdx.y].numDsts;
+    
+    // Dispatch to specialized implementation for common cases
+    
+    // Most common case: 1 src -> 1 dst (standard copy)
+    if (numSrcs == 1 && numDsts == 1) {
+      GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 1, 1>
+        (params, seType, warpSize, waveOrder, numSubIterations);
+      return;
+    }
+    
+    // Write-only benchmark
+    if (numSrcs == 0 && numDsts == 1) {
+      GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 0, 1>
+        (params, seType, warpSize, waveOrder, numSubIterations);
+      return;
+    }
+    
+    // Read-only benchmark
+    if (numSrcs == 1 && numDsts == 0) {
+      GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 1, 0>
+        (params, seType, warpSize, waveOrder, numSubIterations);
+      return;
+    }
+    
+    // Dual-source reduction
+    if (numSrcs == 2 && numDsts == 1) {
+      GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 2, 1>
+        (params, seType, warpSize, waveOrder, numSubIterations);
+      return;
+    }
+    
+    // Broadcast to 2 destinations
+    if (numSrcs == 1 && numDsts == 2) {
+      GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 1, 2>
+        (params, seType, warpSize, waveOrder, numSubIterations);
+      return;
+    }
+    
+    // Triple-source reduction
+    if (numSrcs == 3 && numDsts == 1) {
+      GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 3, 1>
+        (params, seType, warpSize, waveOrder, numSubIterations);
+      return;
+    }
+    
+    // Quad-source reduction
+    if (numSrcs == 4 && numDsts == 1) {
+      GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 4, 1>
+        (params, seType, warpSize, waveOrder, numSubIterations);
+      return;
+    }
+    
+    // Fallback for uncommon cases
+    if (threadIdx.x == 0 && blockIdx.x == 0 && blockIdx.y == 0) {
+      printf("[WARN] Using unoptimized path for numSrcs=%d, numDsts=%d\n", numSrcs, numDsts);
+    }
+    GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 1, 1>
+      (params, seType, warpSize, waveOrder, numSubIterations);
   }
 
 #define GPU_KERNEL_TEMPORAL_DECL(BLOCKSIZE, UNROLL, DWORD)           \

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3015,9 +3015,10 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
   }
 
   // Kernel for GFX execution
+  // NUM_SRCS/NUM_DSTS: If 0, use runtime numSrcs/numDsts args; otherwise use template values
   template <typename PACKED_FLOAT, int BLOCKSIZE, int UNROLL, int TEMPORAL_MODE,
             int NUM_SRCS, int NUM_DSTS>
-  __device__ void GpuReduceKernelImpl(SubExecParam* params, int seType, int warpSize, int waveOrder, int numSubIterations)
+  __device__ void GpuReduceKernelImpl(SubExecParam* params, int seType, int warpSize, int waveOrder, int numSubIterations, int numSrcsArg, int numDstsArg)
   {
     int64_t startCycle;
     // For warp-level, each warp's first thread records timing; for threadblock-level, only first thread of block
@@ -3048,9 +3049,9 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     if (p.preferredXccId != -1 && xccId != p.preferredXccId) return;
 #endif
 
-    // Collect data information
-    constexpr int32_t numSrcs = NUM_SRCS;
-    constexpr int32_t numDsts = NUM_DSTS;
+    // Use template values if non-zero, otherwise use runtime arguments
+    int32_t const numSrcs = (NUM_SRCS != 0) ? NUM_SRCS : numSrcsArg;
+    int32_t const numDsts = (NUM_DSTS != 0) ? NUM_DSTS : numDstsArg;
     PACKED_FLOAT const* __restrict__ srcFloatPacked[MAX_SRCS];
     PACKED_FLOAT*       __restrict__ dstFloatPacked[MAX_DSTS];
     for (int i = 0; i < numSrcs; i++) srcFloatPacked[i] = (PACKED_FLOAT const*)p.src[i];
@@ -3197,31 +3198,28 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     int const numSrcs = params[blockIdx.y].numSrcs;
     int const numDsts = params[blockIdx.y].numDsts;
     
-    // Dispatch to specialized implementation based on numSrcs and numDsts
+    // Dispatch to specialized implementation for common cases
     if (numSrcs == 1 && numDsts == 1) {
       GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 1, 1>
-        (params, seType, warpSize, waveOrder, numSubIterations);
+        (params, seType, warpSize, waveOrder, numSubIterations, numSrcs, numDsts);
       return;
     }
     
     if (numSrcs == 0 && numDsts == 1) {
       GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 0, 1>
-        (params, seType, warpSize, waveOrder, numSubIterations);
+        (params, seType, warpSize, waveOrder, numSubIterations, numSrcs, numDsts);
       return;
     }
     
     if (numSrcs == 1 && numDsts == 0) {
       GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 1, 0>
-        (params, seType, warpSize, waveOrder, numSubIterations);
+        (params, seType, warpSize, waveOrder, numSubIterations, numSrcs, numDsts);
       return;
     }
     
-    // Fallback for other cases
-    if (threadIdx.x == 0 && blockIdx.x == 0 && blockIdx.y == 0) {
-      printf("[WARN] Using unoptimized path for numSrcs=%d, numDsts=%d\n", numSrcs, numDsts);
-    }
-    GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 1, 1>
-      (params, seType, warpSize, waveOrder, numSubIterations);
+    // Fallback: Use (0,0) template which uses runtime arguments for any combination
+    GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 0, 0>
+      (params, seType, warpSize, waveOrder, numSubIterations, numSrcs, numDsts);
   }
 
 #define GPU_KERNEL_TEMPORAL_DECL(BLOCKSIZE, UNROLL, DWORD)           \

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3193,62 +3193,31 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
   __global__ void __launch_bounds__(BLOCKSIZE)
     GpuReduceKernel(SubExecParam* params, int seType, int warpSize, int waveOrder, int numSubIterations)
   {
-    // Read numSrcs and numDsts from first subexec param (consistent across all subexecs in this kernel)
+    // Read numSrcs and numDsts from params
     int const numSrcs = params[blockIdx.y].numSrcs;
     int const numDsts = params[blockIdx.y].numDsts;
     
-    // Dispatch to specialized implementation for common cases
+    // Dispatch to specialized implementation
     
-    // Most common case: 1 src -> 1 dst (standard copy)
     if (numSrcs == 1 && numDsts == 1) {
       GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 1, 1>
         (params, seType, warpSize, waveOrder, numSubIterations);
       return;
     }
     
-    // Write-only benchmark
     if (numSrcs == 0 && numDsts == 1) {
       GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 0, 1>
         (params, seType, warpSize, waveOrder, numSubIterations);
       return;
     }
     
-    // Read-only benchmark
     if (numSrcs == 1 && numDsts == 0) {
       GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 1, 0>
         (params, seType, warpSize, waveOrder, numSubIterations);
       return;
     }
     
-    // Dual-source reduction
-    if (numSrcs == 2 && numDsts == 1) {
-      GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 2, 1>
-        (params, seType, warpSize, waveOrder, numSubIterations);
-      return;
-    }
-    
-    // Broadcast to 2 destinations
-    if (numSrcs == 1 && numDsts == 2) {
-      GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 1, 2>
-        (params, seType, warpSize, waveOrder, numSubIterations);
-      return;
-    }
-    
-    // Triple-source reduction
-    if (numSrcs == 3 && numDsts == 1) {
-      GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 3, 1>
-        (params, seType, warpSize, waveOrder, numSubIterations);
-      return;
-    }
-    
-    // Quad-source reduction
-    if (numSrcs == 4 && numDsts == 1) {
-      GpuReduceKernelImpl<PACKED_FLOAT, BLOCKSIZE, UNROLL, TEMPORAL_MODE, 4, 1>
-        (params, seType, warpSize, waveOrder, numSubIterations);
-      return;
-    }
-    
-    // Fallback for uncommon cases
+    // Fallback for other cases
     if (threadIdx.x == 0 && blockIdx.x == 0 && blockIdx.y == 0) {
       printf("[WARN] Using unoptimized path for numSrcs=%d, numDsts=%d\n", numSrcs, numDsts);
     }


### PR DESCRIPTION
- Refactor GpuReduceKernel into GpuReduceKernelImpl with NUM_SRCS/NUM_DSTS templates
- Add dispatch wrapper to select specialized kernel based on runtime values
- Instantiate common cases: (0,1), (1,0), (1,1)
- Enables compile-time optimization of source/destination loops

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
