### PR TITLE
Add check for ROCM version for syncwarp

### DIFF
--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3173,10 +3173,11 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     // Wait for all threads to finish
     if (seType == 1) {
       // For warp-level, sync within warp only
- #if HIP_VERSION_MARJOR >= 7
-      __syncwarp();
- #else
+ #if defined(__HIP_PLATFORM_AMD__) && (HIP_VERSION_MARJOR < 7)
       __builtin_amdgcn_wave_barrier();
+ #else
+
+      __syncwarp();
  #endif
     } else {
       // For threadblock-level, sync all threads

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3173,7 +3173,11 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     // Wait for all threads to finish
     if (seType == 1) {
       // For warp-level, sync within warp only
+ #if HIP_VERSION_MARJOR >= 7
       __syncwarp();
+ #else
+      __builtin_amdgcn_wave_barrier();
+ #endif
     } else {
       // For threadblock-level, sync all threads
       __syncthreads();

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3173,7 +3173,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     // Wait for all threads to finish
     if (seType == 1) {
       // For warp-level, sync within warp only
- #if defined(__HIP_PLATFORM_AMD__) && (HIP_VERSION_MARJOR < 7)
+ #if defined(__HIP_PLATFORM_AMD__) && (HIP_VERSION_MAJOR < 7)
       __builtin_amdgcn_wave_barrier();
  #else
 


### PR DESCRIPTION
`syncwarp` not available in rocm 6.x or earlier