### PR TITLE
fix qpCount storage limit to allow 256+

### DIFF
--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -2348,7 +2348,7 @@ namespace {
     int                        dstDmabufFd;       ///< DMA-BUF file descriptor for DST (if using dmabuf)
     uint64_t                   srcDmabufOffset;   ///< Offset within SRC DMA-BUF
     uint64_t                   dstDmabufOffset;   ///< Offset within DST DMA-BUF
-    uint8_t                    qpCount;           ///< Number of QPs to be used for transferring data
+    uint32_t                   qpCount;           ///< Number of QPs to be used for transferring data
     bool                       srcIsExeNic;       ///< Whether SRC or DST NIC initiates traffic
     vector<vector<ibv_sge>>    sgePerQueuePair;   ///< Scatter-gather elements per queue pair
     vector<vector<ibv_send_wr>>sendWorkRequests;  ///< Send work requests per queue pair
@@ -3959,7 +3959,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     std::vector<std::chrono::high_resolution_clock::time_point> transferTimers(transferCount);
 
     do {
-      std::vector<uint8_t> receivedQPs(transferCount, 0);
+      std::vector<uint32_t> receivedQPs(transferCount, 0);
       // post the sends
       for (auto i = 0; i < transferCount; i++) {
         transferTimers[i] = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
## Motivation

Worked with @pierreantoineH and discovered there was a limitation to run `NUM_QUEUE_PAIRS=256` (255 is OK). 

## Technical Details

There appears to be related to the storage class for qpCount used that was uint8_t. changing it to uint32_t would allow us to run to the larger numbers of QPs that is supported by different NICs.

## Test Plan

without this change, defining QPs up to 255 works:
```
$ NUM_QUEUE_PAIRS=255 ./TransferBench nicrings
```
and this causes TransferBench to hang at 256+:
```
$ NUM_QUEUE_PAIRS=256 ./TransferBench nicrings
```

## Test Result

These tests can work with the change.
```
NUM_QUEUE_PAIRS=256 ./TransferBench a2a_n
NUM_QUEUE_PAIRS=256 ./TransferBench nicrings
```


## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
