### PR TITLE
Added rocm lib path discovery with TheRock support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,15 @@ MPI_PATH  ?= /usr/local/openmpi
 HIPCC ?= $(ROCM_PATH)/bin/amdclang++
 NVCC ?= $(CUDA_PATH)/bin/nvcc
 
+# ROCm device libraries can live in different locations depending on packaging.
+# hipcc/clang needs to find the amdgcn bitcode directory at link time.
+ROCM_DEVICE_LIB_PATH ?=
+ifneq ($(wildcard $(ROCM_PATH)/amdgcn/bitcode),)
+  ROCM_DEVICE_LIB_PATH := $(ROCM_PATH)/amdgcn/bitcode
+else ifneq ($(wildcard $(ROCM_PATH)/lib/llvm/amdgcn/bitcode),)
+  ROCM_DEVICE_LIB_PATH := $(ROCM_PATH)/lib/llvm/amdgcn/bitcode
+endif
+
 # Option to compile with single GFX kernel to drop compilation time
 SINGLE_KERNEL ?= 0
 
@@ -40,6 +49,9 @@ ifeq ($(filter clean,$(MAKECMDGOALS)),)
   CXXFLAGS = -I$(ROCM_PATH)/include -I$(ROCM_PATH)/include/hip -I$(ROCM_PATH)/include/hsa
   HIPLDFLAGS= -lnuma -L$(ROCM_PATH)/lib -lhsa-runtime64 -lamdhip64
   HIPFLAGS = -Wall -x hip -D__HIP_PLATFORM_AMD__ -D__HIPCC__ $(GPU_TARGETS_FLAGS)
+  ifneq ($(strip $(ROCM_DEVICE_LIB_PATH)),)
+    HIPFLAGS += --rocm-device-lib-path=$(ROCM_DEVICE_LIB_PATH)
+  endif
   NVFLAGS  = -x cu -lnuma -arch=native
 
   ifeq ($(SINGLE_KERNEL), 1)
@@ -111,7 +123,7 @@ endif
 all: $(EXE)
 
 TransferBench: ./src/client/Client.cpp $(shell find -regex ".*\.\hpp")
-	$(HIPCC) $(CXXFLAGS) $(HIPFLAGS) $(COMMON_FLAGS) $< -o $@ $(HIPLDFLAGS) $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) $(HIPFLAGS) $(COMMON_FLAGS) $< -o $@ $(HIPLDFLAGS) $(LDFLAGS)
 
 TransferBenchCuda: ./src/client/Client.cpp $(shell find -regex ".*\.\hpp")
 	$(NVCC) $(NVFLAGS) $(COMMON_FLAGS) $< -o $@ $(LDFLAGS)


### PR DESCRIPTION
## Motivation

Compilation failure with https://github.com/ROCm/TheRock installation

## Technical Details

1. Added path for device libs as to either of generic path `$(ROCM_PATH)/amdgcn/bitcode` or `$(ROCM_PATH)/lib/llvm/amdgcn/bitcode)`
2. Replaces Transferbench compilation argument from `$(HIPCC)` to `$(CXX)` to comply with overridden CXX compiler environment

## Test Plan

1. Install amdgpu driver
2. Install TheRock nightly
3. Install `openmpi-bin`, `openmpi-common` and `libopenmpi-dev`
4. Clone transferbench
5. Modify MPI_PATH to where include/mpi.h exists
6. Modify ROCM_PATH which points to TheRock stack

## Test Result

Build successful and execution working as expected:

```
$ make
Makefile:42: "Could not find /opt/rocm-7.11.0/bin/amdclang++. Using fallback to /opt/rocm-7.11.0/bin/hipcc"
Building with NIC executor support. Can set DISABLE_NIC_EXEC=1 to disable
Building with MPI communicator support.  Can set DISABLE_MPI_COMM=1 to disable
/opt/rocm-7.11.0/bin/hipcc -I/opt/rocm-7.11.0/include -I/opt/rocm-7.11.0/include/hip -I/opt/rocm-7.11.0/include/hsa -DNIC_EXEC_ENABLED -DMPI_COMM_ENABLED -I/usr/lib/x86_64-linux-gnu/openmpi/include -Wall -x hip -D__HIP_PLATFORM_AMD__ -D__HIPCC__ "--offload-arch=native" --rocm-device-lib-path=/opt/rocm-7.11.0/lib/llvm/amdgcn/bitcode -O3 -I./src/header -I./src/client -I./src/client/Presets src/client/Client.cpp -o TransferBench -lnuma -L/opt/rocm-7.11.0/lib -lhsa-runtime64 -lamdhip64 -lpthread -libverbs -L//usr/lib/x86_64-linux-gnu/openmpi/lib -lmpi

$ ./TransferBench 
TransferBench v1.66.00 (with MPI+NIC support) (Single-node mode)
=============================================================================================================
Usage: ./TransferBench config <N>
  config: Either:
          - Filename of configFile containing Transfers to execute (see example.cfg for format)
          - Name of preset config:
  N     : (Optional) Number of bytes to copy per Transfer.
          If not specified, defaults to 268435456 bytes. Must be a multiple of 4 bytes
          If 0 is specified, a range of Ns will be benchmarked
          May append a suffix ('K', 'M', 'G') for kilobytes / megabytes / gigabytes

Environment variables:
======================
 ALWAYS_VALIDATE   - Validate after each iteration instead of once after all iterations
...
...
...
```


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
