### PR TITLE
Increase CQ size for high qps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Documentation for TransferBench is available at
 - Support for dumping executed Transfers to a config file specified by TB_DUMP_CFG_FILE
   - This will write Transfers that are executed (for example via a preset) to a config file that can then be executed
 - Reporting number of iterations run when running in timed mode (NUM_ITERATIONS < 0)
+- Adding NIC_CQ_POLL_BATCH to control CQ poll batch size for NIC transfers
 
 ### Modified
   - DMA-BUF support enablement in CMake changed to ENABLE_DMA_BUF to be more similar to other compile-time options
@@ -20,6 +21,7 @@ Documentation for TransferBench is available at
   - scaling preset changes from using USE_FINE_GRAIN to CPU_MEM_TYPE and GPU_MEM_TYPE
   - NIC_FILTER renamed to TB_NIC_FILTER for consistency
   - DUMP_LINES renamed to TB_DUMP_LINES for consistency
+  - Dynamically size CQs for NIC transfers in high QPs case
 
 ## v1.66.02
 ### Added

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -112,6 +112,7 @@ public:
   uint8_t ibPort;                    // NIC port number to be used
   int ipAddressFamily;               // IP Address Famliy
   int nicChunkBytes;                 // Number of bytes to send per chunk for RDMA operations
+  int nicCqPollBatch;                // Number of CQ entries to poll per ibv_poll_cq call
   int nicRelaxedOrder;               // Use relaxed ordering for RDMA
   int roceVersion;                   // RoCE version number
 
@@ -174,6 +175,7 @@ public:
     roceVersion       = GetEnvVar("ROCE_VERSION"        , 2);
     ipAddressFamily   = GetEnvVar("IP_ADDRESS_FAMILY"   , 4);
     nicChunkBytes     = GetEnvVar("NIC_CHUNK_BYTES"     , 1073741824);
+    nicCqPollBatch    = GetEnvVar("NIC_CQ_POLL_BATCH"   , 4);
     nicRelaxedOrder   = GetEnvVar("NIC_RELAX_ORDER"     , 1);
 
     gpuMaxHwQueues    = GetEnvVar("GPU_MAX_HW_QUEUES"   , 4);
@@ -340,6 +342,7 @@ public:
     printf(" MAX_VAR_SUBEXEC   - Maximum # of subexecutors to use for variable subExec Transfers (0 for device limits)\n");
 #if NIC_EXEC_ENABLED
     printf(" NIC_CHUNK_BYTES   - Number of bytes to send at a time using NIC (default = 1GB)\n");
+    printf(" NIC_CQ_POLL_BATCH - Number of CQ entries to poll per ibv_poll_cq call (default = 4)\n");
     printf(" NIC_RELAX_ORDER   - Set to non-zero to use relaxed ordering");
 #endif
     printf(" NUM_ITERATIONS    - # of timed iterations per test. If negative, run for this many seconds instead\n");
@@ -452,6 +455,8 @@ public:
 #if NIC_EXEC_ENABLED
     Print("NIC_CHUNK_BYTES", nicChunkBytes,
           "Sending %lu bytes at a time for NIC RDMA", nicChunkBytes);
+    Print("NIC_CQ_POLL_BATCH", nicCqPollBatch,
+          "Polling %d CQ entries per ibv_poll_cq call", nicCqPollBatch);
     Print("NIC_RELAX_ORDER", nicRelaxedOrder,
           "Using %s ordering for NIC RDMA", nicRelaxedOrder ? "relaxed" : "strict");
 #endif
@@ -644,6 +649,7 @@ public:
     cfg.gfx.wordSize               = gfxWordSize;
 
     cfg.nic.chunkBytes             = nicChunkBytes;
+    cfg.nic.cqPollBatch            = nicCqPollBatch;
     cfg.nic.ibGidIndex             = ibGidIndex;
     cfg.nic.ibPort                 = ibPort;
     cfg.nic.ipAddressFamily        = ipAddressFamily;

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -525,7 +525,7 @@ namespace TransferBench
    * @note This function is applicable when the IBV/RDMA executor is available
    * @returns GPU indices closest to NIC nicIndex, or empty if unable to detect
    */
-  void GetClosestGpusToNic(std::vector<int>& nicIndices, int gpuIndex, int targetRank = -1);
+  void GetClosestGpusToNic(std::vector<int>& gpuIndices, int nicIndex, int targetRank = -1);
 
   /**
    * @returns 0-indexed rank for this process

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -235,6 +235,7 @@ namespace TransferBench
   struct NicOptions
   {
     size_t      chunkBytes      = 1<<30;        ///< How much bytes to transfer at a time
+    int         cqPollBatch     = 4;            ///< Maximum CQ entries polled per call
     int         ibGidIndex      = -1;           ///< GID Index for RoCE NICs (-1 is auto)
     uint8_t     ibPort          = 1;            ///< NIC port number to be used
     int         ipAddressFamily = 4;            ///< 4=IPv4, 6=IPv6 (used for auto GID detection)
@@ -1766,6 +1767,7 @@ namespace {
       NicOptions nic = cfg.nic;
       System::Get().Broadcast(root, sizeof(nic), &nic);
       if (nic.chunkBytes      != cfg.nic.chunkBytes)      ADD_ERROR("cfg.nic.chunkBytes");
+      if (nic.cqPollBatch     != cfg.nic.cqPollBatch)     ADD_ERROR("cfg.nic.cqPollBatch");
       // nic.ibGidIndex  is permitted to be different across ranks
       // nic.ibPort      is permitted to be different across ranks
       if (nic.ipAddressFamily != cfg.nic.ipAddressFamily) ADD_ERROR("cfg.nic.ipAddressFamily");
@@ -1875,6 +1877,9 @@ namespace {
 #ifdef NIC_EXEC_ENABLED
     if (cfg.nic.chunkBytes == 0 || (cfg.nic.chunkBytes % 4 != 0)) {
       errors.push_back({ERR_FATAL, "[nic.chunkBytes] must be a non-negative multiple of 4"});
+    }
+    if (cfg.nic.cqPollBatch <= 0) {
+      errors.push_back({ERR_FATAL, "[nic.cqPollBatch] must be positive"});
     }
 #endif
 
@@ -3971,6 +3976,8 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       }
       // poll for completions
       size_t completedTransfers = 0;
+      int pollBatch = std::max(1, cfg.nic.cqPollBatch);
+      std::vector<ibv_wc> wc((size_t)pollBatch);
       while (completedTransfers < transferCount) {
         for (auto i = 0; i < transferCount; i++) {
           if(receivedQPs[i] < exeInfo.resources[i].qpCount) {
@@ -3978,9 +3985,8 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
             // Poll the completion queue until all queue pairs are complete
             // The order of completion doesn't matter because this completion queue is dedicated to this Transfer
             // Use batch polling to drain multiple completions at once for better efficiency
-            constexpr int POLL_BATCH_SIZE = 32;
-            ibv_wc wc_array[POLL_BATCH_SIZE];
-            int nc = ibv_poll_cq(rss.srcIsExeNic ? rss.srcCompQueue : rss.dstCompQueue, POLL_BATCH_SIZE, wc_array);
+            ibv_wc* wc_array = wc.data();
+            int nc = ibv_poll_cq(rss.srcIsExeNic ? rss.srcCompQueue : rss.dstCompQueue, pollBatch, wc_array);
             if (nc > 0) {
               // Process all completions in the batch
               for (int j = 0; j < nc; j++) {

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1657,9 +1657,6 @@ namespace {
       "/lib/modules/%s/build/.config",
     };
 
-    // Check if zcat is available in the system
-    int has_zcat = (system("which zcat > /dev/null 2>&1") == 0);
-
     for (const auto& path : possiblePaths) {
       // Reset flags for each file
       found_opt1 = 0;
@@ -1669,13 +1666,6 @@ namespace {
 
       // Special handling for /proc/config.gz
       if (strstr(path, "/proc/config.gz") != NULL) {
-        // Skip .gz files if zcat is not available
-        if (!has_zcat) {
-          if (System::Get().IsVerbose()) {
-            printf("[WARN] zcat not available, skipping %s\n", kernel_conf_file);
-          }
-          continue;
-        }
         fp = popen("zcat /proc/config.gz 2>/dev/null", "r");
       } else {
         fp = fopen(kernel_conf_file, "r");

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3988,6 +3988,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       size_t completedTransfers = 0;
       int pollBatch = std::max(1, cfg.nic.cqPollBatch);
       std::vector<ibv_wc> wc((size_t)pollBatch);
+      ibv_wc* wc_array = wc.data();
       while (completedTransfers < transferCount) {
         for (auto i = 0; i < transferCount; i++) {
           if(receivedQPs[i] < exeInfo.resources[i].qpCount) {
@@ -3995,7 +3996,6 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
             // Poll the completion queue until all queue pairs are complete
             // The order of completion doesn't matter because this completion queue is dedicated to this Transfer
             // Use batch polling to drain multiple completions at once for better efficiency
-            ibv_wc* wc_array = wc.data();
             int nc = ibv_poll_cq(rss.srcIsExeNic ? rss.srcCompQueue : rss.dstCompQueue, pollBatch, wc_array);
             if (nc > 0) {
               // Process all completions in the batch

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -2348,7 +2348,7 @@ namespace {
     int                        dstDmabufFd;       ///< DMA-BUF file descriptor for DST (if using dmabuf)
     uint64_t                   srcDmabufOffset;   ///< Offset within SRC DMA-BUF
     uint64_t                   dstDmabufOffset;   ///< Offset within DST DMA-BUF
-    uint8_t                    qpCount;           ///< Number of QPs to be used for transferring data
+    uint32_t                   qpCount;           ///< Number of QPs to be used for transferring data
     bool                       srcIsExeNic;       ///< Whether SRC or DST NIC initiates traffic
     vector<vector<ibv_sge>>    sgePerQueuePair;   ///< Scatter-gather elements per queue pair
     vector<vector<ibv_send_wr>>sendWorkRequests;  ///< Send work requests per queue pair
@@ -3959,7 +3959,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     std::vector<std::chrono::high_resolution_clock::time_point> transferTimers(transferCount);
 
     do {
-      std::vector<uint8_t> receivedQPs(transferCount, 0);
+      std::vector<uint32_t> receivedQPs(transferCount, 0);
       // post the sends
       for (auto i = 0; i < transferCount; i++) {
         transferTimers[i] = std::chrono::high_resolution_clock::now();

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -532,7 +532,7 @@ namespace TransferBench
    * @note This function is applicable when the IBV/RDMA executor is available
    * @returns GPU indices closest to NIC nicIndex, or empty if unable to detect
    */
-  void GetClosestGpusToNic(std::vector<int>& gpuIndices, int nicIndex, int targetRank = -1);
+  void GetClosestGpusToNic(std::vector<int>& nicIndices, int gpuIndex, int targetRank = -1);
 
   /**
    * @returns 0-indexed rank for this process

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -524,7 +524,7 @@ namespace TransferBench
    * @note This function is applicable when the IBV/RDMA executor is available
    * @returns GPU indices closest to NIC nicIndex, or empty if unable to detect
    */
-  void GetClosestGpusToNic(std::vector<int>& nicIndices, int gpuIndex, int targetRank = -1);
+  void GetClosestGpusToNic(std::vector<int>& gpuIndices, int nicIndex, int targetRank = -1);
 
   /**
    * @returns 0-indexed rank for this process

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -524,7 +524,7 @@ namespace TransferBench
    * @note This function is applicable when the IBV/RDMA executor is available
    * @returns GPU indices closest to NIC nicIndex, or empty if unable to detect
    */
-  void GetClosestGpusToNic(std::vector<int>& gpuIndices, int nicIndex, int targetRank = -1);
+  void GetClosestGpusToNic(std::vector<int>& nicIndices, int gpuIndex, int targetRank = -1);
 
   /**
    * @returns 0-indexed rank for this process
@@ -3039,7 +3039,9 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
         }
       }
       // Create SRC completion queues
-      IBV_PTR_CALL(rss.srcCompQueue, ibv_create_cq, rss.srcContext, cfg.nic.queueSize, NULL, NULL, 0);
+      // Ensure CQ size is at least as large as the number of queue pairs to avoid overflow
+      int srcCQSize = std::max(cfg.nic.queueSize, static_cast<int>(rss.qpCount));
+      IBV_PTR_CALL(rss.srcCompQueue, ibv_create_cq, rss.srcContext, srcCQSize, NULL, NULL, 0);
       // Get SRC port attributes
       IBV_CALL(ibv_query_port, rss.srcContext, port, &rss.srcPortAttr);
       // Check for RDMA over Converged Ethernet (RoCE) and update GID index appropriately
@@ -3103,7 +3105,9 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
         }
       }
       // Create DST completion queues
-      IBV_PTR_CALL(rss.dstCompQueue, ibv_create_cq, rss.dstContext, cfg.nic.queueSize, NULL, NULL, 0);
+      // Ensure CQ size is at least as large as the number of queue pairs to avoid overflow
+      int dstCQSize = std::max(cfg.nic.queueSize,static_cast<int>(rss.qpCount));
+      IBV_PTR_CALL(rss.dstCompQueue, ibv_create_cq, rss.dstContext, dstCQSize, NULL, NULL, 0);
       // Get DST port attributes
       IBV_CALL(ibv_query_port, rss.dstContext, port, &rss.dstPortAttr);
       // Check for RDMA over Converged Ethernet (RoCE) and update GID index appropriately
@@ -3973,12 +3977,17 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
             auto& rss = exeInfo.resources[i];
             // Poll the completion queue until all queue pairs are complete
             // The order of completion doesn't matter because this completion queue is dedicated to this Transfer
-            ibv_wc wc;
-            int nc = ibv_poll_cq(rss.srcIsExeNic ? rss.srcCompQueue : rss.dstCompQueue, 1, &wc);
+            // Use batch polling to drain multiple completions at once for better efficiency
+            constexpr int POLL_BATCH_SIZE = 32;
+            ibv_wc wc_array[POLL_BATCH_SIZE];
+            int nc = ibv_poll_cq(rss.srcIsExeNic ? rss.srcCompQueue : rss.dstCompQueue, POLL_BATCH_SIZE, wc_array);
             if (nc > 0) {
-              receivedQPs[i]++;
-              if (wc.status != IBV_WC_SUCCESS) {
-                return {ERR_FATAL, "Transfer %d: Received unsuccessful work completion [status code %d]", rss.transferIdx, wc.status};
+              // Process all completions in the batch
+              for (int j = 0; j < nc; j++) {
+                if (wc_array[j].status != IBV_WC_SUCCESS) {
+                  return {ERR_FATAL, "Transfer %d: Received unsuccessful work completion [status code %d]", rss.transferIdx, wc_array[j].status};
+                }
+                receivedQPs[i]++;
               }
             } else if (nc < 0) {
               return {ERR_FATAL, "Transfer %d: Received negative work completion", rss.transferIdx};

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1509,6 +1509,9 @@ namespace {
       "/lib/modules/%s/build/.config",
     };
 
+    // Check if zcat is available in the system
+    int has_zcat = (system("which zcat > /dev/null 2>&1") == 0);
+
     for (const auto& path : possiblePaths) {
       // Reset flags for each file
       found_opt1 = 0;
@@ -1518,6 +1521,13 @@ namespace {
 
       // Special handling for /proc/config.gz
       if (strstr(path, "/proc/config.gz") != NULL) {
+        // Skip .gz files if zcat is not available
+        if (!has_zcat) {
+          if (System::Get().IsVerbose()) {
+            printf("[WARN] zcat not available, skipping %s\n", kernel_conf_file);
+          }
+          continue;
+        }
         fp = popen("zcat /proc/config.gz 2>/dev/null", "r");
       } else {
         fp = fopen(kernel_conf_file, "r");


### PR DESCRIPTION
### Motivation
Solve hangs issue experiments with large number of QPs (>128)
Implement batch polling together with introducing NIC_CQ_POLL_BATCH environment variable

### Technical Details
CQ Size: max(100, qpCount) - dynamically sized : This increase resolve the hang at large QPs , observed notably at smalll message size (burst of completions filling CQs).

Polling: Up to NIC_CQ_POLL_BATCH completions per poll call, which should help reducing CPU overhead while draining CQ faster

### Test Plan
Config : 2 nodes MI300X server with Broadcom Thor2 NIC .
Command : mpirun -np 2 Transferbench nicrings
With : export NUM_QUEUE_PAIRS=16384
Sweeping NIC_CQ_POLL_BATCH from 1 to 128 (by power of 2) :

### Test Result
No hang. Performance with number of QPs < 64 are in line with previous version, and stable up to NUM_QUEUE_PAIRS=480.
Varying NIC_CQ_POLL_BATCH has nevertheless not shown impact on performance at message size of 256MB