### PR TITLE
Ensuring that exit code is non-zero on fatal error

### DIFF
--- a/src/client/Presets/AllToAll.hpp
+++ b/src/client/Presets/AllToAll.hpp
@@ -162,7 +162,7 @@ void AllToAllPreset(EnvVars&           ev,
   if (!TransferBench::RunTransfers(cfg, transfers, results)) {
     for (auto const& err : results.errResults)
       printf("%s\n", err.errMsg.c_str());
-    exit(0);
+    exit(1);
   } else {
     PrintResults(ev, 1, transfers, results);
   }

--- a/src/client/Presets/AllToAllN.hpp
+++ b/src/client/Presets/AllToAllN.hpp
@@ -83,7 +83,7 @@ void AllToAllRdmaPreset(EnvVars&           ev,
   if (!TransferBench::RunTransfers(cfg, transfers, results)) {
     for (auto const& err : results.errResults)
       printf("%s\n", err.errMsg.c_str());
-    exit(0);
+    exit(1);
   } else {
     PrintResults(ev, 1, transfers, results);
   }

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3773,6 +3773,10 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       ERR_APPEND(TeardownExecutor(cfg, exeDevice, transfers, exeInfo), errResults);
     }
 
+    // Check for fatal error
+    for (auto const& err : errResults) {
+      if (err.errType == ERR_FATAL) return false;
+    }
     return true;
   }
 


### PR DESCRIPTION
## Motivation
RunTransfers wasn't properly returning false when a fatal error was detected
Additionally, the A2A and A2AN presets would not exit with a non-zero error
This could result in missing important information when running TransferBench within scripts

## Technical Details
Make sure RunTransfers checks the errors list for fatal errors before returning

## Test Plan
Inject an fatal error into A2A and confirm that it exits with non-zero value

## Test Result
a2a preset fails with error code 1

## Submission Checklist
