### PR TITLE
fix function header GetClosestGpusToNic

### DIFF
--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -524,7 +524,7 @@ namespace TransferBench
    * @note This function is applicable when the IBV/RDMA executor is available
    * @returns GPU indices closest to NIC nicIndex, or empty if unable to detect
    */
-  void GetClosestGpusToNic(std::vector<int>& nicIndices, int gpuIndex, int targetRank = -1);
+  void GetClosestGpusToNic(std::vector<int>& gpuIndices, int nicIndex, int targetRank = -1);
 
   /**
    * @returns 0-indexed rank for this process


### PR DESCRIPTION
## Motivation

fix the function header `GetClosestGpusToNic` to match the function definition and function calls

## Technical Details

The function header `GetClosestGpusToNic` looks different than in the comments for the header, it seems to be some typo with this function header, so I am trying to match the function definition and function calls elsewhere in this file.

```
 518   /**
 519    * Returns the indices of the GPUs closest to the given NIC
 520    *
 521    * @param[out] gpuIndices     Vector that will contain GPU indices closest to given NIC
 522    * @param[in]  nicIndex        Index of the NIC to query
 523    * @param[in]  targetRank      Rank to query (-1 for local rank)
 524    * @note This function is applicable when the IBV/RDMA executor is available
 525    * @returns GPU indices closest to NIC nicIndex, or empty if unable to detect
 526    */
```

## Test Plan

Tried to run `TransferBench` to see the closest GPU to NICs.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
