### PR TITLE
DMABUF support in TransferBench

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 option(BUILD_LOCAL_GPU_TARGET_ONLY "Build only for GPUs detected on this machine" OFF)
 option(ENABLE_NIC_EXEC             "Enable RDMA NIC Executor in TransferBench"    OFF)
 option(ENABLE_MPI_COMM             "Enable MPI Communicator support"              OFF)
+option(DISABLE_DMABUF              "Disable DMA-BUF support for GPU Direct RDMA"  ON)
 
 # Default GPU architectures to build
 #==================================================================================================
@@ -150,6 +151,38 @@ else()
   endif()
 endif()
 
+## Check for DMA-BUF support (requires IBVERBS_FOUND)
+if(IBVERBS_FOUND AND NOT DISABLE_DMABUF)
+  message(STATUS "Checking for DMA-BUF support...")
+
+  # Check for ibv_reg_dmabuf_mr
+  include(CheckSymbolExists)
+  set(CMAKE_REQUIRED_INCLUDES ${IBVERBS_INCLUDE_DIR})
+  set(CMAKE_REQUIRED_LIBRARIES ${IBVERBS_LIBRARY})
+  check_symbol_exists(ibv_reg_dmabuf_mr "infiniband/verbs.h" HAVE_IBV_DMABUF)
+
+  # Check for hsa_amd_portable_export_dmabuf
+  set(CMAKE_REQUIRED_INCLUDES ${HSA_INCLUDE_DIR})
+  set(CMAKE_REQUIRED_LIBRARIES ${HSA_LIBRARY})
+  check_symbol_exists(hsa_amd_portable_export_dmabuf "hsa/hsa_ext_amd.h" HAVE_ROCM_DMABUF)
+
+  # Enable DMA-BUF only if both APIs are available
+  if(HAVE_IBV_DMABUF AND HAVE_ROCM_DMABUF)
+    set(DMABUF_SUPPORT_FOUND 1)
+    message(STATUS "Building with DMA-BUF support")
+  else()
+    if(NOT HAVE_IBV_DMABUF AND NOT HAVE_ROCM_DMABUF)
+      message(WARNING "Building without DMA-BUF support: missing both ibv_reg_dmabuf_mr and ROCm DMA-BUF export")
+    elseif(NOT HAVE_IBV_DMABUF)
+      message(WARNING "Building without DMA-BUF support: missing ibv_reg_dmabuf_mr")
+    else()
+      message(WARNING "Building without DMA-BUF support: missing ROCm DMA-BUF export")
+    endif()
+  endif()
+elseif(NOT DISABLE_DMABUF)
+  message(WARNING "DMA-BUF support requires ENABLE_NIC_EXEC=ON")
+endif()
+
 ## Check for MPI support
 set(MPI_PATH "" CACHE PATH "Path to MPI installation (takes priority over system MPI)")
 if(NOT ENABLE_MPI_COMM)
@@ -209,6 +242,9 @@ if(MPI_COMM_FOUND)
     target_link_libraries(TransferBench PRIVATE ${MPI_LIBRARY})
   endif()
   target_compile_definitions(TransferBench PRIVATE MPI_COMM_ENABLED)
+endif()
+if(DMABUF_SUPPORT_FOUND)
+  target_compile_definitions(TransferBench PRIVATE HAVE_DMABUF_SUPPORT)
 endif()
 if (HAVE_PARALLEL_JOBS)
   target_compile_options(TransferBench PRIVATE -parallel-jobs=12)

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ CUDA_PATH ?= /usr/local/cuda
 MPI_PATH  ?= /usr/local/openmpi
 
 # Optional features (set to 0 to disable, 1 to enable)
-# DISABLE_NIC_EXEC: Disable RDMA/NIC executor support
-# DISABLE_MPI_COMM: Disable MPI communicator support
-# USE_DMABUF: Enable DMA-BUF support for GPU Direct RDMA (default: 0)
+# DISABLE_NIC_EXEC: Disable RDMA/NIC executor support (default: 0)
+# DISABLE_MPI_COMM: Disable MPI communicator support (default: 0)
+# DISABLE_DMABUF: Disable DMA-BUF support for GPU Direct RDMA (default: 1)
 
 HIPCC ?= $(ROCM_PATH)/bin/amdclang++
 NVCC ?= $(CUDA_PATH)/bin/nvcc
@@ -93,9 +93,9 @@ ifeq ($(filter clean,$(MAKECMDGOALS)),)
       LDFLAGS += -libverbs
       NIC_ENABLED = 1
 
-      # Disable DMA-BUF support by default (set USE_DMABUF=1 to enable)
-      USE_DMABUF ?= 0
-      ifneq ($(USE_DMABUF), 0)
+      # Disable DMA-BUF support by default (set DISABLE_DMABUF=0 to enable)
+      DISABLE_DMABUF ?= 1
+      ifeq ($(DISABLE_DMABUF), 0)
         # Check for both ibv_reg_dmabuf_mr and ROCm DMA-BUF export support
         HAVE_IBV_DMABUF := $(shell echo '#include <infiniband/verbs.h>' | $(CXX) -E - 2>/dev/null | grep -c 'ibv_reg_dmabuf_mr')
         HAVE_ROCM_DMABUF := $(shell echo '#include <hsa/hsa_ext_amd.h>' | $(CXX) -I$(ROCM_PATH)/include -E - 2>/dev/null | grep -c 'hsa_amd_portable_export_dmabuf')
@@ -111,7 +111,7 @@ ifeq ($(filter clean,$(MAKECMDGOALS)),)
           $(info Building with DMA-BUF support)
         endif
       else
-        $(info Building with DMA-BUF support disabled (USE_DMABUF=0))
+        $(info Building with DMA-BUF support disabled (DISABLE_DMABUF=1))
       endif
     endif
     ifeq ($(NIC_ENABLED), 0)

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ ROCM_PATH ?= /opt/rocm
 CUDA_PATH ?= /usr/local/cuda
 MPI_PATH  ?= /usr/local/openmpi
 
+# Optional features (set to 0 to disable, 1 to enable)
+# DISABLE_NIC_EXEC: Disable RDMA/NIC executor support
+# DISABLE_MPI_COMM: Disable MPI communicator support
+# USE_DMABUF: Enable DMA-BUF support for GPU Direct RDMA (default: 1)
+
 HIPCC ?= $(ROCM_PATH)/bin/amdclang++
 NVCC ?= $(CUDA_PATH)/bin/nvcc
 
@@ -87,6 +92,28 @@ ifeq ($(filter clean,$(MAKECMDGOALS)),)
       COMMON_FLAGS += -DNIC_EXEC_ENABLED
       LDFLAGS += -libverbs
       NIC_ENABLED = 1
+
+      # Enable DMA-BUF support by default (set USE_DMABUF=0 to disable)
+      USE_DMABUF ?= 1
+      ifneq ($(USE_DMABUF), 0)
+        # Check for ibv_reg_dmabuf_mr support
+        ifeq ("$(shell echo '#include <infiniband/verbs.h>' | $(CXX) -E - 2>/dev/null | grep -c 'ibv_reg_dmabuf_mr')", "0")
+          $(info Building without ibv_reg_dmabuf_mr support)
+        else
+          COMMON_FLAGS += -DHAVE_REG_DMABUF_MR
+          $(info Building with ibv_reg_dmabuf_mr support)
+        endif
+
+        # Check for ROCm DMA-BUF export support (hsa_amd_portable_export_dmabuf)
+        ifeq ("$(shell echo '#include <hsa/hsa_ext_amd.h>' | $(CXX) -I$(ROCM_PATH)/include -E - 2>/dev/null | grep -c 'hsa_amd_portable_export_dmabuf')", "0")
+          $(info Building without ROCm DMA-BUF export support)
+        else
+          COMMON_FLAGS += -DHAVE_ROCM_DMABUF
+          $(info Building with ROCm DMA-BUF export support)
+        endif
+      else
+        $(info Building with DMA-BUF support disabled (USE_DMABUF=0))
+      endif
     endif
     ifeq ($(NIC_ENABLED), 0)
       $(info Building without NIC executor support)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MPI_PATH  ?= /usr/local/openmpi
 # Optional features (set to 0 to disable, 1 to enable)
 # DISABLE_NIC_EXEC: Disable RDMA/NIC executor support
 # DISABLE_MPI_COMM: Disable MPI communicator support
-# USE_DMABUF: Enable DMA-BUF support for GPU Direct RDMA (default: 1)
+# USE_DMABUF: Enable DMA-BUF support for GPU Direct RDMA (default: 0)
 
 HIPCC ?= $(ROCM_PATH)/bin/amdclang++
 NVCC ?= $(CUDA_PATH)/bin/nvcc
@@ -93,23 +93,22 @@ ifeq ($(filter clean,$(MAKECMDGOALS)),)
       LDFLAGS += -libverbs
       NIC_ENABLED = 1
 
-      # Enable DMA-BUF support by default (set USE_DMABUF=0 to disable)
-      USE_DMABUF ?= 1
+      # Disable DMA-BUF support by default (set USE_DMABUF=1 to enable)
+      USE_DMABUF ?= 0
       ifneq ($(USE_DMABUF), 0)
-        # Check for ibv_reg_dmabuf_mr support
-        ifeq ("$(shell echo '#include <infiniband/verbs.h>' | $(CXX) -E - 2>/dev/null | grep -c 'ibv_reg_dmabuf_mr')", "0")
-          $(info Building without ibv_reg_dmabuf_mr support)
-        else
-          COMMON_FLAGS += -DHAVE_REG_DMABUF_MR
-          $(info Building with ibv_reg_dmabuf_mr support)
-        endif
+        # Check for both ibv_reg_dmabuf_mr and ROCm DMA-BUF export support
+        HAVE_IBV_DMABUF := $(shell echo '#include <infiniband/verbs.h>' | $(CXX) -E - 2>/dev/null | grep -c 'ibv_reg_dmabuf_mr')
+        HAVE_ROCM_DMABUF := $(shell echo '#include <hsa/hsa_ext_amd.h>' | $(CXX) -I$(ROCM_PATH)/include -E - 2>/dev/null | grep -c 'hsa_amd_portable_export_dmabuf')
 
-        # Check for ROCm DMA-BUF export support (hsa_amd_portable_export_dmabuf)
-        ifeq ("$(shell echo '#include <hsa/hsa_ext_amd.h>' | $(CXX) -I$(ROCM_PATH)/include -E - 2>/dev/null | grep -c 'hsa_amd_portable_export_dmabuf')", "0")
-          $(info Building without ROCm DMA-BUF export support)
+        ifeq ($(HAVE_IBV_DMABUF):$(HAVE_ROCM_DMABUF), 0:0)
+          $(info Building without DMA-BUF support: missing both ibv_reg_dmabuf_mr and ROCm DMA-BUF export)
+        else ifeq ($(HAVE_IBV_DMABUF), 0)
+          $(info Building without DMA-BUF support: missing ibv_reg_dmabuf_mr)
+        else ifeq ($(HAVE_ROCM_DMABUF), 0)
+          $(info Building without DMA-BUF support: missing ROCm DMA-BUF export)
         else
-          COMMON_FLAGS += -DHAVE_ROCM_DMABUF
-          $(info Building with ROCm DMA-BUF export support)
+          COMMON_FLAGS += -DHAVE_DMABUF_SUPPORT
+          $(info Building with DMA-BUF support)
         endif
       else
         $(info Building with DMA-BUF support disabled (USE_DMABUF=0))

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1437,49 +1437,108 @@ namespace {
   // Returns true if kernel supports CONFIG_DMABUF_MOVE_NOTIFY and CONFIG_PCI_P2PDMA
   static bool CheckKernelDmabufSupport()
   {
-    static int cachedResult = -1;  // -1: not checked, 0: disabled, 1: enabled
+    static int support = -1;  // -1: not checked, 0: disabled, 1: enabled
 
-    if (cachedResult != -1) {
-      return cachedResult == 1;
+    if (support != -1) {
+      return support;
     }
 
-    bool hasMoveNotify = false;
-    bool hasP2pDma = false;
-
-    // Read kernel config from /boot/config-$(uname -r)
     struct utsname utsname;
-    if (uname(&utsname) == 0) {
-      char kernel_conf_file[128];
-      snprintf(kernel_conf_file, sizeof(kernel_conf_file), "/boot/config-%s", utsname.release);
+    FILE* fp = NULL;
+    char kernel_opt1[28] = "CONFIG_DMABUF_MOVE_NOTIFY=y";
+    char kernel_opt2[20] = "CONFIG_PCI_P2PDMA=y";
+    char kernel_conf_file[128];
+    char buf[256];
+    int found_opt1 = 0;
+    int found_opt2 = 0;
+    int dmaBufSupport = 0;  // Start as disabled, enable only when both options found
 
-      FILE* fp = fopen(kernel_conf_file, "r");
-      if (fp) {
-        char buf[256];
-        while (fgets(buf, sizeof(buf), fp)) {
-          if (strstr(buf, "CONFIG_DMABUF_MOVE_NOTIFY=y")) hasMoveNotify = true;
-          if (strstr(buf, "CONFIG_PCI_P2PDMA=y")) hasP2pDma = true;
+    // Check for kernel name exists
+    if (uname(&utsname) == -1) {
+      if (System::Get().IsVerbose()) {
+        printf("[WARN] Could not get kernel name\n");
+      }
+      support = 0;
+      return 0;
+    }
+
+    // Format and check kernel conf file location
+    const char* possiblePaths[] = {
+      "/proc/config.gz",
+      "/boot/config-%s",
+      "/usr/src/linux-%s/.config",
+      "/usr/src/linux/.config",
+      "/usr/lib/modules/%s/config",
+      "/usr/lib/ostree-boot/config-%s",
+      "/usr/lib/kernel/config-%s",
+      "/usr/src/linux-headers-%s/.config",
+      "/lib/modules/%s/build/.config",
+    };
+
+    for (const auto& path : possiblePaths) {
+      // Reset flags for each file
+      found_opt1 = 0;
+      found_opt2 = 0;
+
+      snprintf(kernel_conf_file, sizeof(kernel_conf_file), path, utsname.release);
+
+      // Special handling for /proc/config.gz
+      if (strstr(path, "/proc/config.gz") != NULL) {
+        fp = popen("zcat /proc/config.gz 2>/dev/null", "r");
+      } else {
+        fp = fopen(kernel_conf_file, "r");
+      }
+
+      if (fp != NULL) {
+        // Look for kernel_opt1 and kernel_opt2 in the conf file
+        while (fgets(buf, sizeof(buf), fp) != NULL) {
+          if (strstr(buf, kernel_opt1) != NULL) {
+            found_opt1 = 1;
+            if (System::Get().IsVerbose()) {
+              printf("[INFO] %s in %s\n", kernel_opt1, kernel_conf_file);
+            }
+          }
+          if (strstr(buf, kernel_opt2) != NULL) {
+            found_opt2 = 1;
+            if (System::Get().IsVerbose()) {
+              printf("[INFO] %s in %s\n", kernel_opt2, kernel_conf_file);
+            }
+          }
         }
-        fclose(fp);
+
+        // Close file handle
+        if (strstr(path, "/proc/config.gz") != NULL) {
+          pclose(fp);
+        } else {
+          fclose(fp);
+        }
+
+        // Check if both options were found
+        if (found_opt1 && found_opt2) {
+          dmaBufSupport = 1;
+          if (System::Get().IsVerbose()) {
+            printf("[INFO] DMA_BUF Support Enabled\n");
+          }
+          break;  // Found both options, exit loop
+        } else {
+          // File found but missing required options, continue to next file
+          if (System::Get().IsVerbose()) {
+            printf("[WARN] CONFIG_DMABUF_MOVE_NOTIFY and/or CONFIG_PCI_P2PDMA not found in %s, trying next location\n", kernel_conf_file);
+          }
+        }
       }
     }
 
-    cachedResult = (hasMoveNotify && hasP2pDma) ? 1 : 0;
-
-    if (cachedResult == 0) {
+    // If DMA-BUF support not enabled, log warning
+    if (!dmaBufSupport) {
       if (System::Get().IsVerbose()) {
-        printf("[WARN] Kernel DMA-BUF support incomplete: ");
-        if (!hasMoveNotify && !hasP2pDma) {
-          printf("missing CONFIG_DMABUF_MOVE_NOTIFY=y and CONFIG_PCI_P2PDMA=y\n");
-        } else if (!hasMoveNotify) {
-          printf("missing CONFIG_DMABUF_MOVE_NOTIFY=y\n");
-        } else {
-          printf("missing CONFIG_PCI_P2PDMA=y\n");
-        }
+        printf("[WARN] DMA_BUF_SUPPORT Failed: kernel config not found or missing required options\n");
         printf("[WARN] Falling back to standard ibv_reg_mr\n");
       }
     }
 
-    return cachedResult == 1;
+    support = dmaBufSupport;
+    return support;
   }
 
   // Export GPU memory as DMA-BUF for RDMA operations

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1431,6 +1431,34 @@ namespace {
     return ERR_NONE;
   }
 
+#if defined(NIC_EXEC_ENABLED) && defined(HAVE_ROCM_DMABUF) && !defined(__NVCC__)
+  // Export GPU memory as DMA-BUF for RDMA operations
+  static ErrResult ExportDmabuf(void* gpuPtr, size_t numBytes, int& dmabufFd, uint64_t& dmabufOffset)
+  {
+    // Round down to host page alignment (4KB typically)
+    const uint64_t HOST_PAGE_SIZE = 1ULL << 12;
+    void* alignedPtr = (void*)((uint64_t)gpuPtr & ~(HOST_PAGE_SIZE - 1));
+    uint64_t offset = (uint64_t)gpuPtr - (uint64_t)alignedPtr;
+
+    // Adjust size to account for alignment
+    size_t alignedSize = numBytes + offset;
+    alignedSize = (alignedSize + HOST_PAGE_SIZE - 1) & ~(HOST_PAGE_SIZE - 1);
+
+    // Export the aligned GPU buffer as DMA-BUF
+    uint64_t exportOffset = 0;
+    hsa_status_t status = hsa_amd_portable_export_dmabuf(alignedPtr, alignedSize, &dmabufFd, &exportOffset);
+
+    if (status != HSA_STATUS_SUCCESS) {
+      return {ERR_FATAL, "Failed to export DMA-BUF: hsa_amd_portable_export_dmabuf returned %d", status};
+    }
+
+    // The offset is the sum of export offset and alignment offset
+    dmabufOffset = exportOffset + offset;
+
+    return ERR_NONE;
+  }
+#endif
+
 // Setup validation-related functions
 //========================================================================================
   // This function resolves executors that may be indexed by "nearest"
@@ -2173,6 +2201,10 @@ namespace {
     vector<ibv_qp*>            dstQueuePairs;     ///< Queue pairs for DST NIC
     ibv_mr*                    srcMemRegion;      ///< Memory region for SRC
     ibv_mr*                    dstMemRegion;      ///< Memory region for DST
+    int                        srcDmabufFd;       ///< DMA-BUF file descriptor for SRC (if using dmabuf)
+    int                        dstDmabufFd;       ///< DMA-BUF file descriptor for DST (if using dmabuf)
+    uint64_t                   srcDmabufOffset;   ///< Offset within SRC DMA-BUF
+    uint64_t                   dstDmabufOffset;   ///< Offset within DST DMA-BUF
     uint8_t                    qpCount;           ///< Number of QPs to be used for transferring data
     bool                       srcIsExeNic;       ///< Whether SRC or DST NIC initiates traffic
     vector<vector<ibv_sge>>    sgePerQueuePair;   ///< Scatter-gather elements per queue pair
@@ -2787,6 +2819,28 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     rss.dstNicIndex = (nicExeRank == srcMemRank ? nonExeDevice.exeIndex : nicExeDevice.exeIndex);
     rss.qpCount     = t.numSubExecs;
 
+    // Initialize DMA-BUF fields
+    rss.srcDmabufFd = -1;
+    rss.dstDmabufFd = -1;
+    rss.srcDmabufOffset = 0;
+    rss.dstDmabufOffset = 0;
+
+    // Print DMA-BUF support status (only once per rank)
+    if (System::Get().IsVerbose()) {
+      static bool dmabufStatusPrinted = false;
+      if (!dmabufStatusPrinted) {
+        dmabufStatusPrinted = true;
+        printf("[INFO] Rank %d DMA-BUF support: ", GetRank());
+#if defined(HAVE_REG_DMABUF_MR) && defined(HAVE_ROCM_DMABUF) && !defined(__NVCC__)
+        printf("ENABLED (ibv_reg_dmabuf_mr + ROCm export)\n");
+#elif defined(HAVE_REG_DMABUF_MR)
+        printf("PARTIAL (ibv_reg_dmabuf_mr only, no ROCm export)\n");
+#else
+        printf("DISABLED (using standard ibv_reg_mr)\n");
+#endif
+      }
+    }
+
     // Establish memory access flags
     unsigned int rdmaAccessFlags = (IBV_ACCESS_LOCAL_WRITE    |
                                     IBV_ACCESS_REMOTE_READ    |
@@ -2810,8 +2864,34 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       IBV_PTR_CALL(rss.srcContext, ibv_open_device, GetIbvDeviceList()[rss.srcNicIndex].devicePtr);
       // Open SRC protection domain
       IBV_PTR_CALL(rss.srcProtect, ibv_alloc_pd, rss.srcContext);
+
+      // Export DMA-BUF for SRC memory if it's GPU memory
+#if defined(HAVE_ROCM_DMABUF) && !defined(__NVCC__)
+      if (!t.srcs.empty() && IsGpuMemType(t.srcs[0].memType)) {
+        ERR_CHECK(ExportDmabuf(rss.srcMem[0], rss.numBytes, rss.srcDmabufFd, rss.srcDmabufOffset));
+        if (System::Get().IsVerbose()) {
+          printf("[INFO] Rank %d exported SRC GPU memory as DMA-BUF (fd=%d, offset=%lu)\n",
+                 GetRank(), rss.srcDmabufFd, rss.srcDmabufOffset);
+        }
+      }
+#endif
+
       // Register SRC memory region
-      IBV_PTR_CALL(rss.srcMemRegion, ibv_reg_mr, rss.srcProtect, rss.srcMem[0], rss.numBytes, rdmaMemRegFlags);
+#ifdef HAVE_REG_DMABUF_MR
+      if (rss.srcDmabufFd >= 0) {
+        IBV_PTR_CALL(rss.srcMemRegion, ibv_reg_dmabuf_mr, rss.srcProtect, rss.srcDmabufOffset,
+                     rss.numBytes, (uint64_t)rss.srcMem[0], rss.srcDmabufFd, rdmaMemRegFlags);
+        if (System::Get().IsVerbose()) {
+          printf("[INFO] Rank %d registered SRC memory using ibv_reg_dmabuf_mr\n", GetRank());
+        }
+      } else
+#endif
+      {
+        IBV_PTR_CALL(rss.srcMemRegion, ibv_reg_mr, rss.srcProtect, rss.srcMem[0], rss.numBytes, rdmaMemRegFlags);
+        if (System::Get().IsVerbose()) {
+          printf("[INFO] Rank %d registered SRC memory using ibv_reg_mr (standard path)\n", GetRank());
+        }
+      }
       // Create SRC completion queues
       IBV_PTR_CALL(rss.srcCompQueue, ibv_create_cq, rss.srcContext, cfg.nic.queueSize, NULL, NULL, 0);
       // Get SRC port attributes
@@ -2848,8 +2928,34 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       IBV_PTR_CALL(rss.dstContext, ibv_open_device, GetIbvDeviceList()[rss.dstNicIndex].devicePtr);
       // Open DST protection domain
       IBV_PTR_CALL(rss.dstProtect, ibv_alloc_pd, rss.dstContext);
+
+      // Export DMA-BUF for DST memory if it's GPU memory
+#if defined(HAVE_ROCM_DMABUF) && !defined(__NVCC__)
+      if (!t.dsts.empty() && IsGpuMemType(t.dsts[0].memType)) {
+        ERR_CHECK(ExportDmabuf(rss.dstMem[0], rss.numBytes, rss.dstDmabufFd, rss.dstDmabufOffset));
+        if (System::Get().IsVerbose()) {
+          printf("[INFO] Rank %d exported DST GPU memory as DMA-BUF (fd=%d, offset=%lu)\n",
+                 GetRank(), rss.dstDmabufFd, rss.dstDmabufOffset);
+        }
+      }
+#endif
+
       // Register DST memory region
-      IBV_PTR_CALL(rss.dstMemRegion, ibv_reg_mr, rss.dstProtect, rss.dstMem[0], rss.numBytes, rdmaMemRegFlags);
+#ifdef HAVE_REG_DMABUF_MR
+      if (rss.dstDmabufFd >= 0) {
+        IBV_PTR_CALL(rss.dstMemRegion, ibv_reg_dmabuf_mr, rss.dstProtect, rss.dstDmabufOffset,
+                     rss.numBytes, (uint64_t)rss.dstMem[0], rss.dstDmabufFd, rdmaMemRegFlags);
+        if (System::Get().IsVerbose()) {
+          printf("[INFO] Rank %d registered DST memory using ibv_reg_dmabuf_mr\n", GetRank());
+        }
+      } else
+#endif
+      {
+        IBV_PTR_CALL(rss.dstMemRegion, ibv_reg_mr, rss.dstProtect, rss.dstMem[0], rss.numBytes, rdmaMemRegFlags);
+        if (System::Get().IsVerbose()) {
+          printf("[INFO] Rank %d registered DST memory using ibv_reg_mr (standard path)\n", GetRank());
+        }
+      }
       // Create DST completion queues
       IBV_PTR_CALL(rss.dstCompQueue, ibv_create_cq, rss.dstContext, cfg.nic.queueSize, NULL, NULL, 0);
       // Get DST port attributes
@@ -2987,6 +3093,18 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     // Deregister memory regions
     if (isSrcRank) IBV_CALL(ibv_dereg_mr, rss.srcMemRegion);
     if (isDstRank) IBV_CALL(ibv_dereg_mr, rss.dstMemRegion);
+
+    // Close DMA-BUF file descriptors
+#if defined(HAVE_ROCM_DMABUF) && !defined(__NVCC__)
+    if (isSrcRank && rss.srcDmabufFd >= 0) {
+      close(rss.srcDmabufFd);
+      rss.srcDmabufFd = -1;
+    }
+    if (isDstRank && rss.dstDmabufFd >= 0) {
+      close(rss.dstDmabufFd);
+      rss.dstDmabufFd = -1;
+    }
+#endif
 
     // Destroy queue pairs
     if (isSrcRank) {

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -48,6 +48,7 @@ THE SOFTWARE.
 #include <string.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/utsname.h>
 #include <thread>
 #include <unistd.h>
 #include <vector>
@@ -1432,6 +1433,55 @@ namespace {
   }
 
 #if defined(NIC_EXEC_ENABLED) && defined(HAVE_DMABUF_SUPPORT) && !defined(__NVCC__)
+  // Check kernel configuration for required DMA-BUF support
+  // Returns true if kernel supports CONFIG_DMABUF_MOVE_NOTIFY and CONFIG_PCI_P2PDMA
+  static bool CheckKernelDmabufSupport()
+  {
+    static int cachedResult = -1;  // -1: not checked, 0: disabled, 1: enabled
+
+    if (cachedResult != -1) {
+      return cachedResult == 1;
+    }
+
+    bool hasMoveNotify = false;
+    bool hasP2pDma = false;
+
+    // Read kernel config from /boot/config-$(uname -r)
+    struct utsname utsname;
+    if (uname(&utsname) == 0) {
+      char kernel_conf_file[128];
+      snprintf(kernel_conf_file, sizeof(kernel_conf_file), "/boot/config-%s", utsname.release);
+
+      FILE* fp = fopen(kernel_conf_file, "r");
+      if (fp) {
+        char buf[256];
+        while (fgets(buf, sizeof(buf), fp)) {
+          if (strstr(buf, "CONFIG_DMABUF_MOVE_NOTIFY=y")) hasMoveNotify = true;
+          if (strstr(buf, "CONFIG_PCI_P2PDMA=y")) hasP2pDma = true;
+        }
+        fclose(fp);
+      }
+    }
+
+    cachedResult = (hasMoveNotify && hasP2pDma) ? 1 : 0;
+
+    if (cachedResult == 0) {
+      if (System::Get().IsVerbose()) {
+        printf("[WARN] Kernel DMA-BUF support incomplete: ");
+        if (!hasMoveNotify && !hasP2pDma) {
+          printf("missing CONFIG_DMABUF_MOVE_NOTIFY=y and CONFIG_PCI_P2PDMA=y\n");
+        } else if (!hasMoveNotify) {
+          printf("missing CONFIG_DMABUF_MOVE_NOTIFY=y\n");
+        } else {
+          printf("missing CONFIG_PCI_P2PDMA=y\n");
+        }
+        printf("[WARN] Falling back to standard ibv_reg_mr\n");
+      }
+    }
+
+    return cachedResult == 1;
+  }
+
   // Export GPU memory as DMA-BUF for RDMA operations
   static ErrResult ExportDmabuf(void* gpuPtr, size_t numBytes, int& dmabufFd, uint64_t& dmabufOffset)
   {
@@ -2832,7 +2882,12 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
         dmabufStatusPrinted = true;
         printf("[INFO] Rank %d DMA-BUF support: ", GetRank());
 #if defined(HAVE_DMABUF_SUPPORT) && !defined(__NVCC__)
-        printf("ENABLED\n");
+        bool kernelSupport = CheckKernelDmabufSupport();
+        if (kernelSupport) {
+          printf("ENABLED\n");
+        } else {
+          printf("DISABLED (kernel config missing, using standard ibv_reg_mr)\n");
+        }
 #else
         printf("DISABLED (using standard ibv_reg_mr)\n");
 #endif
@@ -2865,7 +2920,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 
       // Export DMA-BUF for SRC memory if it's GPU memory
 #if defined(HAVE_DMABUF_SUPPORT) && !defined(__NVCC__)
-      if (!t.srcs.empty() && IsGpuMemType(t.srcs[0].memType)) {
+      if (!t.srcs.empty() && IsGpuMemType(t.srcs[0].memType) && CheckKernelDmabufSupport()) {
         ERR_CHECK(ExportDmabuf(rss.srcMem[0], rss.numBytes, rss.srcDmabufFd, rss.srcDmabufOffset));
         if (System::Get().IsVerbose()) {
           printf("[INFO] Rank %d exported SRC GPU memory as DMA-BUF (fd=%d, offset=%lu)\n",
@@ -2929,7 +2984,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 
       // Export DMA-BUF for DST memory if it's GPU memory
 #if defined(HAVE_DMABUF_SUPPORT) && !defined(__NVCC__)
-      if (!t.dsts.empty() && IsGpuMemType(t.dsts[0].memType)) {
+      if (!t.dsts.empty() && IsGpuMemType(t.dsts[0].memType) && CheckKernelDmabufSupport()) {
         ERR_CHECK(ExportDmabuf(rss.dstMem[0], rss.numBytes, rss.dstDmabufFd, rss.dstDmabufOffset));
         if (System::Get().IsVerbose()) {
           printf("[INFO] Rank %d exported DST GPU memory as DMA-BUF (fd=%d, offset=%lu)\n",

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1431,7 +1431,7 @@ namespace {
     return ERR_NONE;
   }
 
-#if defined(NIC_EXEC_ENABLED) && defined(HAVE_ROCM_DMABUF) && !defined(__NVCC__)
+#if defined(NIC_EXEC_ENABLED) && defined(HAVE_DMABUF_SUPPORT) && !defined(__NVCC__)
   // Export GPU memory as DMA-BUF for RDMA operations
   static ErrResult ExportDmabuf(void* gpuPtr, size_t numBytes, int& dmabufFd, uint64_t& dmabufOffset)
   {
@@ -2831,10 +2831,8 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       if (!dmabufStatusPrinted) {
         dmabufStatusPrinted = true;
         printf("[INFO] Rank %d DMA-BUF support: ", GetRank());
-#if defined(HAVE_REG_DMABUF_MR) && defined(HAVE_ROCM_DMABUF) && !defined(__NVCC__)
-        printf("ENABLED (ibv_reg_dmabuf_mr + ROCm export)\n");
-#elif defined(HAVE_REG_DMABUF_MR)
-        printf("PARTIAL (ibv_reg_dmabuf_mr only, no ROCm export)\n");
+#if defined(HAVE_DMABUF_SUPPORT) && !defined(__NVCC__)
+        printf("ENABLED\n");
 #else
         printf("DISABLED (using standard ibv_reg_mr)\n");
 #endif
@@ -2866,7 +2864,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       IBV_PTR_CALL(rss.srcProtect, ibv_alloc_pd, rss.srcContext);
 
       // Export DMA-BUF for SRC memory if it's GPU memory
-#if defined(HAVE_ROCM_DMABUF) && !defined(__NVCC__)
+#if defined(HAVE_DMABUF_SUPPORT) && !defined(__NVCC__)
       if (!t.srcs.empty() && IsGpuMemType(t.srcs[0].memType)) {
         ERR_CHECK(ExportDmabuf(rss.srcMem[0], rss.numBytes, rss.srcDmabufFd, rss.srcDmabufOffset));
         if (System::Get().IsVerbose()) {
@@ -2877,7 +2875,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 #endif
 
       // Register SRC memory region
-#ifdef HAVE_REG_DMABUF_MR
+#ifdef HAVE_DMABUF_SUPPORT
       if (rss.srcDmabufFd >= 0) {
         IBV_PTR_CALL(rss.srcMemRegion, ibv_reg_dmabuf_mr, rss.srcProtect, rss.srcDmabufOffset,
                      rss.numBytes, (uint64_t)rss.srcMem[0], rss.srcDmabufFd, rdmaMemRegFlags);
@@ -2930,7 +2928,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       IBV_PTR_CALL(rss.dstProtect, ibv_alloc_pd, rss.dstContext);
 
       // Export DMA-BUF for DST memory if it's GPU memory
-#if defined(HAVE_ROCM_DMABUF) && !defined(__NVCC__)
+#if defined(HAVE_DMABUF_SUPPORT) && !defined(__NVCC__)
       if (!t.dsts.empty() && IsGpuMemType(t.dsts[0].memType)) {
         ERR_CHECK(ExportDmabuf(rss.dstMem[0], rss.numBytes, rss.dstDmabufFd, rss.dstDmabufOffset));
         if (System::Get().IsVerbose()) {
@@ -2941,7 +2939,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 #endif
 
       // Register DST memory region
-#ifdef HAVE_REG_DMABUF_MR
+#ifdef HAVE_DMABUF_SUPPORT
       if (rss.dstDmabufFd >= 0) {
         IBV_PTR_CALL(rss.dstMemRegion, ibv_reg_dmabuf_mr, rss.dstProtect, rss.dstDmabufOffset,
                      rss.numBytes, (uint64_t)rss.dstMem[0], rss.dstDmabufFd, rdmaMemRegFlags);
@@ -3095,7 +3093,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     if (isDstRank) IBV_CALL(ibv_dereg_mr, rss.dstMemRegion);
 
     // Close DMA-BUF file descriptors
-#if defined(HAVE_ROCM_DMABUF) && !defined(__NVCC__)
+#if defined(HAVE_DMABUF_SUPPORT) && !defined(__NVCC__)
     if (isSrcRank && rss.srcDmabufFd >= 0) {
       close(rss.srcDmabufFd);
       rss.srcDmabufFd = -1;


### PR DESCRIPTION
## Motivation

This change is to enable DMABUF support in TransferBench. There is some OS kernel with an inbox network driver that only supports dmabuf, and not have the patched peermem support from the out-of-box driver software, therefore we would like TransferBench to also support dmabuf which would allow inbox network driver to work for those kernel. 

## Technical Details

DMA-BUF support requires both the ibverbs API (`ibv_reg_dmabuf_mr`) and ROCm DMA-BUF export API `hsa_amd_portable_export_dmabuf` to function correctly. We should keep existing default for using peermem support, and only enable when `make DISABLE_DMABUF=0` is set at build time. I added some descriptions about DMABUF related API is found in the related headers in `Makefile` so the `HAVE_DMABUF_SUPPORT` is triggered when both APIs are available in check.

## Test Plan
(edited: instead of USE_DMABUF=1 to enable which was used initially, during code review it was suggested to use DISABLE_DMABUF instead, thus edited to use DISABLE_DMABUF=0, to enable)

- Build with DISABLE_DMABUF=1 (default when DISABLE_DMABUF not specified) - it uses legacy peermem support with the message "Building with DMA-BUF support disabled" at build time.
- Build with DISABLE_DMABUF=0 on system missing API (e.g. ibv_reg_dmabuf_mr and/or hsa_amd_portable_export_dmabuf). It will not build with dmabuf support.
- Build with DISABLE_DMABUF=0 - it uses dmabuf support with the message at ""Building with DMA-BUF support". It would use DMABUF support at runtime if the kernel has the `CONFIG_DMABUF_MOVE_NOTIFY=y` and `CONFIG_PCI_P2PDMA=y` 

Tested with CentOS 9 using the `6.16.1-0_fbk1_npi_rc0_brcmrdma2_324_ga601bc980ed0`.
Tested with CentOS 9 using the `6.9.0-0_fbk6_brcmrdma11_125_gfecec9d12677`.
Tested with Ubuntu 24.04.3 LTS with `6.8.0-53-generic`.
Verify RDMA operations work correctly with and without DMA-BUF support
Tested on system with ROCm 7.1.1 with Broadcom Thor2 Ethernet NICs, and tested previously separately on Mellanox ConnectX-7 on one other external config.

## Test Result

Confirmed default build (DISABLE_DMABUF=1) completes successfully
Confirmed DISABLE_DMABUF=0 correctly detects and enables both APIs on 6.16 kernel that only has inbox driver with DMABUF support without peermem support works. 
Verified RDMA transfers work with DMA-BUF support enabled, using `a2a_n` present on single node, and `nicrings` preset on multi-node.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
