### PR TITLE
Fix ibv_poll_cq hang due to CQ overflow at high QP

### DIFF
--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -111,6 +111,7 @@ public:
   int ibGidIndex;                    // GID Index for RoCE NICs
   uint8_t ibPort;                    // NIC port number to be used
   int ipAddressFamily;               // IP Address Famliy
+  int nicCqPollMaxEvent;             // Maximum CQ entries polled per call
   int nicChunkBytes;                 // Number of bytes to send per chunk for RDMA operations
   int nicRelaxedOrder;               // Use relaxed ordering for RDMA
   int roceVersion;                   // RoCE version number
@@ -173,6 +174,7 @@ public:
     ibPort            = GetEnvVar("IB_PORT_NUMBER"      , 1);
     roceVersion       = GetEnvVar("ROCE_VERSION"        , 2);
     ipAddressFamily   = GetEnvVar("IP_ADDRESS_FAMILY"   , 4);
+    nicCqPollMaxEvent = GetEnvVar("NIC_CQ_POLL_MAX_EVENT", 4);
     nicChunkBytes     = GetEnvVar("NIC_CHUNK_BYTES"     , 1073741824);
     nicRelaxedOrder   = GetEnvVar("NIC_RELAX_ORDER"     , 1);
 
@@ -339,6 +341,7 @@ public:
     printf(" MIN_VAR_SUBEXEC   - Minumum # of subexecutors to use for variable subExec Transfers\n");
     printf(" MAX_VAR_SUBEXEC   - Maximum # of subexecutors to use for variable subExec Transfers (0 for device limits)\n");
 #if NIC_EXEC_ENABLED
+  printf(" NIC_CQ_POLL_MAX_EVENT - Max CQ entries polled per call while draining NIC completions (default=4)\n");
     printf(" NIC_CHUNK_BYTES   - Number of bytes to send at a time using NIC (default = 1GB)\n");
     printf(" NIC_RELAX_ORDER   - Set to non-zero to use relaxed ordering");
 #endif
@@ -450,6 +453,8 @@ public:
           "Using up to %s subexecutors for variable subExec transfers",
           maxNumVarSubExec ? std::to_string(maxNumVarSubExec).c_str() : "all available");
 #if NIC_EXEC_ENABLED
+    Print("NIC_CQ_POLL_MAX_EVENT", nicCqPollMaxEvent,
+      "Polling up to %d NIC completion(s) per CQ poll call", nicCqPollMaxEvent);
     Print("NIC_CHUNK_BYTES", nicChunkBytes,
           "Sending %lu bytes at a time for NIC RDMA", nicChunkBytes);
     Print("NIC_RELAX_ORDER", nicRelaxedOrder,
@@ -644,6 +649,7 @@ public:
     cfg.gfx.wordSize               = gfxWordSize;
 
     cfg.nic.chunkBytes             = nicChunkBytes;
+    cfg.nic.cqMaxPollEvent         = nicCqPollMaxEvent;
     cfg.nic.ibGidIndex             = ibGidIndex;
     cfg.nic.ibPort                 = ibPort;
     cfg.nic.ipAddressFamily        = ipAddressFamily;

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3970,7 +3970,8 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
         bool const signalChunk = isLastChunk || (chunksSinceSignal + 1 >= signalInterval);
 
         ibv_send_wr& wr = rss.sendWorkRequests[qpIndex][chunkIdx];
-        wr.send_flags = signalChunk ? IBV_SEND_SIGNALED : 0;
+        wr.send_flags &= ~IBV_SEND_SIGNALED;
+        if (signalChunk) wr.send_flags |= IBV_SEND_SIGNALED;
 
         int error = ibv_post_send(queuePairs[qpIndex], &wr, &badWorkReq);
         if (error)

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3932,80 +3932,29 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
   }
 
 #ifdef NIC_EXEC_ENABLED
-  static ErrResult PollNicCompletions(ibv_cq* cq, size_t numCompletions, int transferIdx, int cqMaxPollEvent)
+  // Post one queue pair worth of work requests for a NIC transfer.
+  // Signaling policy is prepared ahead of time in sendWorkRequests: only the
+  // final chunk of each QP is signaled, so one posted QP maps to one CQE.
+  static ErrResult ExecuteNicTransfer(TransferResources&   rss,
+                                      uint32_t      const  qpIndex)
   {
-    int pollBatch = std::max(1, cqMaxPollEvent);
-    std::vector<ibv_wc> wc((size_t)pollBatch);
-    size_t completed = 0;
-
-    while (completed < numCompletions) {
-      int pollCount = (int)std::min(numCompletions - completed, (size_t)pollBatch);
-      int nc = ibv_poll_cq(cq, pollCount, wc.data());
-      if (nc < 0)
-        return {ERR_FATAL, "Transfer %d: Received negative work completion", transferIdx};
-      if (nc == 0)
-        continue;
-
-      for (int idx = 0; idx < nc; idx++) {
-        if (wc[idx].status != IBV_WC_SUCCESS)
-          return {ERR_FATAL, "Transfer %d: Received unsuccessful work completion [status code %d]", transferIdx, wc[idx].status};
-      }
-      completed += nc;
-    }
-
-    return ERR_NONE;
-  }
-
-  // Execution of a single NIC Transfer
-  static ErrResult ExecuteNicTransfer(int           const  iteration,
-                                      ConfigOptions const& cfg,
-                                      int           const  exeIndex,
-                                      TransferResources&   rss)
-  {
-    auto* completionQueue = rss.srcIsExeNic ? rss.srcCompQueue : rss.dstCompQueue;
+    ibv_send_wr* badWorkReq = nullptr;
     auto& queuePairs = rss.srcIsExeNic ? rss.srcQueuePairs : rss.dstQueuePairs;
-
-    size_t const signalInterval = std::max((size_t)1, (size_t)cfg.nic.maxSendWorkReq - 1);
-    size_t const maxOutstandingCompletions = std::max((size_t)1, (size_t)cfg.nic.queueSize / 2);
-
-    // Loop over each queue pair and post/poll in bounded batches to avoid SQ/CQ overflow
-    for (int qpIndex = 0; qpIndex < rss.qpCount; qpIndex++) {
-      ibv_send_wr* badWorkReq = nullptr;
-      size_t const numChunks = rss.sendWorkRequests[qpIndex].size();
-      size_t chunksSinceSignal = 0;
-      size_t outstandingCompletions = 0;
-
-      for (size_t chunkIdx = 0; chunkIdx < numChunks; chunkIdx++) {
-        bool const isLastChunk = (chunkIdx + 1 == numChunks);
-        bool const signalChunk = isLastChunk || (chunksSinceSignal + 1 >= signalInterval);
-
-        ibv_send_wr& wr = rss.sendWorkRequests[qpIndex][chunkIdx];
-        wr.send_flags &= ~IBV_SEND_SIGNALED;
-        if (signalChunk) wr.send_flags |= IBV_SEND_SIGNALED;
-
-        int error = ibv_post_send(queuePairs[qpIndex], &wr, &badWorkReq);
-        if (error)
-          return {ERR_FATAL, "Transfer %d: Error when calling ibv_post_send for QP %d chunk %lu of %lu (Error code %d = %s)\n",
-            rss.transferIdx, qpIndex, chunkIdx, numChunks, error, strerror(error)};
-
-        chunksSinceSignal = signalChunk ? 0 : (chunksSinceSignal + 1);
-        if (signalChunk)
-          outstandingCompletions++;
-
-        if (outstandingCompletions >= maxOutstandingCompletions) {
-          ERR_CHECK(PollNicCompletions(completionQueue, 1, rss.transferIdx, cfg.nic.cqMaxPollEvent));
-          outstandingCompletions--;
-        }
-      }
-
-      if (outstandingCompletions)
-        ERR_CHECK(PollNicCompletions(completionQueue, outstandingCompletions, rss.transferIdx, cfg.nic.cqMaxPollEvent));
+    size_t const numChunks = rss.sendWorkRequests[qpIndex].size();
+    for (size_t chunkIdx = 0; chunkIdx < numChunks; chunkIdx++) {
+      int error = ibv_post_send(queuePairs[qpIndex],
+                                &rss.sendWorkRequests[qpIndex][chunkIdx],
+                                &badWorkReq);
+      if (error)
+        return {ERR_FATAL, "Transfer %d: Error when calling ibv_post_send for QP %d chunk %lu of %lu (Error code %d = %s)\n",
+                rss.transferIdx, qpIndex, chunkIdx, numChunks, error, strerror(error)};
     }
 
     return ERR_NONE;
   }
 
   // Execution of a single NIC executor
+  // keep transfers overlapped by round-robin posting/polling across all transfers instead of completing one transfer at a time
   static ErrResult RunNicExecutor(int           const  iteration,
                                   ConfigOptions const& cfg,
                                   int           const  exeIndex,
@@ -4023,16 +3972,89 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 
     int subIterations = 0;
     auto cpuStart = std::chrono::high_resolution_clock::now();
+    std::vector<std::chrono::high_resolution_clock::time_point> transferTimers(transferCount);
 
     do {
-      // Execute transfers with bounded post/poll in each transfer
+      std::vector<uint32_t> receivedQPs(transferCount, 0);
+      std::vector<uint32_t> postedQPs(transferCount, 0);
+
+      // Per-transfer cap on in-flight CQEs to keep completion queues from becoming full at high QP counts
+      std::vector<uint32_t> maxOutstandingCompletions(transferCount, 1);
+      std::vector<bool> transferDone(transferCount, false);
+      size_t completedTransfers = 0;
+
+      int pollBatch = std::max(1, cfg.nic.cqMaxPollEvent);
+      std::vector<ibv_wc> wc((size_t)pollBatch);
+
       for (auto i = 0; i < transferCount; i++) {
-        auto transferStart = std::chrono::high_resolution_clock::now();
-        ERR_CHECK(ExecuteNicTransfer(iteration, cfg, exeIndex, exeInfo.resources[i]));
-        if (iteration >= 0) {
-          auto cpuDelta = std::chrono::high_resolution_clock::now() - transferStart;
-          double deltaMsec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() * 1000.0;
-          totalTimeMsec[i] += deltaMsec;
+        transferTimers[i] = std::chrono::high_resolution_clock::now();
+
+        auto& rss = exeInfo.resources[i];
+        ibv_cq* completionQueue = rss.srcIsExeNic ? rss.srcCompQueue : rss.dstCompQueue;
+        int cqDepth = completionQueue ? completionQueue->cqe : cfg.nic.queueSize;
+
+        // Reserve one CQ slot of headroom. when a full CQ is reached, it is where hang was likely to ocurr when many QPs was active
+        maxOutstandingCompletions[i] = (uint32_t)std::max(1, cqDepth - 1);
+      }
+
+      // poll until all transfers have posted and completed all of their QPs
+      while (completedTransfers < transferCount) {
+        for (auto i = 0; i < transferCount; i++) {
+        // round robin posting keeps transfers in flight together while limiting in flight completions per transfer to avoid CQ overflow
+          if (transferDone[i])
+            continue;
+
+          auto& rss = exeInfo.resources[i];
+          if (postedQPs[i] >= (uint32_t)rss.qpCount)
+            continue;
+
+          // outstanding CQEs for this transfer = posted signaled QPs - completed signaled QPs
+          uint32_t outstandingCompletions = postedQPs[i] - receivedQPs[i];
+          if (outstandingCompletions >= maxOutstandingCompletions[i])
+            continue;
+
+          // post the next QP for this transfer, then continue so others can progress
+          ERR_CHECK(ExecuteNicTransfer(rss, postedQPs[i]));
+          postedQPs[i]++;
+        }
+
+        // poll completions in round-robin to match the posting order
+        for (auto i = 0; i < transferCount; i++) {
+          if (transferDone[i])
+            continue;
+
+          auto& rss = exeInfo.resources[i];
+          if (receivedQPs[i] >= postedQPs[i])
+            continue;
+
+          // poll only as many completions as are currently expected to avoid over-polling this transfer's completion queue and potential hangs
+          uint32_t outstandingCompletions = postedQPs[i] - receivedQPs[i];
+          int pollCount = (int)std::min(outstandingCompletions, (uint32_t)pollBatch);
+          auto* completionQueue = rss.srcIsExeNic ? rss.srcCompQueue : rss.dstCompQueue;
+          int nc = ibv_poll_cq(completionQueue, pollCount, wc.data());
+
+          if (nc < 0)
+            return {ERR_FATAL, "Transfer %d: Received negative work completion", rss.transferIdx};
+
+          for (int idx = 0; idx < nc; idx++) {
+            if (wc[idx].status != IBV_WC_SUCCESS)
+              return {ERR_FATAL, "Transfer %d: Received unsuccessful work completion [status code %d]", rss.transferIdx, wc[idx].status};
+          }
+
+          if (nc > 0) {
+            // nc counts signaled QPs completed for this transfer
+            receivedQPs[i] += (uint32_t)nc;
+          }
+
+          if (receivedQPs[i] == postedQPs[i] && postedQPs[i] == (uint32_t)rss.qpCount) {
+            transferDone[i] = true;
+            completedTransfers++;
+            if (iteration >= 0) {
+              auto cpuDelta = std::chrono::high_resolution_clock::now() - transferTimers[i];
+              double deltaMsec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() * 1000.0;
+              totalTimeMsec[i] += deltaMsec;
+            }
+          }
         }
       }
     } while(++subIterations < cfg.general.numSubIterations);

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -235,6 +235,7 @@ namespace TransferBench
   struct NicOptions
   {
     size_t      chunkBytes      = 1<<30;        ///< How much bytes to transfer at a time
+    int         cqMaxPollEvent  = 4;            ///< Maximum CQ entries polled per call
     int         ibGidIndex      = -1;           ///< GID Index for RoCE NICs (-1 is auto)
     uint8_t     ibPort          = 1;            ///< NIC port number to be used
     int         ipAddressFamily = 4;            ///< 4=IPv4, 6=IPv6 (used for auto GID detection)
@@ -1766,6 +1767,7 @@ namespace {
       NicOptions nic = cfg.nic;
       System::Get().Broadcast(root, sizeof(nic), &nic);
       if (nic.chunkBytes      != cfg.nic.chunkBytes)      ADD_ERROR("cfg.nic.chunkBytes");
+      if (nic.cqMaxPollEvent  != cfg.nic.cqMaxPollEvent)  ADD_ERROR("cfg.nic.cqMaxPollEvent");
       // nic.ibGidIndex  is permitted to be different across ranks
       // nic.ibPort      is permitted to be different across ranks
       if (nic.ipAddressFamily != cfg.nic.ipAddressFamily) ADD_ERROR("cfg.nic.ipAddressFamily");
@@ -1875,6 +1877,9 @@ namespace {
 #ifdef NIC_EXEC_ENABLED
     if (cfg.nic.chunkBytes == 0 || (cfg.nic.chunkBytes % 4 != 0)) {
       errors.push_back({ERR_FATAL, "[nic.chunkBytes] must be a non-negative multiple of 4"});
+    }
+    if (cfg.nic.cqMaxPollEvent <= 0) {
+      errors.push_back({ERR_FATAL, "[nic.cqMaxPollEvent] must be positive"});
     }
 #endif
 
@@ -3917,15 +3922,15 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
   }
 
 #ifdef NIC_EXEC_ENABLED
-  static ErrResult PollNicCompletions(ibv_cq* cq, size_t numCompletions, int transferIdx)
+  static ErrResult PollNicCompletions(ibv_cq* cq, size_t numCompletions, int transferIdx, int cqMaxPollEvent)
   {
-    constexpr int MaxPollBatch = 32;
-    ibv_wc wc[MaxPollBatch];
+    int pollBatch = std::max(1, cqMaxPollEvent);
+    std::vector<ibv_wc> wc((size_t)pollBatch);
     size_t completed = 0;
 
     while (completed < numCompletions) {
-      int pollCount = (int)std::min(numCompletions - completed, (size_t)MaxPollBatch);
-      int nc = ibv_poll_cq(cq, pollCount, wc);
+      int pollCount = (int)std::min(numCompletions - completed, (size_t)pollBatch);
+      int nc = ibv_poll_cq(cq, pollCount, wc.data());
       if (nc < 0)
         return {ERR_FATAL, "Transfer %d: Received negative work completion", transferIdx};
       if (nc == 0)
@@ -3977,13 +3982,13 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
           outstandingCompletions++;
 
         if (outstandingCompletions >= maxOutstandingCompletions) {
-          ERR_CHECK(PollNicCompletions(completionQueue, 1, rss.transferIdx));
+          ERR_CHECK(PollNicCompletions(completionQueue, 1, rss.transferIdx, cfg.nic.cqMaxPollEvent));
           outstandingCompletions--;
         }
       }
 
       if (outstandingCompletions)
-        ERR_CHECK(PollNicCompletions(completionQueue, outstandingCompletions, rss.transferIdx));
+        ERR_CHECK(PollNicCompletions(completionQueue, outstandingCompletions, rss.transferIdx, cfg.nic.cqMaxPollEvent));
     }
 
     return ERR_NONE;

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3917,24 +3917,75 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
   }
 
 #ifdef NIC_EXEC_ENABLED
+  static ErrResult PollNicCompletions(ibv_cq* cq, size_t numCompletions, int transferIdx)
+  {
+    constexpr int MaxPollBatch = 32;
+    ibv_wc wc[MaxPollBatch];
+    size_t completed = 0;
+
+    while (completed < numCompletions) {
+      int pollCount = (int)std::min(numCompletions - completed, (size_t)MaxPollBatch);
+      int nc = ibv_poll_cq(cq, pollCount, wc);
+      if (nc < 0)
+        return {ERR_FATAL, "Transfer %d: Received negative work completion", transferIdx};
+      if (nc == 0)
+        continue;
+
+      for (int idx = 0; idx < nc; idx++) {
+        if (wc[idx].status != IBV_WC_SUCCESS)
+          return {ERR_FATAL, "Transfer %d: Received unsuccessful work completion [status code %d]", transferIdx, wc[idx].status};
+      }
+      completed += nc;
+    }
+
+    return ERR_NONE;
+  }
+
   // Execution of a single NIC Transfer
   static ErrResult ExecuteNicTransfer(int           const  iteration,
                                       ConfigOptions const& cfg,
                                       int           const  exeIndex,
                                       TransferResources&   rss)
   {
-    // Loop over each of the queue pairs and post work request
-    ibv_send_wr* badWorkReq;
+    auto* completionQueue = rss.srcIsExeNic ? rss.srcCompQueue : rss.dstCompQueue;
+    auto& queuePairs = rss.srcIsExeNic ? rss.srcQueuePairs : rss.dstQueuePairs;
+
+    size_t const signalInterval = std::max((size_t)1, (size_t)cfg.nic.maxSendWorkReq - 1);
+    size_t const maxOutstandingCompletions = std::max((size_t)1, (size_t)cfg.nic.queueSize / 2);
+
+    // Loop over each queue pair and post/poll in bounded batches to avoid SQ/CQ overflow
     for (int qpIndex = 0; qpIndex < rss.qpCount; qpIndex++) {
-      size_t numChunks = rss.sendWorkRequests[qpIndex].size();
+      ibv_send_wr* badWorkReq = nullptr;
+      size_t const numChunks = rss.sendWorkRequests[qpIndex].size();
+      size_t chunksSinceSignal = 0;
+      size_t outstandingCompletions = 0;
+
       for (size_t chunkIdx = 0; chunkIdx < numChunks; chunkIdx++) {
-        int error = ibv_post_send(rss.srcIsExeNic ? rss.srcQueuePairs[qpIndex] : rss.dstQueuePairs[qpIndex],
-                                  &rss.sendWorkRequests[qpIndex][chunkIdx], &badWorkReq);
+        bool const isLastChunk = (chunkIdx + 1 == numChunks);
+        bool const signalChunk = isLastChunk || (chunksSinceSignal + 1 >= signalInterval);
+
+        ibv_send_wr& wr = rss.sendWorkRequests[qpIndex][chunkIdx];
+        wr.send_flags = signalChunk ? IBV_SEND_SIGNALED : 0;
+
+        int error = ibv_post_send(queuePairs[qpIndex], &wr, &badWorkReq);
         if (error)
           return {ERR_FATAL, "Transfer %d: Error when calling ibv_post_send for QP %d chunk %lu of %lu (Error code %d = %s)\n",
             rss.transferIdx, qpIndex, chunkIdx, numChunks, error, strerror(error)};
+
+        chunksSinceSignal = signalChunk ? 0 : (chunksSinceSignal + 1);
+        if (signalChunk)
+          outstandingCompletions++;
+
+        if (outstandingCompletions >= maxOutstandingCompletions) {
+          ERR_CHECK(PollNicCompletions(completionQueue, 1, rss.transferIdx));
+          outstandingCompletions--;
+        }
       }
+
+      if (outstandingCompletions)
+        ERR_CHECK(PollNicCompletions(completionQueue, outstandingCompletions, rss.transferIdx));
     }
+
     return ERR_NONE;
   }
 
@@ -3956,42 +4007,16 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 
     int subIterations = 0;
     auto cpuStart = std::chrono::high_resolution_clock::now();
-    std::vector<std::chrono::high_resolution_clock::time_point> transferTimers(transferCount);
 
     do {
-      std::vector<uint32_t> receivedQPs(transferCount, 0);
-      // post the sends
+      // Execute transfers with bounded post/poll in each transfer
       for (auto i = 0; i < transferCount; i++) {
-        transferTimers[i] = std::chrono::high_resolution_clock::now();
+        auto transferStart = std::chrono::high_resolution_clock::now();
         ERR_CHECK(ExecuteNicTransfer(iteration, cfg, exeIndex, exeInfo.resources[i]));
-      }
-      // poll for completions
-      size_t completedTransfers = 0;
-      while (completedTransfers < transferCount) {
-        for (auto i = 0; i < transferCount; i++) {
-          if(receivedQPs[i] < exeInfo.resources[i].qpCount) {
-            auto& rss = exeInfo.resources[i];
-            // Poll the completion queue until all queue pairs are complete
-            // The order of completion doesn't matter because this completion queue is dedicated to this Transfer
-            ibv_wc wc;
-            int nc = ibv_poll_cq(rss.srcIsExeNic ? rss.srcCompQueue : rss.dstCompQueue, 1, &wc);
-            if (nc > 0) {
-              receivedQPs[i]++;
-              if (wc.status != IBV_WC_SUCCESS) {
-                return {ERR_FATAL, "Transfer %d: Received unsuccessful work completion [status code %d]", rss.transferIdx, wc.status};
-              }
-            } else if (nc < 0) {
-              return {ERR_FATAL, "Transfer %d: Received negative work completion", rss.transferIdx};
-            }
-            if(receivedQPs[i] == rss.qpCount) {
-              auto cpuDelta = std::chrono::high_resolution_clock::now() - transferTimers[i];
-              double deltaMsec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() * 1000.0;
-              if (iteration >= 0) {
-                totalTimeMsec[i] += deltaMsec;
-              }
-              completedTransfers++;
-            }
-          }
+        if (iteration >= 0) {
+          auto cpuDelta = std::chrono::high_resolution_clock::now() - transferStart;
+          double deltaMsec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() * 1000.0;
+          totalTimeMsec[i] += deltaMsec;
         }
       }
     } while(++subIterations < cfg.general.numSubIterations);


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

After the change, #237 that overcomes the 256 QP limit in TransferBench, I tried to use TransferBench to test the NICs for large QP counts, it is discovered that there is hang would occur (somewhat) randomly around 2020-2030 QPs, the command that generate the hang can be the nicrings or a2a_n presets for NUM_QUEUE_PAIRS=2048. From the stack trace, the hang appears at duirng ibv_cq_poll when large QP is used:
```
$ TB_VERBOSE=1 NUM_QUEUE_PAIRS=2048 ./TransferBench nicrings
...
[INFO] Transfer 7 SubExec 2047 executed by rank 0 NIC 11 is remote write with 1 chunks
[INFO] Transfer 7 SubExec 2047 chunk 0 local 0x7f3f033e0000 remote 0x7f3ef31e0000 of size 131072

$ watch -d -n 1 pstack $(pgrep TransferBench)
Thread 6 (Thread 0x7ecd4f9db640 (LWP 494118) "TransferBench"):
#0  0x00007f2519a7e3d1 in bnxt_re_poll_one (cq=cq@entry=0x312f890, nwc=nwc@entry=1, wc=0x7ecd4f9d2eb0, resize=resize@entry=0x7ecd4f9d2e1c) at /mnt/GT_NFS/paklui/IBGDA/rdma-core-stable-v57/providers/bnxt_re/main.h:550
#1  0x00007f2519a80bea in bnxt_re_poll_cq (ibvcq=0x312f890, nwc=1, wc=0x7ecd4f9d2eb0) at /mnt/GT_NFS/paklui/IBGDA/rdma-core-stable-v57/providers/bnxt_re/verbs.c:1069
#2  0x00000000004ad0bd in TransferBench::(anonymous namespace)::RunExecutor(int, TransferBench::ConfigOptions const&, TransferBench::ExeDevice const&, TransferBench::(anonymous namespace)::ExeInfo&) ()
...
```

Checking a few pstack in loop to watch for progress but it does not change and constantly stuck inside the ib_poll_cq call. The ExecuteNicTransfer would loop over the list of QPs and post WR. if you keep posting without polling, CQ entries accumulate and can exhaust CQ capacity. This may overflow the CQ depth and stall completion accounting. =>which seems to have caused hang when we are having large QPs at around 2020-2030 QPs.

The intent for this test is to try to run with high QP counts to simulate resource consumption on the NIC and driver at larger connection counts or at scale. While trying to look for the cause, the assumption is that the issue (is very likely) due to the current logic that it posts a large number of signaled WRs before polling happens. 

The proposed change to avoid hang at large QP is for the NIC execution path to post and poll in batches (it appears that currently the ibv_poll_cq checks for 1 instead of batches https://github.com/ROCm/TransferBench/blob/dbf9bc1212fdfa6845122bc522751dd7d78c3eea/src/header/TransferBench.hpp#3977

This motivation for this change is to have during NIC transfers to signal periodically and poll while posting to keep the ongoing completions bounded replace unbounded post-all then poll behavior that could hang/stall with large QP counts keep each transfer timing in RunNicExecutor after the new bounded execution path add PollNicCompletion helper function to drain CQEs in batches.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Previously how it worked (or worked at low QP count)
- After posting all sends for all transfers, https://github.com/ROCm/TransferBench/blob/dbf9bc1212fdfa6845122bc522751dd7d78c3eea/src/header/TransferBench.hpp#L3963-L3967 it starts polling completions. https://github.com/ROCm/TransferBench/blob/dbf9bc1212fdfa6845122bc522751dd7d78c3eea/src/header/TransferBench.hpp#L3968-L3996
- It tracks receivedQPs[i] per transfer. 
- For each transfer still in progress, it polls exactly one CQ entry (ibv_poll_cq(..., 1, &wc)). https://github.com/ROCm/TransferBench/blob/dbf9bc1212fdfa6845122bc522751dd7d78c3eea/src/header/TransferBench.hpp#L3977
- If a CQE arrives and status is good, receivedQPs[i]++.
- When receivedQPs[i] == rss.qpCount, that transfer is considered done and timed.
- It repeats until for all the transfers have been completed in that while loop.
- It assumes “one completion per QP” for completion accounting, as it came from WR setup where only the last chunk in a QP chain was signaled (IBV_SEND_SIGNALED), so polling expected one CQE per QP completion event.

Description for the change
- it changes when/how often completions are requested and polled, changed from 1 to 4 (cqMaxPollEvent). Currently RCCL uses either 4 or 16 depends on the netib patch used. (for Transferbench, an new env allows to it to be adjustable: NIC_CQ_POLL_MAX_EVENT) https://github.com/ROCm/rccl/blob/57e58688f44c77076ad536ef1f6b68741fc6e694/src/transport/net_ib_rocm.cc#L2933-L2971
- it signals periodically, then polls in bounded fashion during posting, instead of post all of the sends, then poll later
- this change should only affect the signaling and notification frequency, and should not change other areas
- comparing to previous, this change creates polling windows, and should lower completion queue pressure, which before it caused CQ overrun/stall that believe that contributes to the hang at large QP count
- the current change still checks every polled Work Completion status and drains required completions before return
- https://github.com/ROCm/TransferBench/compare/develop...paklui:TransferBench:2KQP?expand=1#diff-5a69eadf0bdee9073c96d48a70429756616bb904658b37439878f6a90fd7b234R3975-R3982
- separate out the previous poll for completion into its helper function PollNicCompletions

## Test Plan

Tried to run the failing case for QPs at 2048, 4096, and higher, appeared to work:
```
TB_VERBOSE=1 NUM_QUEUE_PAIRS=2048 ./TransferBench a2a_n
```

## Test Result

It does not hang at large QP used, just take a bit longer to run.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
