### PR TITLE
improve DMABUF zcat check

### DIFF
--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1509,6 +1509,9 @@ namespace {
       "/lib/modules/%s/build/.config",
     };
 
+    // Check if zcat is available in the system
+    int has_zcat = (system("which zcat > /dev/null 2>&1") == 0);
+
     for (const auto& path : possiblePaths) {
       // Reset flags for each file
       found_opt1 = 0;
@@ -1518,6 +1521,13 @@ namespace {
 
       // Special handling for /proc/config.gz
       if (strstr(path, "/proc/config.gz") != NULL) {
+        // Skip .gz files if zcat is not available
+        if (!has_zcat) {
+          if (System::Get().IsVerbose()) {
+            printf("[WARN] zcat not available, skipping %s\n", kernel_conf_file);
+          }
+          continue;
+        }
         fp = popen("zcat /proc/config.gz 2>/dev/null", "r");
       } else {
         fp = fopen(kernel_conf_file, "r");


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Minor change to sync with what is used in RCCL for ROCM-2855. This change is to improve the zcat check which is used to find out the /proc/config.gz can be used to check for the kernel config params for DMABUF support.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
ROCM-2855

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
```
TB_VERBOSE=1 ./TransferBench nicrings
```
Tried to simulate without zcat check fail (e.g. when zcat not available), it will progress into checking another file for DMABUF support:
```
[INFO] Rank 0 DMA-BUF support: [WARN] zcat not available, skipping /proc/config.gz
[INFO] CONFIG_PCI_P2PDMA=y in /boot/config-6.16.1-0_fbk1_npi_rc0_brcmrdma2_324_ga601bc980ed0
```
when zcat available, it would show:
```
[INFO] Rank 0 preparing transfer 0 (1 SRC 1 DST)
[INFO] Rank 0 DMA-BUF support: [INFO] CONFIG_PCI_P2PDMA=y in /proc/config.gz
[INFO] CONFIG_DMABUF_MOVE_NOTIFY=y in /proc/config.gz
[INFO] DMA_BUF Support Enabled
ENABLED
[INFO] Rank 0 exported SRC GPU memory as DMA-BUF (fd=15, offset=0)
[INFO] Rank 0 registered SRC memory using ibv_reg_dmabuf_mr
```

## Test Result

<!-- Briefly summarize test outcomes. -->
I tried and the check appears to work as intended.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
