### PR TITLE
Adding HBM read bandwidth preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Documentation for TransferBench is available at
   - This will write Transfers that are executed (for example via a preset) to a config file that can then be executed
 - Reporting number of iterations run when running in timed mode (NUM_ITERATIONS < 0)
 - Adding NIC_CQ_POLL_BATCH to control CQ poll batch size for NIC transfers
+- New "hbm" preset which sweeps and tests local HBM read performance
 
 ### Modified
   - DMA-BUF support enablement in CMake changed to ENABLE_DMA_BUF to be more similar to other compile-time options

--- a/src/client/Presets/AllToAll.hpp
+++ b/src/client/Presets/AllToAll.hpp
@@ -20,9 +20,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-int AllToAllPreset(EnvVars&           ev,
-                    size_t      const  numBytesPerTransfer,
-                    std::string const  presetName)
+int AllToAllPreset(EnvVars&          ev,
+                   size_t      const numBytesPerTransfer,
+                   std::string const presetName,
+                   bool        const bytesSpecified)
 {
   enum
   {

--- a/src/client/Presets/AllToAllN.hpp
+++ b/src/client/Presets/AllToAllN.hpp
@@ -22,9 +22,10 @@ THE SOFTWARE.
 
 #include "EnvVars.hpp"
 
-int AllToAllRdmaPreset(EnvVars&           ev,
-                       size_t      const  numBytesPerTransfer,
-                       std::string const  presetName)
+int AllToAllRdmaPreset(EnvVars&          ev,
+                       size_t      const numBytesPerTransfer,
+                       std::string const presetName,
+                       bool        const bytesSpecified)
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR]a2an preset currently not supported for multi-node\n");

--- a/src/client/Presets/AllToAllSweep.hpp
+++ b/src/client/Presets/AllToAllSweep.hpp
@@ -22,9 +22,10 @@ THE SOFTWARE.
 
 #include "EnvVars.hpp"
 
-int AllToAllSweepPreset(EnvVars&           ev,
-                        size_t      const  numBytesPerTransfer,
-                        std::string const  presetName)
+int AllToAllSweepPreset(EnvVars&          ev,
+                        size_t      const numBytesPerTransfer,
+                        std::string const presetName,
+                        bool        const bytesSpecified)
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR] All to All Sweep preset currently not supported for multi-node\n");

--- a/src/client/Presets/HbmBandwidth.hpp
+++ b/src/client/Presets/HbmBandwidth.hpp
@@ -318,18 +318,19 @@ int HbmBandwidthPreset(EnvVars&           ev,
   {
     if (!ev.outputToCsv) Utils::Print("[HBM Bandwidth Related]\n");
     if (Utils::RankDoesOutput()) {
-      ev.Print("BLOCKSIZES"    , EnvVars::ToStr(blockSizes).c_str(), "Threadblock sizes to sweep over");
-      ev.Print("CRITERIA"      , criteria                          , "Reporting highest %s bandwidth", criteria == 0 ? "MAX" : criteria == 1 ? "AVG" : "MIN");
-      ev.Print("ELEM_BYTES"    , EnvVars::ToStr(elemBytes).c_str() , "Element sizes in bytes to sweep over");
+      ev.Print("BLOCKSIZES"    , EnvVars::ToStr(blockSizes).c_str(), "Threadblock sizes to sweep over (multiple of 128 up to 1024)");
+      ev.Print("CRITERIA"      , criteria                          , "Reporting highest %s bandwidth (0=MAX,1=AVG,2=MIN)", criteria == 0 ? "MAX" : criteria == 1 ? "AVG" : "MIN");
+      ev.Print("ELEM_BYTES"    , EnvVars::ToStr(elemBytes).c_str() , "Element sizes in bytes to sweep over (must contain only 4,8 or 16)");
       ev.Print("GPU_INDICES"   , EnvVars::ToStr(gpuIndices).c_str(), "GPU indices to test.  Leave empty for all");
       ev.Print("MEM_TYPE"      , memTypeIdx                        , "Using %s GPU memory (%s)", devMemTypeStr.c_str(), Utils::GetAllGpuMemTypeStr().c_str());
       ev.Print("NUM_BUFFERS"   , numBuffers                        , "Number of buffers to rotate through (1 per iteration)");
       ev.Print("NUM_ITERATIONS", numIterations                     , "Number of iterations to time");
-      ev.Print("NUM_SUB_EXECS" , EnvVars::ToStr(numSesList).c_str(), "Number of subexecutors to sweep over");
+      ev.Print("NUM_SUB_EXECS" , EnvVars::ToStr(numSesList).c_str(), "Number of subexecutors to sweep over (default to all available)");
       ev.Print("PREWARM_MSEC"  , prewarmMsec                       , "Prewarm duration in msec");
-      ev.Print("SHOW_DETAILS"  , showDetails                       , "Show sweep details (ignored for multi-rank)");
+      ev.Print("SHOW_DETAILS"  , showDetails                       , "Show sweep details (ignored for multi-rank).  Setting to 2 shows per iteration output");
+      ev.Print("SHOW_EXTRA"    , showExtra                         , "Show best sweep config details");
       ev.Print("TEMPORAL_MASK" , temporalMask                      , "Temporal mask (1 = temporal, 2 = non-temporal, 3 = both)");
-      ev.Print("UNROLLS"       , EnvVars::ToStr(unrolls).c_str()   , "Unroll factors to sweep over");
+      ev.Print("UNROLLS"       , EnvVars::ToStr(unrolls).c_str()   , "Unroll factors to sweep over (must contain only 1,2,4,8 or 16)");
       ev.Print("USE_WALLCLOCK" , useWallClock                      , useWallClock ? "Using GPU wall-clock for timing" : "Using events for timing");
       Utils::Print("\n");
     }

--- a/src/client/Presets/HbmBandwidth.hpp
+++ b/src/client/Presets/HbmBandwidth.hpp
@@ -167,10 +167,14 @@ struct HbmBwResult
   double bw[3];  // MAX | AVG | MIN
 };
 
-int HbmBandwidthPreset(EnvVars&           ev,
-                       size_t      const  numBytesPerTransfer,
-                       std::string const  presetName)
+int HbmBandwidthPreset(EnvVars&          ev,
+                       size_t      const numBytesPerTransfer,
+                       std::string const presetName,
+                       bool        const bytesSpecified)
 {
+  // If bytes aren't specified, default to 1GB
+  size_t numBytesAtLeast = (bytesSpecified ? numBytesPerTransfer : 1024 * 1024 * 1024);
+
   // Determine rank information
   int numRanks = TransferBench::GetNumRanks();
   int myRank   = TransferBench::GetRank();
@@ -322,7 +326,7 @@ int HbmBandwidthPreset(EnvVars&           ev,
       ev.Print("CRITERIA"      , criteria                          , "Reporting highest %s bandwidth (0=MAX,1=AVG,2=MIN)", criteria == 0 ? "MAX" : criteria == 1 ? "AVG" : "MIN");
       ev.Print("ELEM_BYTES"    , EnvVars::ToStr(elemBytes).c_str() , "Element sizes in bytes to sweep over (must contain only 4,8 or 16)");
       ev.Print("GPU_INDICES"   , EnvVars::ToStr(gpuIndices).c_str(), "GPU indices to test.  Leave empty for all");
-      ev.Print("MEM_TYPE"      , memTypeIdx                        , "Using %s GPU memory (%s)", devMemTypeStr.c_str(), Utils::GetAllGpuMemTypeStr().c_str());
+      ev.Print("MEM_TYPE"      , memTypeIdx                        , "Using %s memory (%s)", devMemTypeStr.c_str(), Utils::GetAllGpuMemTypeStr().c_str());
       ev.Print("NUM_BUFFERS"   , numBuffers                        , "Number of buffers to rotate through (1 per iteration)");
       ev.Print("NUM_ITERATIONS", numIterations                     , "Number of iterations to time");
       ev.Print("NUM_SUB_EXECS" , EnvVars::ToStr(numSesList).c_str(), "Number of subexecutors to sweep over (default to all available)");
@@ -344,16 +348,16 @@ int HbmBandwidthPreset(EnvVars&           ev,
 
   // Determine how how much memory to allocate based on sweep setting
   // During each Step each threadblock works on BLOCKSIZE * UNROLL * ELEM_BYTES bytes
-  // Each buffer will be allocated as the smallest multiple of this, larger than numBytesPerTransfer,
+  // Each buffer will be allocated as the smallest multiple of this, larger than numBytesAtLeast,
   // NOTE: It's not safe to just base this on maximums values in each sweep parameter,
-  //       (e.g if maximum size divides numBytesPerTransfer perfectly) so looping over entire space is safer
+  //       (e.g if maximum size divides numBytesAtLeast perfectly) so looping over entire space is safer
   size_t largestTotalBytesPerBuffer = 0;
   for (int numSubExec : numSesList) {
     for (int blockSize : blockSizes) {
       for (int unroll : unrolls) {
         for (int elemByte : elemBytes) {
           size_t totalBytesPerStep = numSubExec * blockSize * unroll * elemByte;
-          size_t numSteps = std::max((size_t)1, (numBytesPerTransfer + totalBytesPerStep - 1) / totalBytesPerStep);
+          size_t numSteps = std::max((size_t)1, (numBytesAtLeast + totalBytesPerStep - 1) / totalBytesPerStep);
           size_t totalBytesPerBuffer = numSteps * totalBytesPerStep;
           if (totalBytesPerBuffer > largestTotalBytesPerBuffer) largestTotalBytesPerBuffer = totalBytesPerBuffer;
         }
@@ -372,7 +376,7 @@ int HbmBandwidthPreset(EnvVars&           ev,
     // Calculate total number of tests that will be executed per GPU
     size_t numTests = numSesList.size() * blockSizes.size() * unrolls.size() * elemBytes.size() * (temporalMask == 3 ? 2 : 1);
 
-    Utils::Print("Testing (%lu configs per GPU): ", numTests);
+    Utils::Print("Testing on at least %lu bytes (%lu configs per GPU): ", numBytesAtLeast, numTests);
     fflush(stdout);
   }
 
@@ -439,7 +443,7 @@ int HbmBandwidthPreset(EnvVars&           ev,
           for (int elemByte : elemBytes) {
             int elemByteIdx = (int)log2(elemByte) - 2;
             size_t totalBytesPerStep = numSubExec * blockSize * unroll * elemByte;
-            size_t numSteps = std::max((size_t)1, (numBytesPerTransfer + totalBytesPerStep - 1) / totalBytesPerStep);
+            size_t numSteps = std::max((size_t)1, (numBytesAtLeast + totalBytesPerStep - 1) / totalBytesPerStep);
             size_t totalBytes = numSteps * totalBytesPerStep;
 
             for (int useNt = 0; useNt <= 1; useNt++) {

--- a/src/client/Presets/HbmBandwidth.hpp
+++ b/src/client/Presets/HbmBandwidth.hpp
@@ -216,7 +216,7 @@ int HbmBandwidthPreset(EnvVars&          ev,
 
   // Check for consistency across ranks
   IS_UNIFORM(blockSizes,    "BLOCKSIZES");
-  IS_UNIFORM(blockSizes,    "CRITERIA");
+  IS_UNIFORM(criteria,      "CRITERIA");
   IS_UNIFORM(elemBytes,     "ELEM_BYTES");
   // GPU_INDICES may be different per rank
   IS_UNIFORM(memTypeIdx,    "MEM_TYPE");
@@ -225,7 +225,7 @@ int HbmBandwidthPreset(EnvVars&          ev,
   IS_UNIFORM(numSesList,    "NUM_SUB_EXECS");
   IS_UNIFORM(prewarmMsec,   "PREWARM_MSEC");
   IS_UNIFORM(showDetails,   "SHOW_DETAILS");
-  IS_UNIFORM(showDetails,   "SHOW_EXTRA");
+  IS_UNIFORM(showExtra,     "SHOW_EXTRA");
   IS_UNIFORM(temporalMask,  "TEMPORAL_MASK");
   IS_UNIFORM(unrolls,       "UNROLLS");
   IS_UNIFORM(useWallClock,  "USE_WALLCLOCK");
@@ -262,17 +262,18 @@ int HbmBandwidthPreset(EnvVars&          ev,
   if (!gpuIndices.empty()) {
     for (auto gpuIdx : gpuIndices) {
       if (gpuIdx < 0 || gpuIdx >= numDetectedGpus) {
-        Utils::Print("[ERROR] GPU_INDICES index out of range (%d) (rank %d)", gpuIdx, myRank);
+        Utils::Print("[ERROR] GPU_INDICES index out of range (%d) (rank %d)\n", gpuIdx, myRank);
         return 1;
       }
     }
   }
 
-  if (numBuffers <= 1) {
+  if (numBuffers < 1) {
     Utils::Print("[ERROR] NUM_BUFFERS must be a positive number (not %d)\n", numBuffers);
+    return 1;
   }
   if (numBuffers > numIterations) {
-    Utils::Print("[WARN] NUM_BUFFERS (%d) exceeds NUM_ITERATIONS ($d), so some buffers will not be used\n",
+    Utils::Print("[WARN] NUM_BUFFERS (%d) exceeds NUM_ITERATIONS (%d), so some buffers will not be used\n",
                  numBuffers, numIterations);
     numBuffers = numIterations;
   }
@@ -307,6 +308,7 @@ int HbmBandwidthPreset(EnvVars&          ev,
 
   if (unrolls.empty()) {
     Utils::Print("[ERROR] UNROLLS may not be empty");
+    return 1;
   }
   for (auto unroll : unrolls) {
     if (unroll != 1 && unroll != 2 && unroll != 4 && unroll != 8 && unroll != 16) {
@@ -383,16 +385,6 @@ int HbmBandwidthPreset(EnvVars&          ev,
   for (int gpuIdx : gpuIndices) {
     HIP_CALL(hipSetDevice(gpuIdx));
 
-    // Determine wall clock rate for this GPU
-    int wallClockRate;
-    if (useWallClock) {
-#if defined(__NVCC__)
-      wallClockRate = 1000000;
-#else
-      HIP_CALL(hipDeviceGetAttribute(&wallClockRate, hipDeviceAttributeWallClockRate, gpuIdx));
-#endif
-    }
-
     // Create streams/events for this GPU
     hipStream_t stream;
     hipEvent_t startEvent, stopEvent;
@@ -400,16 +392,22 @@ int HbmBandwidthPreset(EnvVars&          ev,
     HIP_CALL(hipEventCreate(&startEvent));
     HIP_CALL(hipEventCreate(&stopEvent));
 
-    // Allocate pinned host memory closest to this GPU to capture timestamps
-    long long* minStartCycle;
-    long long* maxStopCycle;
-    if (Utils::AllocateMemory({MEM_CPU_CLOSEST, gpuIdx, myRank}, sizeof(int64_t), (void**)&minStartCycle)) {
-      Utils::Print("[ERROR] Unable to allocate pinned host memory on rank %d closest to GPU %d\n", myRank, gpuIdx);
-      return 1;
-    }
-    if (Utils::AllocateMemory({MEM_CPU_CLOSEST, gpuIdx, myRank}, sizeof(int64_t), (void**)&maxStopCycle)) {
-      Utils::Print("[ERROR] Unable to allocate pinned host memory on rank %d closest to GPU %d\n", myRank, gpuIdx);
-      return 1;
+    // Allocate pinned host memory closest to this GPU to capture timestamps (if enabled)
+    int wallClockRate;
+    long long* minStartCycle = nullptr;
+    long long* maxStopCycle = nullptr;
+
+    if (useWallClock) {
+    #if defined(__NVCC__)
+      wallClockRate = 1000000;
+#else
+      HIP_CALL(hipDeviceGetAttribute(&wallClockRate, hipDeviceAttributeWallClockRate, gpuIdx));
+#endif
+      if (Utils::AllocateMemory({MEM_CPU_CLOSEST, gpuIdx, myRank}, sizeof(int64_t), (void**)&minStartCycle) ||
+          Utils::AllocateMemory({MEM_CPU_CLOSEST, gpuIdx, myRank}, sizeof(int64_t), (void**)&maxStopCycle)) {
+        Utils::Print("[ERROR] Unable to allocate pinned host memory on rank %d closest to GPU %d\n", myRank, gpuIdx);
+        return 1;
+      }
     }
 
     // Allocate and initialize each GPU buffer
@@ -458,7 +456,7 @@ int HbmBandwidthPreset(EnvVars&          ev,
               int currBufferIdx = 0;
               auto prewarmEnd = std::chrono::steady_clock::now() + std::chrono::milliseconds(prewarmMsec);
               do {
-                kernel<<<gridDim, blockDim, 0, stream>>>(inputBuffers[currBufferIdx++], NULL, numSteps, minStartCycle, maxStopCycle);
+                kernel<<<gridDim, blockDim, 0, stream>>>(inputBuffers[currBufferIdx++], nullptr, numSteps, minStartCycle, maxStopCycle);
                 HIP_CALL(hipStreamSynchronize(stream));
                 if (currBufferIdx == numBuffers) currBufferIdx = 0;
               } while (std::chrono::steady_clock::now() < prewarmEnd);
@@ -473,15 +471,13 @@ int HbmBandwidthPreset(EnvVars&          ev,
                 if (!useWallClock) {
                   HIP_CALL(hipEventRecord(startEvent, stream));
                 }
-                kernel<<<gridDim, blockDim, 0, stream>>>(inputBuffers[currBufferIdx++], NULL, numSteps,
-                                                         useWallClock ? minStartCycle : NULL, maxStopCycle);
+                kernel<<<gridDim, blockDim, 0, stream>>>(inputBuffers[currBufferIdx++], nullptr, numSteps, minStartCycle, maxStopCycle);
                 if (!useWallClock) {
                   HIP_CALL(hipEventRecord(stopEvent, stream));
                 }
 #else
-                hipExtLaunchKernelGGL(kernel, gridDim, blockDim, 0, stream, useWallClock ? NULL : startEvent, useWallClock ? NULL : stopEvent, 0,
-                                      inputBuffers[currBufferIdx], nullptr , numSteps,
-                                      useWallClock ? minStartCycle : NULL, maxStopCycle);
+                hipExtLaunchKernelGGL(kernel, gridDim, blockDim, 0, stream, useWallClock ? nullptr : startEvent, useWallClock ? nullptr : stopEvent, 0,
+                                      inputBuffers[currBufferIdx++], nullptr, numSteps, minStartCycle, maxStopCycle);
 #endif
                 HIP_CALL(hipStreamSynchronize(stream));
                 if (currBufferIdx == numBuffers) currBufferIdx = 0;
@@ -539,6 +535,14 @@ int HbmBandwidthPreset(EnvVars&          ev,
       ErrResult err = DeallocateMemory(memType, inputBuffers[bufferIdx], largestTotalBytesPerBuffer);
       if (err.errType != ERR_NONE) {
         Utils::Print("[ERROR] Error when deallocating memory (%s)\n", err.errMsg.c_str());
+        return 1;
+      }
+    }
+
+    if (useWallClock) {
+      if (Utils::DeallocateMemory(MEM_CPU_CLOSEST, minStartCycle, sizeof(int64_t)) ||
+          Utils::DeallocateMemory(MEM_CPU_CLOSEST, maxStopCycle,  sizeof(int64_t))) {
+        Utils::Print("[ERROR] Unable to deallocate pinned host memory on rank %d closest to GPU %d\n", myRank, gpuIdx);
         return 1;
       }
     }

--- a/src/client/Presets/HbmBandwidth.hpp
+++ b/src/client/Presets/HbmBandwidth.hpp
@@ -105,7 +105,7 @@ void HbmReadBwKernel(const void* __restrict pSrcBuffer,
 
   // Update min/max start times
   __syncthreads();
-  if (threadIdx.x == 0) {
+  if (threadIdx.x == 0 && minStartCycle != NULL) {
     int64_t stopTime = GetTimestamp();
     atomicMin(minStartCycle, startTime);
     atomicMax(maxStopCycle, stopTime);
@@ -473,13 +473,15 @@ int HbmBandwidthPreset(EnvVars&          ev,
                 if (!useWallClock) {
                   HIP_CALL(hipEventRecord(startEvent, stream));
                 }
-                kernel<<<gridDim, blockDim, 0, stream>>>(inputBuffers[currBufferIdx++], NULL, numSteps, minStartCycle, maxStopCycle);
+                kernel<<<gridDim, blockDim, 0, stream>>>(inputBuffers[currBufferIdx++], NULL, numSteps,
+                                                         useWallClock ? minStartCycle : NULL, maxStopCycle);
                 if (!useWallClock) {
                   HIP_CALL(hipEventRecord(stopEvent, stream));
                 }
 #else
                 hipExtLaunchKernelGGL(kernel, gridDim, blockDim, 0, stream, useWallClock ? NULL : startEvent, useWallClock ? NULL : stopEvent, 0,
-                                      inputBuffers[currBufferIdx], nullptr , numSteps, minStartCycle, maxStopCycle);
+                                      inputBuffers[currBufferIdx], nullptr , numSteps,
+                                      useWallClock ? minStartCycle : NULL, maxStopCycle);
 #endif
                 HIP_CALL(hipStreamSynchronize(stream));
                 if (currBufferIdx == numBuffers) currBufferIdx = 0;

--- a/src/client/Presets/HbmBandwidth.hpp
+++ b/src/client/Presets/HbmBandwidth.hpp
@@ -1,0 +1,608 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include "EnvVars.hpp"
+#include "Utilities.hpp"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace TransferBench;
+
+// CUDA translation
+#if defined(__NVCC__)
+#define hipEvent_t           cudaEvent_t
+#define hipEventCreate       cudaEventCreate
+#define hipEventDestroy      cudaEventDestroy
+#define hipEventElapsedTime  cudaEventElapsedTime
+#define hipEventRecord       cudaEventRecord
+#define hipSetDevice         cudaSetDevice
+#define hipStream_t          cudaStream_t
+#define hipStreamCreate      cudaStreamCreate
+#define hipStreamDestroy     cudaStreamDestroy
+#define hipStreamSynchronize cudaStreamSynchronize
+#endif
+
+// Load a value
+template<bool USE_NT, typename T>
+__device__ __forceinline__ T Load(const T& ref)
+{
+#if !defined(__NVCC__)
+  if (USE_NT) return __builtin_nontemporal_load(&ref);
+#endif
+  return ref;
+}
+
+// Main kernel for HBM bandwidth testing
+template<int LAUNCH_BOUND, int UNROLL, typename T, bool USE_NT>
+__global__ __launch_bounds__(LAUNCH_BOUND)
+void HbmReadBwKernel(const void* __restrict pSrcBuffer,
+                     void*       __restrict dummy,
+                     const size_t           numSteps,
+                     long long*  __restrict minStartCycle,
+                     long long*  __restrict maxStopCycle)
+{
+  int64_t startTime;
+  if (threadIdx.x == 0) {
+    startTime = GetTimestamp();
+  }
+
+  // Cast src/dst buffers to the correct type
+  T const* __restrict srcBuffer = reinterpret_cast<T const*>(pSrcBuffer);
+  T*       __restrict dstBuffer = reinterpret_cast<T*      >(dummy);
+  T v{};
+
+  // Determine the total number of elements this threadblock handles
+  size_t elemPerThreadblock = numSteps * blockDim.x * UNROLL;
+
+  // Determine the initial offset for this threadblock
+  size_t srcOffset = blockIdx.x * elemPerThreadblock + threadIdx.x;
+
+  #pragma unroll 1
+  for (size_t step = 0; step < numSteps; step++) {
+    #pragma unroll
+    for (uint32_t i = 0; i < UNROLL; i++) {
+      v |= Load<USE_NT>(srcBuffer[srcOffset]);
+      srcOffset += blockDim.x;
+    }
+  }
+
+  // This statement is never true, but is required to make sure compiler
+  // doesn't optimize away the reads
+  if (elemPerThreadblock == 0)
+    *dstBuffer = v;
+
+  // Update min/max start times
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    int64_t stopTime = GetTimestamp();
+    atomicMin(minStartCycle, startTime);
+    atomicMax(maxStopCycle, stopTime);
+  }
+}
+
+// Build up function pointer table
+typedef void (*HbmReadBwKernelFuncPtr)(const void*, void *, size_t, long long*, long long*);
+
+#define HBM_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, DTYPE) \
+  {HbmReadBwKernel<LAUNCH_BOUND, UNROLL, DTYPE, false>,       \
+   HbmReadBwKernel<LAUNCH_BOUND, UNROLL, DTYPE, true>}
+
+#define HBM_KERNEL_DTYPE_DECL(LAUNCH_BOUND, UNROLL)             \
+  {HBM_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, uint32_t),    \
+   HBM_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, uint64_t),    \
+   HBM_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, __uint128_t)}
+
+#define HBM_KERNEL_UNROLL_DECL(LAUNCH_BOUND) \
+  {HBM_KERNEL_DTYPE_DECL(LAUNCH_BOUND, 1),   \
+   HBM_KERNEL_DTYPE_DECL(LAUNCH_BOUND, 2),   \
+   HBM_KERNEL_DTYPE_DECL(LAUNCH_BOUND, 4),   \
+   HBM_KERNEL_DTYPE_DECL(LAUNCH_BOUND, 8),   \
+   HBM_KERNEL_DTYPE_DECL(LAUNCH_BOUND, 16)}
+
+  HbmReadBwKernelFuncPtr HbmReadKernelTable[4][5][3][2] =
+  {
+    HBM_KERNEL_UNROLL_DECL(256),
+    HBM_KERNEL_UNROLL_DECL(512),
+    HBM_KERNEL_UNROLL_DECL(768),
+    HBM_KERNEL_UNROLL_DECL(1024)
+  };
+
+// Kernel to fill buffer with random data
+__global__ void FillPsuedoRandomData(size_t N, uint32_t* p, uint32_t shift)
+{
+  for (size_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < N; idx += blockDim.x * gridDim.x) {
+    uint32_t d = static_cast<uint32_t>(idx + shift);
+    uint32_t val = 2166136261u;
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+      val ^= d & 0xff;
+      val *= 16777619u;
+      d >>= 8;
+    }
+    p[idx] = val;
+  }
+}
+
+struct HbmBwResult
+{
+  int rank;
+  int gpuIdx;
+  int numSubExec;
+  int blockSize;
+  int unroll;
+  int elemByte;
+
+  double bw[3];  // MAX | AVG | MIN
+};
+
+int HbmBandwidthPreset(EnvVars&           ev,
+                       size_t      const  numBytesPerTransfer,
+                       std::string const  presetName)
+{
+  // Determine rank information
+  int numRanks = TransferBench::GetNumRanks();
+  int myRank   = TransferBench::GetRank();
+
+  // Make sure each rank has at least one GPU
+  for (int rank = 0; rank < numRanks; rank++) {
+    if (TransferBench::GetNumExecutors(EXE_GPU_GFX, rank) == 0) {
+      Utils::Print("[ERROR] Each rank must have at least GPU.  Rank %d has no GPUs\n", rank);
+      return 1;
+    }
+  }
+  int defSubExec = TransferBench::GetNumSubExecutors({EXE_GPU_GFX, 0});
+
+  // Collect environment variables
+  std::vector<int> blockSizes    = EnvVars::GetEnvVarArray("BLOCKSIZES"    ,   {256, 512});
+  int              criteria      = EnvVars::GetEnvVar     ("CRITERIA"      ,            0);
+  std::vector<int> elemBytes     = EnvVars::GetEnvVarArray("ELEM_BYTES"    ,       {16,8});
+  std::vector<int> gpuIndices    = EnvVars::GetEnvVarArray("GPU_INDICES"   ,           {});
+  int              memTypeIdx    = EnvVars::GetEnvVar     ("MEM_TYPE"      ,            0);
+  int              numBuffers    = EnvVars::GetEnvVar     ("NUM_BUFFERS"   ,            2);
+  int              numIterations = EnvVars::GetEnvVar     ("NUM_ITERATIONS",          100);
+  std::vector<int> numSesList    = EnvVars::GetEnvVarArray("NUM_SUB_EXECS" , {defSubExec});
+  int              outputToCsv   = EnvVars::GetEnvVar     ("OUTPUT_TO_CSV" ,            0);
+  int              prewarmMsec   = EnvVars::GetEnvVar     ("PREWARM_MSEC"  ,           50);
+  int              showBorders   = EnvVars::GetEnvVar     ("SHOW_BORDERS"  ,            1);
+  int              showDetails   = EnvVars::GetEnvVar     ("SHOW_DETAILS"  ,            0);
+  int              showExtra     = EnvVars::GetEnvVar     ("SHOW_EXTRA"    ,            0);
+  int              temporalMask  = EnvVars::GetEnvVar     ("TEMPORAL_MASK" ,            3);
+  std::vector<int> unrolls       = EnvVars::GetEnvVarArray("UNROLLS"       ,     {16,8,4});
+  int              useWallClock  = EnvVars::GetEnvVar     ("USE_WALLCLOCK" ,            1);
+
+  // SHOW_DETAILS is not supported in multi-rank runs
+  if (numRanks > 1) showDetails = 0;
+
+  // Non-temporal reads are not supported for CUDA
+#if defined(__NVCC__)
+  temporalMask = 1;
+#endif
+
+  // Check for consistency across ranks
+  IS_UNIFORM(blockSizes,    "BLOCKSIZES");
+  IS_UNIFORM(blockSizes,    "CRITERIA");
+  IS_UNIFORM(elemBytes,     "ELEM_BYTES");
+  // GPU_INDICES may be different per rank
+  IS_UNIFORM(memTypeIdx,    "MEM_TYPE");
+  IS_UNIFORM(numBuffers,    "NUM_BUFFERS");
+  IS_UNIFORM(numIterations, "NUM_ITERATIONS");
+  IS_UNIFORM(numSesList,    "NUM_SUB_EXECS");
+  IS_UNIFORM(prewarmMsec,   "PREWARM_MSEC");
+  IS_UNIFORM(showDetails,   "SHOW_DETAILS");
+  IS_UNIFORM(showDetails,   "SHOW_EXTRA");
+  IS_UNIFORM(temporalMask,  "TEMPORAL_MASK");
+  IS_UNIFORM(unrolls,       "UNROLLS");
+  IS_UNIFORM(useWallClock,  "USE_WALLCLOCK");
+
+  // Validate environment variables and set defaults
+  if (blockSizes.empty()) {
+    Utils::Print("[ERROR] BLOCKSIZES may not be empty\n");
+    return 1;
+  }
+  for (auto blockSize : blockSizes) {
+    if (blockSize <= 0 || blockSize % 128 != 0 || blockSize > 1024) {
+      Utils::Print("[ERROR] BLOCKSIZES must only contain positive multiples of 128 up to 1024 (not %d)\n", blockSize);
+      return 1;
+    }
+  }
+
+  if (criteria < 0 || criteria > 2) {
+    Utils::Print("[ERROR] CRITERIA must be either 0 (for MAX), 1 (for AVG), or 2 (for MIN) (not %d)\n", criteria);
+    return 1;
+  }
+
+  if (elemBytes.empty()) {
+    Utils::Print("[ERROR] ELEM_BYTES may not be empty\n");
+    return 1;
+  }
+  for (auto elemByte : elemBytes) {
+    if (elemByte != 4 && elemByte != 8 && elemByte != 16) {
+      Utils::Print("[ERROR] ELEM_BYTES may only contain {4,8 or 16}\n");
+      return 1;
+    }
+  }
+
+  int numDetectedGpus = TransferBench::GetNumExecutors(EXE_GPU_GFX);
+  if (!gpuIndices.empty()) {
+    for (auto gpuIdx : gpuIndices) {
+      if (gpuIdx < 0 || gpuIdx >= numDetectedGpus) {
+        Utils::Print("[ERROR] GPU_INDICES index out of range (%d) (rank %d)", gpuIdx, myRank);
+        return 1;
+      }
+    }
+  }
+
+  if (numBuffers <= 1) {
+    Utils::Print("[ERROR] NUM_BUFFERS must be a positive number (not %d)\n", numBuffers);
+  }
+  if (numBuffers > numIterations) {
+    Utils::Print("[WARN] NUM_BUFFERS (%d) exceeds NUM_ITERATIONS ($d), so some buffers will not be used\n",
+                 numBuffers, numIterations);
+    numBuffers = numIterations;
+  }
+
+  if (numIterations <= 0) {
+    Utils::Print("[ERROR] NUM_ITERATIONS must be positive (not %d)\n", numIterations);
+    return 1;
+  }
+
+
+  if (numSesList.empty()) {
+    // By default, use all available sub executors
+    numSesList.push_back(defSubExec);
+  } else {
+    for (auto x : numSesList) {
+      if (x <= 0 || x > defSubExec) {
+        Utils::Print("[ERROR] Number of subexecutors must be positive and less than %d\n", defSubExec);
+        return 1;
+      }
+    }
+  }
+
+  if (prewarmMsec < 0) {
+    Utils::Print("[ERROR] PREWARM_MSEC must be non-negative (not %d)\n", prewarmMsec);
+    return 1;
+  }
+
+  if (temporalMask < 1 || temporalMask > 3) {
+    Utils::Print("[ERROR] TEMPORAL_MASK must be between 1 to 3 (not %d)\n", temporalMask);
+    return 1;
+  }
+
+  if (unrolls.empty()) {
+    Utils::Print("[ERROR] UNROLLS may not be empty");
+  }
+  for (auto unroll : unrolls) {
+    if (unroll != 1 && unroll != 2 && unroll != 4 && unroll != 8 && unroll != 16) {
+      Utils::Print("[ERROR] UNROLLS must only contain {1,2,4,8 or 16} (not %d)\n", unroll);
+      return 1;
+    }
+  }
+
+  MemType memType = Utils::GetGpuMemType(memTypeIdx);
+  std::string devMemTypeStr = Utils::GetGpuMemTypeStr(memTypeIdx);
+
+  if (!ev.hideEnv)
+  {
+    if (!ev.outputToCsv) Utils::Print("[HBM Bandwidth Related]\n");
+    if (Utils::RankDoesOutput()) {
+      ev.Print("BLOCKSIZES"    , EnvVars::ToStr(blockSizes).c_str(), "Threadblock sizes to sweep over");
+      ev.Print("CRITERIA"      , criteria                          , "Reporting highest %s bandwidth", criteria == 0 ? "MAX" : criteria == 1 ? "AVG" : "MIN");
+      ev.Print("ELEM_BYTES"    , EnvVars::ToStr(elemBytes).c_str() , "Element sizes in bytes to sweep over");
+      ev.Print("GPU_INDICES"   , EnvVars::ToStr(gpuIndices).c_str(), "GPU indices to test.  Leave empty for all");
+      ev.Print("MEM_TYPE"      , memTypeIdx                        , "Using %s GPU memory (%s)", devMemTypeStr.c_str(), Utils::GetAllGpuMemTypeStr().c_str());
+      ev.Print("NUM_BUFFERS"   , numBuffers                        , "Number of buffers to rotate through (1 per iteration)");
+      ev.Print("NUM_ITERATIONS", numIterations                     , "Number of iterations to time");
+      ev.Print("NUM_SUB_EXECS" , EnvVars::ToStr(numSesList).c_str(), "Number of subexecutors to sweep over");
+      ev.Print("PREWARM_MSEC"  , prewarmMsec                       , "Prewarm duration in msec");
+      ev.Print("SHOW_DETAILS"  , showDetails                       , "Show sweep details (ignored for multi-rank)");
+      ev.Print("TEMPORAL_MASK" , temporalMask                      , "Temporal mask (1 = temporal, 2 = non-temporal, 3 = both)");
+      ev.Print("UNROLLS"       , EnvVars::ToStr(unrolls).c_str()   , "Unroll factors to sweep over");
+      ev.Print("USE_WALLCLOCK" , useWallClock                      , useWallClock ? "Using GPU wall-clock for timing" : "Using events for timing");
+      Utils::Print("\n");
+    }
+  }
+
+  if (gpuIndices.empty()) {
+    // If empty, use all available GPUs on local rank
+    for (int gpuIdx = 0; gpuIdx < numDetectedGpus; gpuIdx++)
+      gpuIndices.push_back(gpuIdx);
+  }
+
+  // Determine how how much memory to allocate based on sweep setting
+  // During each Step each threadblock works on BLOCKSIZE * UNROLL * ELEM_BYTES bytes
+  // Each buffer will be allocated as the smallest multiple of this, larger than numBytesPerTransfer,
+  // NOTE: It's not safe to just base this on maximums values in each sweep parameter,
+  //       (e.g if maximum size divides numBytesPerTransfer perfectly) so looping over entire space is safer
+  size_t largestTotalBytesPerBuffer = 0;
+  for (int numSubExec : numSesList) {
+    for (int blockSize : blockSizes) {
+      for (int unroll : unrolls) {
+        for (int elemByte : elemBytes) {
+          size_t totalBytesPerStep = numSubExec * blockSize * unroll * elemByte;
+          size_t numSteps = std::max((size_t)1, (numBytesPerTransfer + totalBytesPerStep - 1) / totalBytesPerStep);
+          size_t totalBytesPerBuffer = numSteps * totalBytesPerStep;
+          if (totalBytesPerBuffer > largestTotalBytesPerBuffer) largestTotalBytesPerBuffer = totalBytesPerBuffer;
+        }
+      }
+    }
+  }
+
+  if (showDetails) {
+    Utils::Print("GPU ## | #SE | BKSZ | UR | EB | TOTALBYTES | #STEP | MAX GB/s | AVG GB/s | MIN GB/s\n");
+  }
+
+  // Test all local GPUs
+  std::vector<HbmBwResult> localResults;
+
+  if (!showDetails) {
+    // Calculate total number of tests that will be executed per GPU
+    size_t numTests = numSesList.size() * blockSizes.size() * unrolls.size() * elemBytes.size() * (temporalMask == 3 ? 2 : 1);
+
+    Utils::Print("Testing (%lu configs per GPU): ", numTests);
+    fflush(stdout);
+  }
+
+  for (int gpuIdx : gpuIndices) {
+    HIP_CALL(hipSetDevice(gpuIdx));
+
+    // Determine wall clock rate for this GPU
+    int wallClockRate;
+    if (useWallClock) {
+#if defined(__NVCC__)
+      wallClockRate = 1000000;
+#else
+      HIP_CALL(hipDeviceGetAttribute(&wallClockRate, hipDeviceAttributeWallClockRate, gpuIdx));
+#endif
+    }
+
+    // Create streams/events for this GPU
+    hipStream_t stream;
+    hipEvent_t startEvent, stopEvent;
+    HIP_CALL(hipStreamCreate(&stream));
+    HIP_CALL(hipEventCreate(&startEvent));
+    HIP_CALL(hipEventCreate(&stopEvent));
+
+    // Allocate pinned host memory closest to this GPU to capture timestamps
+    long long* minStartCycle;
+    long long* maxStopCycle;
+    if (Utils::AllocateMemory({MEM_CPU_CLOSEST, gpuIdx, myRank}, sizeof(int64_t), (void**)&minStartCycle)) {
+      Utils::Print("[ERROR] Unable to allocate pinned host memory on rank %d closest to GPU %d\n", myRank, gpuIdx);
+      return 1;
+    }
+    if (Utils::AllocateMemory({MEM_CPU_CLOSEST, gpuIdx, myRank}, sizeof(int64_t), (void**)&maxStopCycle)) {
+      Utils::Print("[ERROR] Unable to allocate pinned host memory on rank %d closest to GPU %d\n", myRank, gpuIdx);
+      return 1;
+    }
+
+    // Allocate and initialize each GPU buffer
+    MemDevice memDevice = {memType, gpuIdx, myRank};
+    std::vector<void*> inputBuffers(numBuffers);
+    for (int bufferIdx = 0; bufferIdx < numBuffers; bufferIdx++) {
+      ErrResult err = AllocateMemory(memDevice, largestTotalBytesPerBuffer, &inputBuffers[bufferIdx]);
+      if (err.errType != ERR_NONE) {
+        Utils::Print("[ERROR] Error when allocating memory (%s)\n", err.errMsg.c_str());
+        return 1;
+      }
+      FillPsuedoRandomData<<<32, 256, 0, stream>>>(largestTotalBytesPerBuffer / sizeof(uint32_t),
+                                                   (uint32_t*)inputBuffers[bufferIdx], bufferIdx);
+    }
+    HIP_CALL(hipStreamSynchronize(stream));
+
+    HbmBwResult bestResult = {};
+
+    // Run sweep to find fastest result
+    for (int numSubExec : numSesList) {
+      dim3 gridDim(numSubExec, 1, 1);
+      for (int blockSize : blockSizes) {
+        if (!showDetails) {
+          Utils::Print(".");
+          fflush(stdout);
+        }
+        dim3 blockDim(blockSize, 1, 1);
+        int launchBoundIdx = (blockSize + 255) / 256 - 1;
+        for (int unroll : unrolls) {
+          int unrollIdx = (int)log2(unroll);
+          for (int elemByte : elemBytes) {
+            int elemByteIdx = (int)log2(elemByte) - 2;
+            size_t totalBytesPerStep = numSubExec * blockSize * unroll * elemByte;
+            size_t numSteps = std::max((size_t)1, (numBytesPerTransfer + totalBytesPerStep - 1) / totalBytesPerStep);
+            size_t totalBytes = numSteps * totalBytesPerStep;
+
+            for (int useNt = 0; useNt <= 1; useNt++) {
+              if (!(temporalMask & (1<<useNt))) continue;
+              auto kernel = HbmReadKernelTable[launchBoundIdx][unrollIdx][elemByteIdx][useNt];
+
+              double minBw = std::numeric_limits<double>::max();
+              double maxBw = std::numeric_limits<double>::lowest();
+              double sumBw = 0.0;
+
+              /* Run warmups for user-specified time */
+              int currBufferIdx = 0;
+              auto prewarmEnd = std::chrono::steady_clock::now() + std::chrono::milliseconds(prewarmMsec);
+              do {
+                kernel<<<gridDim, blockDim, 0, stream>>>(inputBuffers[currBufferIdx++], NULL, numSteps, minStartCycle, maxStopCycle);
+                HIP_CALL(hipStreamSynchronize(stream));
+                if (currBufferIdx == numBuffers) currBufferIdx = 0;
+              } while (std::chrono::steady_clock::now() < prewarmEnd);
+
+              /* Run timed iterations */
+              currBufferIdx = 0;
+              for (int iteration = 0; iteration < numIterations; iteration++) {
+                *minStartCycle = std::numeric_limits<long long int>::max();
+                *maxStopCycle = 0;
+
+#if defined(__NVCC__)
+                if (!useWallClock) {
+                  HIP_CALL(hipEventRecord(startEvent, stream));
+                }
+                kernel<<<gridDim, blockDim, 0, stream>>>(inputBuffers[currBufferIdx++], NULL, numSteps, minStartCycle, maxStopCycle);
+                if (!useWallClock) {
+                  HIP_CALL(hipEventRecord(stopEvent, stream));
+                }
+#else
+                hipExtLaunchKernelGGL(kernel, gridDim, blockDim, 0, stream, useWallClock ? NULL : startEvent, useWallClock ? NULL : stopEvent, 0,
+                                      inputBuffers[currBufferIdx], nullptr , numSteps, minStartCycle, maxStopCycle);
+#endif
+                HIP_CALL(hipStreamSynchronize(stream));
+                if (currBufferIdx == numBuffers) currBufferIdx = 0;
+
+                float elapsedMsec;
+                if (useWallClock) {
+                  elapsedMsec = (*maxStopCycle - *minStartCycle) / (double)wallClockRate;
+                } else {
+                  HIP_CALL(hipEventElapsedTime(&elapsedMsec, startEvent, stopEvent));
+                }
+
+                double bw = totalBytes / (elapsedMsec / 1000.0) / 1e9;
+
+                if (showDetails > 1) {
+                  Utils::Print("GPU %02d | %3d | %4d | %2d | %2d | %10lu | %5d | %8.3f\n",
+                               gpuIdx, numSubExec, blockSize, unroll, elemByte, totalBytes, numSteps, bw);
+                  fflush(stdout);
+                }
+
+                minBw = std::min(minBw, bw);
+                maxBw = std::max(maxBw, bw);
+                sumBw += bw;
+              }
+
+              double avgBw = sumBw / numIterations;
+
+              if (showDetails) {
+                Utils::Print("GPU %02d | %3d | %4d | %2d | %2d | %10lu | %5d | %8.3f | %8.3f | %8.3f\n",
+                             gpuIdx, numSubExec, blockSize, unroll, elemByte, totalBytes, numSteps, maxBw, avgBw, minBw);
+                fflush(stdout);
+              }
+
+              double bw[3] = {maxBw, avgBw, minBw};
+              if (bw[criteria] > bestResult.bw[criteria]) {
+                bestResult.rank       = myRank;
+                bestResult.gpuIdx     = gpuIdx;
+                bestResult.numSubExec = numSubExec;
+                bestResult.blockSize  = blockSize;
+                bestResult.unroll     = unroll;
+                bestResult.elemByte   = elemByte;
+                bestResult.bw[0]      = bw[0];
+                bestResult.bw[1]      = bw[1];
+                bestResult.bw[2]      = bw[2];
+              }
+            }
+          }
+        }
+      }
+    }
+
+    localResults.push_back(bestResult);
+
+    // Deallocate memory buffers
+    for (int bufferIdx = 0; bufferIdx < numBuffers; bufferIdx++) {
+      ErrResult err = DeallocateMemory(memType, inputBuffers[bufferIdx], largestTotalBytesPerBuffer);
+      if (err.errType != ERR_NONE) {
+        Utils::Print("[ERROR] Error when deallocating memory (%s)\n", err.errMsg.c_str());
+        return 1;
+      }
+    }
+
+    // Cleanup streams and events
+    HIP_CALL(hipStreamDestroy(stream));
+    HIP_CALL(hipEventDestroy(startEvent));
+    HIP_CALL(hipEventDestroy(stopEvent));
+  }
+  if (!showDetails) {
+    Utils::Print("\n"); fflush(stdout);
+  }
+
+  // Determine the total number of results
+  std::vector<int> numGpusOnRank(numRanks);
+  int totalGpus = 0;
+  for (int rank = 0; rank < numRanks; rank++) {
+    numGpusOnRank[rank] = (int)gpuIndices.size();
+    TransferBench::System::Get().Broadcast(rank, sizeof(int), &numGpusOnRank[rank]);
+    totalGpus += numGpusOnRank[rank];
+  }
+
+  int numRows = 1 + totalGpus;
+  int numCols = 5 + (showExtra ? 4 : 0);
+  int precision = 2;
+  Utils::TableHelper table(numRows, numCols, precision);
+
+  table.DrawRowBorder(0);
+  table.DrawRowBorder(1);
+  table.DrawColBorder(0);
+  table.DrawColBorder(2);
+  table.DrawColBorder(5);
+  table.DrawColBorder(numCols);
+
+  // Header row
+  table.Set(0, 0, " Rank ");
+  table.Set(0, 1, " GPU ");
+  table.Set(0, 2, " MaxBw (GB/s) ");
+  table.Set(0, 3, " AvgBw (GB/s) ");
+  table.Set(0, 4, " MinBw (GB/s) ");
+  if (showExtra) {
+    table.Set(0, 5, " #SE ");
+    table.Set(0, 6, " Blocksize ");
+    table.Set(0, 7, " Unroll ");
+    table.Set(0, 8, " EBytes ");
+  }
+
+  // Data rows
+  int rowIdx = 1;
+  for (int rank = 0; rank < numRanks; rank++) {
+    for (int gpu = 0; gpu < numGpusOnRank[rank]; gpu++) {
+      HbmBwResult result;
+      if (rank == myRank) result = localResults[gpu];
+      TransferBench::System::Get().Broadcast(rank, sizeof(result), &result);
+
+      table.Set(rowIdx, 0, " %d "   , result.rank);
+      table.Set(rowIdx, 1, " %d "   , result.gpuIdx);
+      table.Set(rowIdx, 2, " %8.2f ", result.bw[0]);
+      table.Set(rowIdx, 3, " %8.2f ", result.bw[1]);
+      table.Set(rowIdx, 4, " %8.2f ", result.bw[2]);
+      if (showExtra) {
+        table.Set(rowIdx, 5, " %d ", result.numSubExec);
+        table.Set(rowIdx, 6, " %d ", result.blockSize);
+        table.Set(rowIdx, 7, " %d ", result.unroll);
+        table.Set(rowIdx, 8, " %d ", result.elemByte);
+      }
+      rowIdx++;
+    }
+    table.DrawRowBorder(rowIdx);
+  }
+  table.PrintTable(outputToCsv, showBorders);
+
+  return 0;
+}

--- a/src/client/Presets/HbmBandwidth.hpp
+++ b/src/client/Presets/HbmBandwidth.hpp
@@ -105,7 +105,7 @@ void HbmReadBwKernel(const void* __restrict pSrcBuffer,
 
   // Update min/max start times
   __syncthreads();
-  if (threadIdx.x == 0 && minStartCycle != NULL) {
+  if (threadIdx.x == 0 && minStartCycle != nullptr) {
     int64_t stopTime = GetTimestamp();
     atomicMin(minStartCycle, startTime);
     atomicMax(maxStopCycle, stopTime);
@@ -464,8 +464,10 @@ int HbmBandwidthPreset(EnvVars&          ev,
               /* Run timed iterations */
               currBufferIdx = 0;
               for (int iteration = 0; iteration < numIterations; iteration++) {
-                *minStartCycle = std::numeric_limits<long long int>::max();
-                *maxStopCycle = 0;
+                if (useWallClock) {
+                  *minStartCycle = std::numeric_limits<long long int>::max();
+                  *maxStopCycle = 0;
+                }
 
 #if defined(__NVCC__)
                 if (!useWallClock) {

--- a/src/client/Presets/HealthCheck.hpp
+++ b/src/client/Presets/HealthCheck.hpp
@@ -439,9 +439,10 @@ int TestHbmPerformance(int modelId, bool verbose)
   return hasFail;
 }
 
-int HealthCheckPreset(EnvVars&           ev,
-                      size_t      const  numBytesPerTransfer,
-                      std::string const  presetName)
+int HealthCheckPreset(EnvVars&          ev,
+                      size_t      const numBytesPerTransfer,
+                      std::string const presetName,
+                      bool        const bytesSpecified)
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR] Healthcheck preset currently not supported for multi-node\n");

--- a/src/client/Presets/NicPeerToPeer.hpp
+++ b/src/client/Presets/NicPeerToPeer.hpp
@@ -122,9 +122,10 @@ int GetClosestDeviceToNic(MemType memType, int nicIdx, int rank) {
          TransferBench::GetClosestGpuToNic(nicIdx, rank);
 }
 
-int NicPeerToPeerPreset(EnvVars&           ev,
-                        size_t      const  numBytesPerTransfer,
-                        std::string const  presetName)
+int NicPeerToPeerPreset(EnvVars&          ev,
+                        size_t      const numBytesPerTransfer,
+                        std::string const presetName,
+                        bool        const bytesSpecified)
 {
   if (Utils::GetNumRankGroups() > 1) {
     Utils::Print("[ERROR] NIC p2p preset can only be run across ranks that are homogenous\n");

--- a/src/client/Presets/NicRings.hpp
+++ b/src/client/Presets/NicRings.hpp
@@ -20,9 +20,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-int NicRingsPreset(EnvVars&           ev,
-                   size_t      const  numBytesPerTransfer,
-                   std::string const  presetName)
+int NicRingsPreset(EnvVars&          ev,
+                   size_t      const numBytesPerTransfer,
+                   std::string const presetName,
+                   bool        const bytesSpecified)
 {
 
   // Check for single homogenous group

--- a/src/client/Presets/OneToAll.hpp
+++ b/src/client/Presets/OneToAll.hpp
@@ -20,9 +20,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-int OneToAllPreset(EnvVars&           ev,
-                   size_t      const  numBytesPerTransfer,
-                   std::string const  presetName)
+int OneToAllPreset(EnvVars&          ev,
+                   size_t      const numBytesPerTransfer,
+                   std::string const presetName,
+                   bool        const bytesSpecified)
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR] One-to-All preset currently not supported for multi-node\n");

--- a/src/client/Presets/PeerToPeer.hpp
+++ b/src/client/Presets/PeerToPeer.hpp
@@ -20,9 +20,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-int PeerToPeerPreset(EnvVars&           ev,
-                     size_t      const  numBytesPerTransfer,
-                     std::string const  presetName)
+int PeerToPeerPreset(EnvVars&          ev,
+                     size_t      const numBytesPerTransfer,
+                     std::string const presetName,
+                     bool        const bytesSpecified)
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR] Peer-to-peer preset currently not supported for multi-node\n");

--- a/src/client/Presets/PodAllToAll.hpp
+++ b/src/client/Presets/PodAllToAll.hpp
@@ -41,9 +41,10 @@ void StrideGenerate(std::vector<int>& list, int k) {
   list = std::move(out);
 }
 
-int PodAllToAllPreset(EnvVars&           ev,
-                      size_t      const  numBytesPerTransfer,
-                      std::string const  presetName)
+int PodAllToAllPreset(EnvVars&          ev,
+                      size_t      const numBytesPerTransfer,
+                      std::string const presetName,
+                      bool        const bytesSpecified)
 {
   enum
   {

--- a/src/client/Presets/PodPeerToPeer.hpp
+++ b/src/client/Presets/PodPeerToPeer.hpp
@@ -20,9 +20,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-int PodPeerToPeerPreset(EnvVars&           ev,
-                        size_t      const  numBytesPerTransfer,
-                        std::string const  presetName)
+int PodPeerToPeerPreset(EnvVars&          ev,
+                        size_t      const numBytesPerTransfer,
+                        std::string const presetName,
+                        bool        const bytesSpecified)
 {
   if (Utils::GetNumRankGroups() > 1) {
     Utils::Print("[ERROR] Pod p2p preset can only be run across ranks that are homogenous\n");

--- a/src/client/Presets/Presets.hpp
+++ b/src/client/Presets/Presets.hpp
@@ -45,7 +45,7 @@ THE SOFTWARE.
 typedef int (*PresetFunc)(EnvVars&          ev,
                           size_t      const numBytesPerTransfer,
                           std::string const presetName,
-                          bool        const bytesSpecified);
+                          [[maybe_unused]] bool const bytesSpecified);
 
 std::map<std::string, std::pair<PresetFunc, std::string>> presetFuncMap =
 {

--- a/src/client/Presets/Presets.hpp
+++ b/src/client/Presets/Presets.hpp
@@ -44,7 +44,8 @@ THE SOFTWARE.
 
 typedef int (*PresetFunc)(EnvVars&          ev,
                           size_t      const numBytesPerTransfer,
-                          std::string const presetName);
+                          std::string const presetName,
+                          bool        const bytesSpecified);
 
 std::map<std::string, std::pair<PresetFunc, std::string>> presetFuncMap =
 {
@@ -80,8 +81,9 @@ int RunPreset(EnvVars&       ev,
               int&           retCode)
 {
   std::string preset = (argc > 1 ? argv[1] : "");
+  bool bytesSpecified = (argc > 2);
   if (presetFuncMap.count(preset)) {
-    retCode = (presetFuncMap[preset].first)(ev, numBytesPerTransfer, preset);
+    retCode = (presetFuncMap[preset].first)(ev, numBytesPerTransfer, preset, bytesSpecified);
     return 1;
   }
   return 0;

--- a/src/client/Presets/Presets.hpp
+++ b/src/client/Presets/Presets.hpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "AllToAll.hpp"
 #include "AllToAllN.hpp"
 #include "AllToAllSweep.hpp"
+#include "HbmBandwidth.hpp"
 #include "HealthCheck.hpp"
 #include "NicRings.hpp"
 #include "NicPeerToPeer.hpp"
@@ -50,6 +51,7 @@ std::map<std::string, std::pair<PresetFunc, std::string>> presetFuncMap =
   {"a2a",         {AllToAllPreset,      "Tests parallel transfers between all pairs of GPU devices"}},
   {"a2a_n",       {AllToAllRdmaPreset,  "Tests parallel transfers between all pairs of GPU devices using Nearest NIC RDMA transfers"}},
   {"a2asweep",    {AllToAllSweepPreset, "Test GFX-based all-to-all transfers swept across different CU and GFX unroll counts"}},
+  {"hbm",         {HbmBandwidthPreset,  "Tests HBM bandwidth"}},
   {"healthcheck", {HealthCheckPreset,   "Simple bandwidth health check (MI300X series only)"}},
   {"nicrings",    {NicRingsPreset,      "Tests NIC rings created across identical NIC indices across ranks"}},
   {"nicp2p",      {NicPeerToPeerPreset, "Multi-node peer-to-peer RDMA transfer test between all NICs"}},

--- a/src/client/Presets/Scaling.hpp
+++ b/src/client/Presets/Scaling.hpp
@@ -20,9 +20,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-int ScalingPreset(EnvVars&           ev,
-                  size_t      const  numBytesPerTransfer,
-                  std::string const  presetName)
+int ScalingPreset(EnvVars&          ev,
+                  size_t      const numBytesPerTransfer,
+                  std::string const presetName,
+                  bool        const bytesSpecified)
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR] Scaling preset currently not supported for multi-node\n");

--- a/src/client/Presets/Schmoo.hpp
+++ b/src/client/Presets/Schmoo.hpp
@@ -19,9 +19,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-int SchmooPreset(EnvVars&           ev,
-                 size_t      const  numBytesPerTransfer,
-                 std::string const  presetName)
+int SchmooPreset(EnvVars&          ev,
+                 size_t      const numBytesPerTransfer,
+                 std::string const presetName,
+                 bool        const bytesSpecified)
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR] Schmoo preset currently not supported for multi-node\n");

--- a/src/client/Presets/Sweep.hpp
+++ b/src/client/Presets/Sweep.hpp
@@ -39,9 +39,10 @@ void LogTransfers(FILE *fp, int const testNum, std::vector<Transfer> const& tran
   }
 }
 
-int SweepPreset(EnvVars&           ev,
-                size_t      const  numBytesPerTransfer,
-                std::string const  presetName)
+int SweepPreset(EnvVars&          ev,
+                size_t      const numBytesPerTransfer,
+                std::string const presetName,
+                bool        const bytesSpecified)
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR] Sweep preset currently not supported for multi-node\n");

--- a/src/client/Utilities.hpp
+++ b/src/client/Utilities.hpp
@@ -149,6 +149,11 @@ namespace TransferBench::Utils
   std::string GetAllGpuMemTypeStr();
   std::string GetAllMemTypeStr(bool isCpu);
 
+  // Helper forwarders to allocation/deallocation functions
+  // Returns true if error occurs
+  bool AllocateMemory(MemDevice memDevice, size_t numBytes, void** memPtr);
+  bool DeallocateMemory(MemType memType, void *memPtr, size_t const bytes);
+
   // Implementation details below
   //================================================================
   TableHelper::TableHelper(int numRows, int numCols, int precision) :
@@ -409,6 +414,46 @@ namespace TransferBench::Utils
     }
     return ss.str();
   }
+
+  template <typename T>
+  struct is_std_vector : std::false_type {};
+
+  template <typename T, typename Alloc>
+  struct is_std_vector<std::vector<T, Alloc>> : std::true_type {};
+
+  // This function can be used to check if a value is identical across ranks
+  template <typename T>
+  bool IsUniform(const T& val) {
+    if constexpr (is_std_vector<T>::value) {
+      using Elem = typename T::value_type;
+      static_assert(std::is_trivially_copyable_v<Elem>, "vector element must be trivially copyable");
+
+      size_t size = val.size();
+      size_t rootSize = size;
+      System::Get().Broadcast(0, sizeof(rootSize), &rootSize);
+      if (size != rootSize) return false;
+
+      std::vector<Elem> ref = val;
+      System::Get().Broadcast(0, rootSize * sizeof(Elem), ref.data());
+
+      return (std::memcmp(ref.data(), val.data(), rootSize * sizeof(Elem)) == 0);
+    } else {
+      static_assert(std::is_trivially_copyable_v<T>, "Type must be trivially copyable");
+      T ref = val;
+      System::Get().Broadcast(0, sizeof(T), &ref);
+
+      return (std::memcmp(&ref, &val, sizeof(T)) == 0);
+    }
+  }
+
+  // Macro for use in presets that will return 1 if a value is not uniform across ranks
+#define IS_UNIFORM(val, name)                                                      \
+  do {                                                                             \
+    if (!Utils::IsUniform(val)) {                                                  \
+      Utils::Print("[ERROR] %s must be uniform across all ranks\n", name); \
+      return 1;                                                                    \
+    }                                                                              \
+  } while(0)
 
   // Helper function to determine if current rank does output
   bool RankDoesOutput()
@@ -713,4 +758,14 @@ namespace TransferBench::Utils
   {
     return isCpu ? GetAllCpuMemTypeStr() : GetAllGpuMemTypeStr();
   }
+
+  bool AllocateMemory(MemDevice memDevice, size_t numBytes, void** memPtr)
+  {
+    return (TransferBench::AllocateMemory(memDevice, numBytes, memPtr).errType != TransferBench::ERR_NONE);
+  }
+  bool DeallocateMemory(MemType memType, void *memPtr, size_t const bytes)
+  {
+    return (TransferBench::DeallocateMemory(memType, memPtr, bytes).errType != TransferBench::ERR_NONE);
+  }
+
 };

--- a/src/client/Utilities.hpp
+++ b/src/client/Utilities.hpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #pragma once
 #include <unordered_map>
 #include <unordered_set>
+#include <type_traits>
 #include "TransferBench.hpp"
 
 namespace TransferBench::Utils

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3877,7 +3877,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
         bool requiresFabricHandle = (srcMemDevice.memRank != exeDevice.exeRank) && IsGpuExeType(exeDevice.exeType);
         if (srcMemDevice.memRank == localRank) {
           ERR_CHECK(AllocateMemory(srcMemDevice, t.numBytes + cfg.data.byteOffset, (void**)&rss.srcMem[iSrc],
-                                   &rss.srcActualBytes[iSrc], requiresFabricHandle ? &rss.srcMemHandle[iSrc] : NULL));
+                                   &rss.srcActualBytes[iSrc], requiresFabricHandle ? &rss.srcMemHandle[iSrc] : nullptr));
         }
 
         // Exchange memory pointer across ranks
@@ -6199,7 +6199,6 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 #if defined(__NVCC__)
 #ifdef NVML_ENABLED
     if (!MnnvlCheck()) return;
-    int flag;
     char busId[] = "00000000:00:00.0";
     if (cudaDeviceGetPCIBusId(busId, sizeof(busId), 0)) return;
 


### PR DESCRIPTION
## Motivation
This PR adds a new HBM bandwidth preset `hbm`, which sweeps over various GFX options to find the maximum attainable read bandwidth.  Sweep options include which GPUs to target `GPU_INDICES`, number of subexecutors (CUs/WGPs) to use `NUM_SUB_EXECS`, unrolling factors `UNROLLS`, and element bytes sizes `ELEM_BYTES`.  

Usage: `./TransferBench hbm <numBytesAtLeast=1GB>`


## Technical Details
This preset contains its own specialized / simplified HIP kernel which is optimized for HBM reads, separate from the main TransferBench MIMO Transfer kernel.  GPU wallclock timestamps are used by default to measure time (skips kernel launch latency) `USE_WALLCLOCK`, with HIP event timing being the alternative method of time measurement (includes kernel launch latency).  Each threadblock is assigned an identical amount of data to read, such that unroll and threadblock size are accounted for, so that the total amount of data read across all threadblocks is greater than or equal to the optional numBytesAtLeast argument.  A time-based pre-warm is executed first `PREWARM_MSEC`, before some number of iterations are executed `NUM_ITERATIONS`.  In total there are `NUM_BUFFER` input buffers allocated (according to `MEM_TYPE`) and initialized with pseudo random data.  Each iteration cycles through these different input buffers.

To get more information about runs, users can set `SHOW_EXTRA` to see which options resulted in the best bandwidth based on the criteria set by `CRITERIA` (max/avg/min bandwidth).  Setting `SHOW_DETAILS` to 1 will show per config results, and setting to 2 will show per iteration results.

This preset supports multi-rank is supported - results will be collected then reported across all GPUs / all ranks.
This preset should also run on NVIDIA hardware, although some memory types aren't supported.

## Test Plan
Collected some sample results on machines.  Repeats appear to be quite consistent between runs, as well as between (max/avg/min).

MI300X:
```
[HBM Bandwidth Related]
BLOCKSIZES           =      256,512 : Threadblock sizes to sweep over (multiple of 128 up to 1024)
CRITERIA             =            0 : Reporting highest MAX bandwidth (0=MAX,1=AVG,2=MIN)
ELEM_BYTES           =         16,8 : Element sizes in bytes to sweep over (must contain only 4,8 or 16)
GPU_INDICES          =              : GPU indices to test.  Leave empty for all
MEM_TYPE             =            0 : Using default GPU memory (0=default, 1=fine-grained, 2=uncached, 3=managed)
NUM_BUFFERS          =            2 : Number of buffers to rotate through (1 per iteration)
NUM_ITERATIONS       =          100 : Number of iterations to time
NUM_SUB_EXECS        =          304 : Number of subexecutors to sweep over (default to all available)
PREWARM_MSEC         =           50 : Prewarm duration in msec
SHOW_DETAILS         =            0 : Show sweep details (ignored for multi-rank).  Setting to 2 shows per iteration output
SHOW_EXTRA           =            0 : Show best sweep config details
TEMPORAL_MASK        =            3 : Temporal mask (1 = temporal, 2 = non-temporal, 3 = both)
UNROLLS              =       16,8,4 : Unroll factors to sweep over (must contain only 1,2,4,8 or 16)
USE_WALLCLOCK        =            1 : Using GPU wall-clock for timing

Testing on at least 1073741824 bytes (24 configs per GPU): ................
┌------------┬--------------------------------------------┐
│ Rank   GPU │ MaxBw (GB/s)   AvgBw (GB/s)   MinBw (GB/s) │
├------------┼--------------------------------------------┤
│    0     0 │      5080.94        5052.32        4988.59 │
│    0     1 │      5083.34        5056.90        5024.94 │
│    0     2 │      5083.34        5060.90        5003.90 │
│    0     3 │      5080.70        5051.52        5016.03 │
│    0     4 │      5066.11        5044.05        4998.79 │
│    0     5 │      5077.83        5047.59        5020.01 │
│    0     6 │      5072.32        5048.55        5019.31 │
│    0     7 │      5080.70        5049.15        4969.92 │
└------------┴--------------------------------------------┘
```



