### PR TITLE
Modification to A2A presets

### DIFF
--- a/src/client/Presets/NicAllToAll.hpp
+++ b/src/client/Presets/NicAllToAll.hpp
@@ -67,24 +67,24 @@ int NicAllToAllPreset(EnvVars&                    ev,
 
   if (numPlanes < 1) {
     Utils::Print("[ERROR] NUM_PLANES must be >= 1 (got %d)\n", numPlanes);
-    return 1;
+    return ERR_FATAL;
   }
   if (N % numPlanes) {
     Utils::Print("[ERROR] NUM_PLANES (%d) must divide total NICs (%d = %d ranks * %d nics/rank).\n",
                  numPlanes, N, numRanks, numNicsPerRank);
-    return 1;
+    return ERR_FATAL;
   }
   int const planeSize = N / numPlanes;
 
   // NUM_GROUPS = groups per plane. Default 1 -> one group per plane (full a2a within each plane).
   if (numGroups < 1) {
     Utils::Print("[ERROR] NUM_GROUPS must be >= 1 (got %d)\n", numGroups);
-    return 1;
+    return ERR_FATAL;
   }
   if (planeSize % numGroups) {
     Utils::Print("[ERROR] NUM_GROUPS (%d) must divide plane size (%d = %d total NICs / %d planes).\n",
                  numGroups, planeSize, N, numPlanes);
-    return 1;
+    return ERR_FATAL;
   }
   int const groupSize = planeSize / numGroups;
 

--- a/src/client/Presets/NicAllToAll.hpp
+++ b/src/client/Presets/NicAllToAll.hpp
@@ -106,7 +106,7 @@ int NicAllToAllPreset(EnvVars&                    ev,
       ev.Print("NUM_PLANES"         , numPlanes    , "Splitting %d total NICs into %d plane(s) of %d NICs each", N, numPlanes, planeSize);
       ev.Print("GROUP_STRIDE"        , groupStride   , "Stride permutation within each plane before splitting into groups");
       ev.Print("NUM_GROUPS"          , numGroups     , "Splitting each plane into %d group(s) of %d NICs each", numGroups, groupSize);
-      ev.Print("A2A_LOCAL"           , a2aLocal      , "%s local (same-rank) transfers", a2aLocal ? "Include" : "Exclude");
+      ev.Print("A2A_LOCAL"           , a2aLocal      , "%s self NIC endpoint transfers", a2aLocal ? "Include" : "Exclude");
       ev.Print("NUM_QUEUE_PAIRS"     , numQueuePairs , "Using %d queue pairs for NIC transfers", numQueuePairs);
       ev.Print("SHOW_DETAILS"        , showDetails   , "%s full Test details", showDetails ? "Showing" : "Hiding");
       ev.Print("USE_RDMA_READ"       , useRdmaRead   , "Performing RDMA %s", useRdmaRead ? "reads" : "writes");

--- a/src/client/Presets/NicAllToAll.hpp
+++ b/src/client/Presets/NicAllToAll.hpp
@@ -52,78 +52,49 @@ int NicAllToAllPreset(EnvVars&                    ev,
     return 1;
   }
 
+  // Total NICs across all ranks (rank-major id: nicId = rank * numNicsPerRank + nic).
+  int const N = numRanks * numNicsPerRank;
+
+  int planeStride   = EnvVars::GetEnvVar("PLANE_STRIDE"   , 1);
+  int numPlanes     = EnvVars::GetEnvVar("NUM_PLANES"     , 1);
+  int groupStride   = EnvVars::GetEnvVar("GROUP_STRIDE"   , 1);
+  int numGroups     = EnvVars::GetEnvVar("NUM_GROUPS"     , 1);
   int numQueuePairs = EnvVars::GetEnvVar("NUM_QUEUE_PAIRS", 1);
-  int showDetails   = EnvVars::GetEnvVar("SHOW_DETAILS", 0);
-  int useRdmaRead   = EnvVars::GetEnvVar("USE_RDMA_READ", 0);
-  int memTypeIdx    = EnvVars::GetEnvVar("MEM_TYPE", 0);
-  int stride        = EnvVars::GetEnvVar("STRIDE", 1);
+  int showDetails   = EnvVars::GetEnvVar("SHOW_DETAILS"   , 0);
+  int useRdmaRead   = EnvVars::GetEnvVar("USE_RDMA_READ"  , 0);
+  int memTypeIdx    = EnvVars::GetEnvVar("MEM_TYPE"       , 0);
+  int a2aLocal      = EnvVars::GetEnvVar("A2A_LOCAL"      , 0);
 
-  // Compute orbit structure before reading GROUP_SIZE so its default can be stride-aware.
-  // Stride orbits on devices (rank-major devLin = rank * numMemDevices + memIdx): same gcd structure as PodAllToAll's StrideGenerate,
-  // but NIC A2A does not use the permuted slot order for GROUP_SIZE — subgroups follow natural order within each orbit.
-  int const M         = numRanks * numMemDevices;
-  int const kNorm     = ((stride % M) + M) % M;
-  int const dCycles   = (kNorm == 0) ? 1 : std::gcd(kNorm, M);
-  int const orbitSize = M / dCycles;
+  if (numPlanes < 1) {
+    Utils::Print("[ERROR] NUM_PLANES must be >= 1 (got %d)\n", numPlanes);
+    return 1;
+  }
+  if (N % numPlanes) {
+    Utils::Print("[ERROR] NUM_PLANES (%d) must divide total NICs (%d = %d ranks * %d nics/rank).\n",
+                 numPlanes, N, numRanks, numNicsPerRank);
+    return 1;
+  }
+  int const planeSize = N / numPlanes;
 
-  int groupSize    = EnvVars::GetEnvVar("GROUP_SIZE", orbitSize);
-  int noSameRank   = EnvVars::GetEnvVar("NIC_A2A_NO_SAME_RANK", 1);
-  int numNicPlanes = EnvVars::GetEnvVar("NUM_NIC_PLANES", 1);
+  // NUM_GROUPS = groups per plane. Default 1 -> one group per plane (full a2a within each plane).
+  if (numGroups < 1) {
+    Utils::Print("[ERROR] NUM_GROUPS must be >= 1 (got %d)\n", numGroups);
+    return 1;
+  }
+  if (planeSize % numGroups) {
+    Utils::Print("[ERROR] NUM_GROUPS (%d) must divide plane size (%d = %d total NICs / %d planes).\n",
+                 numGroups, planeSize, N, numPlanes);
+    return 1;
+  }
+  int const groupSize = planeSize / numGroups;
 
   if (numQueuePairs < 1) {
     Utils::Print("[ERROR] NUM_QUEUE_PAIRS must be >= 1 (got %d)\n", numQueuePairs);
     return 1;
   }
-  if (groupSize < 1) {
-    Utils::Print("[ERROR] GROUP_SIZE must be >= 1 (got %d)\n", groupSize);
-    return 1;
-  }
-
-  bool scopeInter = false;
-  {
-    char const* scopeStr = getenv("NIC_A2A_SCOPE");
-    if (scopeStr && scopeStr[0]) {
-      if (!strcmp(scopeStr, "inter") || !strcmp(scopeStr, "INTER"))
-        scopeInter = true;
-      else if (strcmp(scopeStr, "intra") && strcmp(scopeStr, "INTRA")) {
-        Utils::Print("[ERROR] NIC_A2A_SCOPE must be \"intra\" or \"inter\"\n");
-        return 1;
-      }
-    }
-  }
 
   MemType memType        = Utils::GetMemType(memTypeIdx, useCpuMem);
   std::string memTypeStr = Utils::GetMemTypeStr(memTypeIdx, useCpuMem);
-
-  if (numNicPlanes < 1) {
-    Utils::Print("[ERROR] NUM_NIC_PLANES must be >= 1\n");
-    return 1;
-  }
-
-  // Same divisibility check as PodAllToAll (total devices = ranks × memory devices per rank).
-  if (M % groupSize) {
-    Utils::Print("[ERROR] Group size %d cannot evenly divide %d total devices from %d ranks.\n",
-                 groupSize, M, numRanks);
-    return 1;
-  }
-
-  // Within each stride orbit, partition by natural rank-major device index: orbit lists devLin = r, r+d, r+2d, ...
-  // (r = devLin %% dCycles). Subgroup id = (index along that list) / GROUP_SIZE.
-  if (orbitSize % groupSize != 0) {
-    Utils::Print("[ERROR] GROUP_SIZE (%d) must divide stride-cycle size %d (devices M=%d, orbits=%d).\n",
-                 groupSize, orbitSize, M, dCycles);
-    Utils::Print("[ERROR] With STRIDE=%d there are %d disjoint cycles; use a GROUP_SIZE that divides each cycle's device count,\n",
-                 stride, dCycles);
-    Utils::Print("[ERROR] or use STRIDE=1 so the cycle size equals total devices (%d).\n", M);
-    return 1;
-  }
-
-  std::vector<int> deviceSubgroup(M);
-  for (int devLin = 0; devLin < M; devLin++) {
-    int const r = devLin % dCycles;
-    int const k = (devLin - r) / dCycles;  // 0 .. orbitSize-1 along natural order in this orbit
-    deviceSubgroup[devLin] = k / groupSize;
-  }
 
   if (Utils::RankDoesOutput()) {
     ev.DisplayEnvVars();
@@ -131,14 +102,11 @@ int NicAllToAllPreset(EnvVars&                    ev,
       if (!ev.outputToCsv) printf("[NIC A2A Related]\n");
       ev.Print("USE_CPU_MEM"         , useCpuMem     , "Using closest %s memory", useCpuMem ? "CPU" : "GPU");
       ev.Print("MEM_TYPE"            , memTypeIdx    , "Using %s memory (%s)", memTypeStr.c_str(), Utils::GetAllMemTypeStr(useCpuMem).c_str());
-      ev.Print("STRIDE"              , stride        , "Reordering devices by taking %d steps", stride);
-      ev.Print("GROUP_SIZE"          , groupSize     , "Dividing all devices into groups of %d for a2a", groupSize);
-      ev.Print("NUM_NIC_PLANES"      , numNicPlanes  , "Number of planes on scale-out");
-      if (scopeInter)
-        ev.Print("NIC_A2A_SCOPE"     , "inter"       , "Between-group transfers only. Other value: intra");
-      else
-        ev.Print("NIC_A2A_SCOPE"     , "intra"       , "Within-group transfers only. Other value: inter");
-      ev.Print("NIC_A2A_NO_SAME_RANK", noSameRank    , "%s transfers where src rank == dst rank", noSameRank ? "Excluding" : "Allowing");
+      ev.Print("PLANE_STRIDE"        , planeStride   , "Stride permutation on global NIC list before splitting into planes");
+      ev.Print("NUM_PLANES"         , numPlanes    , "Splitting %d total NICs into %d plane(s) of %d NICs each", N, numPlanes, planeSize);
+      ev.Print("GROUP_STRIDE"        , groupStride   , "Stride permutation within each plane before splitting into groups");
+      ev.Print("NUM_GROUPS"          , numGroups     , "Splitting each plane into %d group(s) of %d NICs each", numGroups, groupSize);
+      ev.Print("A2A_LOCAL"           , a2aLocal      , "%s local (same-rank) transfers", a2aLocal ? "Include" : "Exclude");
       ev.Print("NUM_QUEUE_PAIRS"     , numQueuePairs , "Using %d queue pairs for NIC transfers", numQueuePairs);
       ev.Print("SHOW_DETAILS"        , showDetails   , "%s full Test details", showDetails ? "Showing" : "Hiding");
       ev.Print("USE_RDMA_READ"       , useRdmaRead   , "Performing RDMA %s", useRdmaRead ? "reads" : "writes");
@@ -166,38 +134,50 @@ int NicAllToAllPreset(EnvVars&                    ev,
     }
   }
 
-  auto devLinOf = [&](int rank, int memIdx) -> int { return rank * numMemDevices + memIdx; };
+  // Build planes: take the rank-major NIC list [0..N), permute by PLANE_STRIDE, chunk consecutively.
+  // Within each plane: permute by GROUP_STRIDE, chunk consecutively into groups.
+  // Each group runs an internal all-to-all; all groups (across all planes) run concurrently.
+  std::vector<int> nicList(N);
+  std::iota(nicList.begin(), nicList.end(), 0);
+  Utils::StrideGenerate(nicList, planeStride);
 
-  // NIC plane: independent of STRIDE over memory devices. Global rank-major order over NIC endpoints, round-robin into P planes.
-  auto nicPlaneOf = [&](int rank, int nic) -> int {
-    int const L = rank * numNicsPerRank + nic;
-    return L % numNicPlanes;
+  struct GroupInfo {
+    int              planeIdx;
+    int              groupIdx;
+    std::vector<int> memberNicIds;   // global NIC ids in this group (post-stride order)
+    size_t           transferStart;  // first index into `transfers`
+    size_t           transferEnd;    // one past last index into `transfers`
   };
+  std::vector<std::vector<int>> planeMembers(numPlanes);
+  std::vector<GroupInfo>        allGroups;
+  allGroups.reserve((size_t)numPlanes * numGroups);
 
   std::vector<Transfer> transfers;
 
-  auto const acceptPair = [&](int srcRank, int srcNic, int dstRank, int dstNic) -> bool {
-    if (nicPlaneOf(srcRank, srcNic) != nicPlaneOf(dstRank, dstNic))
-      return false;
-    int srcDevLin = devLinOf(srcRank, nicToMem[srcRank][srcNic]);
-    int dstDevLin = devLinOf(dstRank, nicToMem[dstRank][dstNic]);
-    if ((srcDevLin % dCycles) != (dstDevLin % dCycles))
-      return false;
-    if (noSameRank && srcRank == dstRank)
-      return false;
-    if (scopeInter)
-      return deviceSubgroup[srcDevLin] != deviceSubgroup[dstDevLin];
-    return deviceSubgroup[srcDevLin] == deviceSubgroup[dstDevLin];
-  };
+  for (int p = 0; p < numPlanes; p++) {
+    std::vector<int> planeNics(nicList.begin() + (size_t)p * planeSize,
+                                nicList.begin() + (size_t)(p + 1) * planeSize);
+    planeMembers[p] = planeNics;  // pre-group-stride membership for display
+    Utils::StrideGenerate(planeNics, groupStride);
 
-  for (int srcRank = 0; srcRank < numRanks; srcRank++) {
-    for (int srcNic = 0; srcNic < numNicsPerRank; srcNic++) {
-      int srcMem = nicToMem[srcRank][srcNic];
-      for (int dstRank = 0; dstRank < numRanks; dstRank++) {
-        for (int dstNic = 0; dstNic < numNicsPerRank; dstNic++) {
-          if (!acceptPair(srcRank, srcNic, dstRank, dstNic)) continue;
+    for (int g = 0; g < numGroups; g++) {
+      GroupInfo gi;
+      gi.planeIdx = p;
+      gi.groupIdx = g;
+      gi.memberNicIds.assign(planeNics.begin() + (size_t)g * groupSize,
+                             planeNics.begin() + (size_t)(g + 1) * groupSize);
+      gi.transferStart = transfers.size();
 
-          int dstMem = nicToMem[dstRank][dstNic];
+      for (int srcId : gi.memberNicIds) {
+        int const srcRank = srcId / numNicsPerRank;
+        int const srcNic  = srcId % numNicsPerRank;
+        int const srcMem  = nicToMem[srcRank][srcNic];
+        for (int dstId : gi.memberNicIds) {
+          int const dstRank = dstId / numNicsPerRank;
+          int const dstNic  = dstId % numNicsPerRank;
+          if (!a2aLocal && srcId == dstId) continue;
+
+          int const dstMem = nicToMem[dstRank][dstNic];
 
           TransferBench::Transfer transfer;
           transfer.srcs.push_back({memType, srcMem, srcRank});
@@ -206,31 +186,61 @@ int NicAllToAllPreset(EnvVars&                    ev,
           transfer.exeSubIndex = useRdmaRead ? srcNic : dstNic;
           transfer.numSubExecs = numQueuePairs;
           transfer.numBytes    = numBytesPerTransfer;
-
           transfers.push_back(transfer);
         }
       }
+      gi.transferEnd = transfers.size();
+      allGroups.push_back(std::move(gi));
     }
   }
 
   Utils::Print("NIC All-To-All benchmark\n");
   Utils::Print("========================\n");
-  Utils::Print("%s traffic over NIC executors. %d rank-major devices; STRIDE sets gcd-orbits; GROUP_SIZE chunks each orbit in natural order.\n",
-               useCpuMem ? "CPU" : "GPU", M);
-  Utils::Print("NICs map to devices via closest %s;\n", useCpuMem ? "CPU NUMA node" : "GPU");
-  Utils::Print("NIC planes: %d , traffic only between NICs in the same plane. Stride: %d\n",
-               numNicPlanes, stride);
-  Utils::Print("Using closest %s per NIC endpoint and %s memory.\n",
-               useCpuMem ? "CPU NUMA node" : "GPU", memTypeStr.c_str());
-  Utils::Print("Visible NICs per rank: %d\n", numNicsPerRank);
-  Utils::Print("%d queue pairs per NIC.  %lu bytes per Transfer.  All numbers are GB/s\n",
-               numQueuePairs, numBytesPerTransfer);
-  Utils::Print("Total transfers: %lu\n\n", transfers.size());
+  Utils::Print("[%lu bytes per Transfer] [Total Transfers: %lu] [MemType:%s] [NIC QueuePairs:%d] [#Ranks:%d]\n",
+               numBytesPerTransfer, transfers.size(), memTypeStr.c_str(), numQueuePairs, numRanks);
+  Utils::Print("Running %d parallel a2a group(s) each of %d devices.  All numbers in GB/s:\n", numGroups, groupSize);
+  Utils::Print("%d total NICs (rank-major) split into %d plane(s) of %d NICs (PLANE_STRIDE=%d).\n",
+               N, numPlanes, planeSize, planeStride);
+  Utils::Print("Each plane split into %d group(s) of %d NICs (GROUP_STRIDE=%d).\n",
+               numGroups, groupSize, groupStride);
+  
 
   if (transfers.empty()) {
     Utils::Print("[WARN] No transfers were generated for this preset.\n");
     return 0;
   }
+
+  // Print the plane / group breakdown up-front (before running) so the user can
+  // see the rank-by-rank NIC layout that's about to be tested.
+  Utils::Print("[Plane / Group breakdown]\n");
+  {
+    size_t groupCursor = 0;
+    for (int p = 0; p < numPlanes; p++) {
+      Utils::Print("Plane %02d (%d NICs):\n", p, (int)planeMembers[p].size());
+      for (int g = 0; g < numGroups; g++, groupCursor++) {
+        auto const& gi = allGroups[groupCursor];
+        Utils::Print("  Group %02d (%d NICs): -> %lu transfers\n",
+                     g, (int)gi.memberNicIds.size(),
+                     gi.transferEnd - gi.transferStart);
+
+        std::map<int, std::vector<int>> ranksToLocals;
+        for (int id : gi.memberNicIds)
+          ranksToLocals[id / numNicsPerRank].push_back(id % numNicsPerRank);
+        for (auto& kv : ranksToLocals)
+          std::sort(kv.second.begin(), kv.second.end());
+
+        for (auto const& [rank, locals] : ranksToLocals) {
+          std::string names;
+          for (size_t k = 0; k < locals.size(); k++) {
+            if (k) names += ", ";
+            names += TransferBench::GetExecutorName({EXE_NIC, locals[k], rank});
+          }
+          Utils::Print("    Rank %02d: %s\n", rank, names.c_str());
+        }
+      }
+    }
+  }
+  Utils::Print("\n");
 
   TransferBench::ConfigOptions cfg = ev.ToConfigOptions();
   TransferBench::TestResults results;
@@ -245,124 +255,197 @@ int NicAllToAllPreset(EnvVars&                    ev,
 
   if (!Utils::RankDoesOutput()) return 0;
 
-  int numRows = 6 + numRanks;
-  int numCols = 3 + numNicsPerRank;
-  Utils::TableHelper table(numRows, numCols);
+  // Per-group SRC->DST bandwidth matrix (one table per group), styled to match
+  // the PodAllToAll preset: outer columns/rows are ranks, with each rank's NICs
+  // packed as fixed-width sub-cells inside one cell.
+  size_t groupCursor = 0;
+  for (int p = 0; p < numPlanes; p++) {
+    for (int g = 0; g < numGroups; g++, groupCursor++) {
+      auto const& gi = allGroups[groupCursor];
 
-  table.Set(2, 0, " Rank ");
-  table.Set(2, 1, " Name ");
-  table.Set(1, numCols - 1, " TOTAL ");
-  table.Set(2, numCols - 1, " (GB/s) ");
-  table.SetColAlignment(1, Utils::TableHelper::ALIGN_LEFT);
-  for (int rank = 0; rank < numRanks; rank++) {
-    table.Set(3 + rank, 0, " %d ", rank);
-    table.Set(3 + rank, 1, " %s ", TransferBench::GetHostname(rank).c_str());
-  }
-  table.Set(numRows - 3, 1, " MAX (GB/s) ");
-  table.Set(numRows - 2, 1, " AVG (GB/s) ");
-  table.Set(numRows - 1, 1, " MIN (GB/s) ");
-  for (int row = numRows - 3; row < numRows; row++)
-    table.SetCellAlignment(row, 1, Utils::TableHelper::ALIGN_RIGHT);
-  table.DrawRowBorder(3);
-  table.DrawRowBorder(numRows - 3);
-
-  std::vector<std::vector<double>> bwByRankNic(numRanks, std::vector<double>(numNicsPerRank, 0.0));
-  for (size_t i = 0; i < results.tfrResults.size(); i++) {
-    int nicIdx  = results.tfrResults[i].exeDevice.exeIndex;
-    int rankIdx = results.tfrResults[i].exeDevice.exeRank;
-    bwByRankNic[rankIdx][nicIdx] += results.tfrResults[i].avgBandwidthGbPerSec;
-  }
-
-  std::vector<bool> nicHasMixedMemMapping(numNicsPerRank, false);
-  bool hasMixedMemMapping = false;
-  for (int nic = 0; nic < numNicsPerRank; nic++) {
-    int refMem = nicToMem[0][nic];
-    for (int rank = 1; rank < numRanks; rank++) {
-      if (nicToMem[rank][nic] != refMem) {
-        nicHasMixedMemMapping[nic] = true;
-        hasMixedMemMapping = true;
-        break;
+      // Rebuild (srcId,dstId) -> transfer index lookup using the same iteration
+      // order used when transfers were generated above.
+      std::map<std::pair<int,int>, size_t> pairIdx;
+      {
+        size_t idx = gi.transferStart;
+        for (int srcId : gi.memberNicIds) {
+          for (int dstId : gi.memberNicIds) {
+            if (!a2aLocal && srcId == dstId) continue;
+            pairIdx[std::make_pair(srcId, dstId)] = idx++;
+          }
+        }
       }
+
+      // Group the member NICs by rank, sorted by local NIC index within each rank.
+      std::map<int, std::vector<int>> ranksToLocals;
+      for (int id : gi.memberNicIds) {
+        ranksToLocals[id / numNicsPerRank].push_back(id % numNicsPerRank);
+      }
+      std::vector<int> rankOrder;
+      rankOrder.reserve(ranksToLocals.size());
+      for (auto& kv : ranksToLocals) {
+        std::sort(kv.second.begin(), kv.second.end());
+        rankOrder.push_back(kv.first);
+      }
+
+      int const M = (int)gi.memberNicIds.size();
+      // Header layout: row 0 (and col 0) is logically a single "outer" row/col
+      // but rendered as two TableHelper rows/cols with no border between them so
+      // the rank label and the GPU/CPU backing-device sub-labels can sit
+      // alongside each other.
+      //   Rows 0,1 / Cols 0,1: doubled outer header block
+      //     - Row 0: " Rank XX " in the first NIC col of each rank (others blank)
+      //     - Row 1: " GPU XX " (or CPU) per src NIC col
+      //     - Col 0: " Rank XX " on first row of each rank's group
+      //     - Col 1: " GPU XX " (or CPU) per src NIC row
+      //   Row 2 / Col 2: NIC sub-labels (the original "row 1 / col 1"), with
+      //                  the SRC+EXE\DST corner at (2,2).
+      //   Row 3+ / Col 3+: one cell per (src NIC, dst NIC) pair, with NIC cols
+      //                    grouped by rank using selective column borders.
+      //   Trailing 2 cols: STotal (per-src-row sum) and Actual (transferCount *
+      //                    rowMinBw); trailing row: RTotal (per-dst-col sum).
+      int const sTotalCol  = 3 + M;
+      int const actualCol  = 3 + M + 1;
+      int const rTotalRow  = 3 + M;
+      int const numTblRows = 3 + M + 1;
+      int const numTblCols = 3 + M + 2;
+      int const precision  = 2;
+      Utils::TableHelper tbl(numTblRows, numTblCols, precision);
+
+      // Build the destination-NIC ordering used for data columns: same as the
+      // source-NIC ordering (group by rank, sorted local NIC index within rank).
+      // Also remember where each rank-group of columns starts so we can place
+      // the row-0 "Rank XX" headers and rank-boundary col borders in the right
+      // places.
+      std::vector<int> dstNicIds;
+      dstNicIds.reserve(M);
+      std::vector<int> rankColStart;
+      rankColStart.reserve(rankOrder.size());
+      {
+        int colCursor = 3;
+        for (int rank : rankOrder) {
+          rankColStart.push_back(colCursor);
+          for (int nicLocal : ranksToLocals[rank]) {
+            dstNicIds.push_back(rank * numNicsPerRank + nicLocal);
+            colCursor++;
+          }
+        }
+      }
+
+      tbl.DrawRowBorder(0);
+      tbl.DrawRowBorder(2);
+      tbl.DrawRowBorder(3);
+      tbl.DrawRowBorder(rTotalRow);
+      tbl.DrawRowBorder(numTblRows);
+      tbl.DrawColBorder(0);
+      tbl.DrawColBorder(2);
+      // Col borders only at rank-group boundaries (and at the right edge).
+      // Col 3 is the start of the first rank-group, which also serves as the
+      // separator between the NIC sub-label column and the data section.
+      // The last rank boundary at col (3+M) doubles as the separator before
+      // the trailing STotal column.
+      {
+        int colCursor = 3;
+        tbl.DrawColBorder(colCursor);
+        for (int rank : rankOrder) {
+          colCursor += (int)ranksToLocals[rank].size();
+          tbl.DrawColBorder(colCursor);
+        }
+      }
+      tbl.DrawColBorder(actualCol);
+      tbl.DrawColBorder(numTblCols);
+
+      tbl.Set(0, 0, " Mem Device ");
+      tbl.SetCellAlignment(0, 0, Utils::TableHelper::ALIGN_CENTER);
+      tbl.Set(2, 2, useRdmaRead ? " SRC\\DST+EXE " : " SRC+EXE\\DST ");
+      tbl.SetCellAlignment(2, 2, Utils::TableHelper::ALIGN_CENTER);
+      tbl.Set(2, sTotalCol, " STotal ");
+      tbl.SetCellAlignment(2, sTotalCol, Utils::TableHelper::ALIGN_CENTER);
+      tbl.Set(2, actualCol, " Actual ");
+      tbl.SetCellAlignment(2, actualCol, Utils::TableHelper::ALIGN_CENTER);
+      tbl.Set(rTotalRow, 2, " RTotal ");
+      tbl.SetCellAlignment(rTotalRow, 2, Utils::TableHelper::ALIGN_CENTER);
+
+      char const* memDevPrefix = useCpuMem ? "CPU" : "GPU";
+
+      Utils::Print("\n--- NIC AllToAll Plane %02d Group %02d (%d NICs) ---\n", p, g, M);
+
+      // Row-0 outer rank header: place " Rank XX " in the first NIC col of each
+      // rank-group; the other NIC cols in row 0 stay empty.
+      for (size_t c = 0; c < rankOrder.size(); c++)
+        tbl.Set(0, rankColStart[c], " Rank %02d ", rankOrder[c]);
+
+      // Rows 1 and 2: per-NIC GPU/CPU sub-header and NIC name sub-header.
+      for (int j = 0; j < M; j++) {
+        int const dstId   = dstNicIds[j];
+        int const dstRank = dstId / numNicsPerRank;
+        int const dstNic  = dstId % numNicsPerRank;
+        int const colIdx  = 3 + j;
+        tbl.Set(1, colIdx, " %s %02d ", memDevPrefix, nicToMem[dstRank][dstNic]);
+        tbl.Set(2, colIdx, " %s ",
+                TransferBench::GetExecutorName({EXE_NIC, dstNic, dstRank}).c_str());
+      }
+
+      // Data rows (M rows, one per src NIC). The outer-row "Rank XX" label only
+      // appears on the first row of each rank's group; per-row sub-labels carry
+      // the GPU/CPU backing device and NIC name. Track per-row and per-col
+      // running totals for STotal/RTotal/Actual.
+      std::vector<double> colTotal(M, 0.0);
+      double sTotalGrand = 0.0;
+      double actualGrand = 0.0;
+      int rowDisp = 0;
+      for (int srcRank : rankOrder) {
+        bool firstInRank = true;
+        for (int srcLocal : ranksToLocals[srcRank]) {
+          int const rowIdx = 3 + rowDisp;
+          if (firstInRank) {
+            tbl.DrawRowBorder(rowIdx);
+            tbl.Set(rowIdx, 0, " Rank %02d ", srcRank);
+            firstInRank = false;
+          }
+          tbl.Set(rowIdx, 1, " %s %02d ", memDevPrefix, nicToMem[srcRank][srcLocal]);
+          tbl.Set(rowIdx, 2, " %s ",
+                  TransferBench::GetExecutorName({EXE_NIC, srcLocal, srcRank}).c_str());
+
+          int const srcId = srcRank * numNicsPerRank + srcLocal;
+          double rowSum   = 0.0;
+          double rowMinBw = std::numeric_limits<double>::max();
+          int    rowCount = 0;
+          for (int j = 0; j < M; j++) {
+            int const dstId  = dstNicIds[j];
+            int const colIdx = 3 + j;
+            if (!a2aLocal && srcId == dstId) {
+              tbl.Set(rowIdx, colIdx, " N/A ");
+            } else {
+              double const bw = results.tfrResults[pairIdx[std::make_pair(srcId, dstId)]]
+                                  .avgBandwidthGbPerSec;
+              tbl.Set(rowIdx, colIdx, " %.2f ", bw);
+              rowSum      += bw;
+              colTotal[j] += bw;
+              rowMinBw     = std::min(rowMinBw, bw);
+              rowCount++;
+            }
+          }
+          double const rowActual = (rowCount > 0) ? rowCount * rowMinBw : 0.0;
+          tbl.Set(rowIdx, sTotalCol, " %.2f ", rowSum);
+          tbl.Set(rowIdx, actualCol, " %.2f ", rowActual);
+          sTotalGrand += rowSum;
+          actualGrand += rowActual;
+          rowDisp++;
+        }
+      }
+
+      // RTotal row: per-dst-col sums plus grand totals for STotal/Actual.
+      for (int j = 0; j < M; j++)
+        tbl.Set(rTotalRow, 3 + j, " %.2f ", colTotal[j]);
+      tbl.Set(rTotalRow, sTotalCol, " %.2f ", sTotalGrand);
+      tbl.Set(rTotalRow, actualCol, " %.2f ", actualGrand);
+
+      tbl.PrintTable(ev.outputToCsv, ev.showBorders);
     }
   }
-
-  std::vector<double> rankTotal(numRanks, 0.0);
-  int colIdx = 2;
-  table.DrawColBorder(colIdx);
-  for (int nic = 0; nic < numNicsPerRank; nic++) {
-    table.Set(0, colIdx, " NIC %02d ", nic);
-    if (nicHasMixedMemMapping[nic]) {
-      table.Set(1, colIdx, " MIXED ");
-    } else if (useCpuMem) {
-      table.Set(1, colIdx, " CPU %02d ", nicToMem[0][nic]);
-    } else {
-      table.Set(1, colIdx, " GPU %02d ", nicToMem[0][nic]);
-    }
-    table.Set(2, colIdx, " %s ", TransferBench::GetExecutorName({EXE_NIC, nic}).c_str());
-
-    double nicMin = std::numeric_limits<double>::max();
-    double nicAvg = 0.0;
-    double nicMax = std::numeric_limits<double>::lowest();
-    for (int rank = 0; rank < numRanks; rank++) {
-      double bw = bwByRankNic[rank][nic];
-      table.Set(3 + rank, colIdx, " %.2f ", bw);
-      nicMin = std::min(nicMin, bw);
-      nicAvg += bw;
-      nicMax = std::max(nicMax, bw);
-      rankTotal[rank] += bw;
-    }
-
-    table.Set(numRows - 3, colIdx, " %.2f ", nicMax);
-    table.Set(numRows - 2, colIdx, " %.2f ", nicAvg / numRanks);
-    table.Set(numRows - 1, colIdx, " %.2f ", nicMin);
-    colIdx++;
-  }
-  table.DrawColBorder(colIdx);
-
-  double rankMin = std::numeric_limits<double>::max();
-  double rankAvg = 0.0;
-  double rankMax = std::numeric_limits<double>::lowest();
-  for (int rank = 0; rank < numRanks; rank++) {
-    table.Set(3 + rank, numCols - 1, " %.2f ", rankTotal[rank]);
-    rankMin = std::min(rankMin, rankTotal[rank]);
-    rankAvg += rankTotal[rank];
-    rankMax = std::max(rankMax, rankTotal[rank]);
-  }
-  table.Set(numRows - 3, numCols - 1, " %.2f ", rankMax);
-  table.Set(numRows - 2, numCols - 1, " %.2f ", rankAvg / numRanks);
-  table.Set(numRows - 1, numCols - 1, " %.2f ", rankMin);
-
-  table.PrintTable(ev.outputToCsv, ev.showBorders);
   Utils::Print("\n");
-  if (hasMixedMemMapping) {
-    Utils::Print("[WARN] NIC-to-%s mapping differs across ranks. 'MIXED' columns are detailed below.\n",
-                 useCpuMem ? "CPU" : "GPU");
 
-    int mapRows = 2 + numRanks;
-    int mapCols = 2 + numNicsPerRank;
-    Utils::TableHelper mapTable(mapRows, mapCols);
-    mapTable.Set(0, 0, " Rank ");
-    mapTable.Set(0, 1, " Name ");
-    mapTable.SetColAlignment(1, Utils::TableHelper::ALIGN_LEFT);
-    for (int nic = 0; nic < numNicsPerRank; nic++) {
-      mapTable.Set(0, 2 + nic, " NIC %02d ", nic);
-      mapTable.SetCellAlignment(0, 2 + nic, Utils::TableHelper::ALIGN_CENTER);
-    }
-    mapTable.DrawRowBorder(1);
-    mapTable.DrawColBorder(2);
-
-    for (int rank = 0; rank < numRanks; rank++) {
-      int rowIdx = 1 + rank;
-      mapTable.Set(rowIdx, 0, " %d ", rank);
-      mapTable.Set(rowIdx, 1, " %s ", TransferBench::GetHostname(rank).c_str());
-      for (int nic = 0; nic < numNicsPerRank; nic++) {
-        mapTable.Set(rowIdx, 2 + nic, " %s %02d ", useCpuMem ? "CPU" : "GPU", nicToMem[rank][nic]);
-      }
-    }
-
-    mapTable.PrintTable(ev.outputToCsv, ev.showBorders);
-    Utils::Print("\n");
-  }
   Utils::Print("Aggregate bandwidth (CPU Timed): %8.3f GB/s\n", results.avgTotalBandwidthGbPerSec);
   Utils::PrintErrors(results.errResults);
 

--- a/src/client/Presets/NicAllToAll.hpp
+++ b/src/client/Presets/NicAllToAll.hpp
@@ -103,7 +103,7 @@ int NicAllToAllPreset(EnvVars&                    ev,
       ev.Print("USE_CPU_MEM"         , useCpuMem     , "Using closest %s memory", useCpuMem ? "CPU" : "GPU");
       ev.Print("MEM_TYPE"            , memTypeIdx    , "Using %s memory (%s)", memTypeStr.c_str(), Utils::GetAllMemTypeStr(useCpuMem).c_str());
       ev.Print("PLANE_STRIDE"        , planeStride   , "Stride permutation on global NIC list before splitting into planes");
-      ev.Print("NUM_PLANES"         , numPlanes    , "Splitting %d total NICs into %d plane(s) of %d NICs each", N, numPlanes, planeSize);
+      ev.Print("NUM_PLANES"          , numPlanes     , "Splitting %d total NICs into %d plane(s) of %d NICs each", N, numPlanes, planeSize);
       ev.Print("GROUP_STRIDE"        , groupStride   , "Stride permutation within each plane before splitting into groups");
       ev.Print("NUM_GROUPS"          , numGroups     , "Splitting each plane into %d group(s) of %d NICs each", numGroups, groupSize);
       ev.Print("A2A_LOCAL"           , a2aLocal      , "%s self NIC endpoint transfers", a2aLocal ? "Include" : "Exclude");
@@ -203,7 +203,6 @@ int NicAllToAllPreset(EnvVars&                    ev,
                N, numPlanes, planeSize, planeStride);
   Utils::Print("Each plane split into %d group(s) of %d NICs (GROUP_STRIDE=%d).\n",
                numGroups, groupSize, groupStride);
-  
 
   if (transfers.empty()) {
     Utils::Print("[WARN] No transfers were generated for this preset.\n");

--- a/src/client/Presets/PodAllToAll.hpp
+++ b/src/client/Presets/PodAllToAll.hpp
@@ -239,7 +239,7 @@ int PodAllToAllPreset(EnvVars&          ev,
     if (!TransferBench::RunTransfers(cfg, podTransfers, results)) {
       for (auto const& err : results.errResults)
         Utils::Print("%s\n", err.errMsg.c_str());
-      return 1;
+      return ERR_FATAL;
     }
     if (showDetails) {
       if (Utils::RankDoesOutput())

--- a/src/client/Presets/PodAllToAll.hpp
+++ b/src/client/Presets/PodAllToAll.hpp
@@ -20,6 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#include <limits>
+
 int PodAllToAllPreset(EnvVars&          ev,
                       size_t      const numBytesPerTransfer,
                       std::string const presetName,
@@ -52,8 +54,8 @@ int PodAllToAllPreset(EnvVars&          ev,
   int showDetails   = EnvVars::GetEnvVar("SHOW_DETAILS"   , 0);
   int useDmaExec    = EnvVars::GetEnvVar("USE_DMA_EXEC"   , 0);
   int useRemoteRead = EnvVars::GetEnvVar("USE_REMOTE_READ", 0);
-  int stride        = EnvVars::GetEnvVar("STRIDE"         , 1);
-  int groupSize     = EnvVars::GetEnvVar("GROUP_SIZE"     , numRanks * numDetectedGpus);
+  int groupStride   = EnvVars::GetEnvVar("GROUP_STRIDE"   , 1);
+  int numGroups     = EnvVars::GetEnvVar("NUM_GROUPS"     , 1);
 
   // Check that all ranks have at least the number of GPUs requested
   // Warn if NIC configuration is slightly different from one another
@@ -103,8 +105,8 @@ int PodAllToAllPreset(EnvVars&          ev,
       ev.Print("NUM_SUB_EXEC"   , numSubExecs  , "Using %d subexecutors/CUs per Transfer", numSubExecs);
       ev.Print("USE_DMA_EXEC"   , useDmaExec   , "Using %s executor", useDmaExec ? "DMA" : "GFX");
       ev.Print("USE_REMOTE_READ", useRemoteRead, "Using %s as executor", useRemoteRead ? "DST" : "SRC");
-      ev.Print("STRIDE"         , stride       , "Reordering devices by taking %d steps", stride);
-      ev.Print("GROUP_SIZE"     , groupSize    , "Dividing all devices into groups of %d for a2a", groupSize);
+      ev.Print("GROUP_STRIDE"   , groupStride  , "Stride permutation on device list before splitting into groups");
+      ev.Print("NUM_GROUPS"     , numGroups    , "Splitting each pod into %d group(s) for a2a", numGroups);
       printf("\n");
     }
   }
@@ -118,8 +120,8 @@ int PodAllToAllPreset(EnvVars&          ev,
     return ERR_FATAL;
   }
 
-  if (numRanks * numDetectedGpus % groupSize) {
-    Utils::Print("[ERROR] Group size %d cannot evenly divide %d total devices from %d ranks.\n", groupSize, numRanks * numDetectedGpus, numRanks);
+  if (numGroups < 1) {
+    Utils::Print("[ERROR] NUM_GROUPS must be >= 1 (got %d)\n", numGroups);
     return ERR_FATAL;
   }
 
@@ -139,11 +141,16 @@ int PodAllToAllPreset(EnvVars&          ev,
   }
   for (auto const& [pod, ranks] : rankToPod) {
     int n = ranks.size() * numGpus;
-    int numGroups = n / groupSize;
+    if (n % numGroups) {
+      Utils::Print("[ERROR] NUM_GROUPS (%d) must divide pod device count (%d = %d ranks * %d gpus/rank)\n",
+                   numGroups, n, (int)ranks.size(), numGpus);
+      return ERR_FATAL;
+    }
+    int groupSize = n / numGroups;
     std::vector<MemDevice> devices(n);
     std::vector<int> indices(n);
     for (int k = 0; k < n; k++) indices[k] = k;
-    Utils::StrideGenerate(indices, stride);
+    Utils::StrideGenerate(indices, groupStride);
     int idx = 0;
     for (int rank : ranks) {
       for (int devIdx = 0; devIdx < numGpus; devIdx++) {
@@ -151,9 +158,17 @@ int PodAllToAllPreset(EnvVars&          ev,
       }
     }
 
+    // Build transfers for every group, then run once per pod so all groups share the same
+    // timed iterations (traffic across groups is concurrent within RunTransfers).
+    std::vector<Transfer> podTransfers;
+    std::vector<size_t> groupTransferBase(numGroups);
+    std::vector<std::vector<std::vector<int>>> groupReIndexes(numGroups);
+
     for (int group = 0; group < numGroups; group++) {
-      std::vector<std::vector<int>> groupReIndex(groupSize, std::vector<int>(groupSize, -1));
-      std::vector<Transfer> transfers;
+      groupTransferBase[group] = podTransfers.size();
+      groupReIndexes[group].assign(groupSize, std::vector<int>(groupSize, -1));
+      std::vector<std::vector<int>>& groupReIndex = groupReIndexes[group];
+
       for (int i = group * groupSize; i < (group + 1) * groupSize; i++) {
         for (int j = group * groupSize; j < (group + 1) * groupSize; j++) {
           if (i == j) {
@@ -171,8 +186,9 @@ int PodAllToAllPreset(EnvVars&          ev,
           transfer.numSubExecs = numSubExecs;
           int const localI = i - group * groupSize;
           int const localJ = j - group * groupSize;
-          groupReIndex[localI][localJ] = (int)transfers.size();
-          transfers.push_back(transfer);
+          groupReIndex[localI][localJ] =
+              (int)(podTransfers.size() - groupTransferBase[group]);
+          podTransfers.push_back(transfer);
         }
 
         if (numQueuePairs > 0) {
@@ -185,19 +201,47 @@ int PodAllToAllPreset(EnvVars&          ev,
                                (int32_t)devices[i].memIndex, (int32_t)devices[i].memRank};
           transfer.exeSubIndex = devices[next].memIndex;
           transfer.numSubExecs = numQueuePairs;
-          transfers.push_back(transfer);
+          podTransfers.push_back(transfer);
         }
       }
-      TransferBench::TestResults results;
-      if (!TransferBench::RunTransfers(cfg, transfers, results)) {
-        for (auto const& err : results.errResults)
-          Utils::Print("%s\n", err.errMsg.c_str());
-        return ERR_FATAL;
-      }
-      if (showDetails) {
-        Utils::PrintResults(ev, 1, transfers, results);
+    }
+
+    if (Utils::RankDoesOutput()) {
+      for (int g = 0; g < numGroups; g++) {
+        int const gb = g * groupSize;
+        Utils::Print("A2A group %d:", g);
+        std::vector<int> ord(groupSize);
+        for (int i = 0; i < groupSize; i++) ord[i] = i;
+        std::sort(ord.begin(), ord.end(), [&](int a, int b) {
+          MemDevice const& da = devices[gb + a];
+          MemDevice const& db = devices[gb + b];
+          if (da.memRank != db.memRank) return da.memRank < db.memRank;
+          return da.memIndex < db.memIndex;
+        });
+        for (size_t si = 0; si < ord.size(); si++) {
+          MemDevice const& d = devices[gb + ord[si]];
+          Utils::Print("%s R%d:G%d", si ? "," : "", d.memRank, d.memIndex);
+        }
         Utils::Print("\n");
       }
+    }
+
+    TransferBench::TestResults results;
+    if (!TransferBench::RunTransfers(cfg, podTransfers, results)) {
+      for (auto const& err : results.errResults)
+        Utils::Print("%s\n", err.errMsg.c_str());
+      return 1;
+    }
+    if (showDetails) {
+      if (Utils::RankDoesOutput())
+        Utils::Print("\n--- Pod AllToAll (all %d groups concurrent) ---\n", numGroups);
+      Utils::PrintResults(ev, 1, podTransfers, results);
+      Utils::Print("\n");
+    }
+
+    for (int group = 0; group < numGroups; group++) {
+      std::vector<std::vector<int>> const& groupReIndex = groupReIndexes[group];
+      size_t const tfrBase = groupTransferBase[group];
 
       // Per-group bandwidth table
       std::vector<std::vector<double>> groupBw(groupSize, std::vector<double>(groupSize, -1.0));
@@ -205,56 +249,155 @@ int PodAllToAllPreset(EnvVars&          ev,
         for (int localJ = 0; localJ < groupSize; localJ++) {
           int const k = groupReIndex[localI][localJ];
           if (k >= 0)
-            groupBw[localI][localJ] = results.tfrResults[k].avgBandwidthGbPerSec;
+            groupBw[localI][localJ] = results.tfrResults[tfrBase + k].avgBandwidthGbPerSec;
         }
       }
       if (Utils::RankDoesOutput()) {
         Utils::Print("\n--- Pod AllToAll Group %d ---\n", group);
         int const groupBase = group * groupSize;
-        int const numRows = 2 + groupSize;
-        int const numCols = 2 + groupSize;
+
+        // Display order: group devices by MPI rank, then GPU index (stride only affects execution order).
+        std::vector<int> order(groupSize);
+        for (int i = 0; i < groupSize; i++) order[i] = i;
+        std::sort(order.begin(), order.end(), [&](int a, int b) {
+          MemDevice const& da = devices[groupBase + a];
+          MemDevice const& db = devices[groupBase + b];
+          if (da.memRank != db.memRank) return da.memRank < db.memRank;
+          return da.memIndex < db.memIndex;
+        });
+        std::vector<int> colRanks;
+        for (int slot : order) {
+          int const r = devices[groupBase + slot].memRank;
+          if (colRanks.empty() || colRanks.back() != r) colRanks.push_back(r);
+        }
+        std::vector<std::vector<int>> localsPerCol;
+        localsPerCol.reserve(colRanks.size());
+        for (int dr : colRanks) {
+          std::vector<int> loc;
+          for (int li = 0; li < groupSize; li++) {
+            if (devices[groupBase + li].memRank == dr) loc.push_back(li);
+          }
+          std::sort(loc.begin(), loc.end(), [&](int a, int b) {
+            return devices[groupBase + a].memIndex < devices[groupBase + b].memIndex;
+          });
+          localsPerCol.push_back(std::move(loc));
+        }
+
+        // Two trailing scalar columns (STotal, Actual) and a trailing RTotal row
+        // matching the a2a/nica2a layouts.
+        int const sTotalCol = 2 + (int)colRanks.size();
+        int const actualCol = sTotalCol + 1;
+        int const rTotalRow = 2 + groupSize;
+        int const numRows = 2 + groupSize + 1;
+        int const numCols = 2 + (int)colRanks.size() + 2;
         int const precision = 2;
         Utils::TableHelper table(numRows, numCols, precision);
         table.DrawRowBorder(0);
         table.DrawColBorder(0);
         table.DrawColBorder(numCols);
         table.DrawRowBorder(numRows);
+        table.DrawRowBorder(rTotalRow);
         table.Set(0, 0, useRemoteRead ? " SRC\\DST+EXE " : " SRC+EXE\\DST ");
         table.DrawRowBorder(1);
         table.DrawColBorder(1);
         table.Set(1, 1, " Mem Device ");
 
-        // Column headers
-        int colPrevRank = -1;
-        for (int j = 0; j < groupSize; j++) {
-          int colIdx = 2 + j;
-          int r = devices[groupBase + j].memRank;
-          if (r != colPrevRank) {
-            table.DrawColBorder(colIdx);
-            table.Set(0, colIdx, " Rank %02d ", r);
-            colPrevRank = r;
+        for (size_t c = 0; c < colRanks.size(); c++) {
+          int const colIdx = 2 + (int)c;
+          table.DrawColBorder(colIdx);
+          table.Set(0, colIdx, " Rank %02d ", colRanks[c]);
+          std::string gpuHdr;
+          for (int li : localsPerCol[c]) {
+            char t[24];
+            snprintf(t, sizeof(t), "  GPU %02d", devices[groupBase + li].memIndex);
+            gpuHdr += t;
           }
-          table.Set(1, colIdx, " GPU %02d ", devices[groupBase + j].memIndex);
+          gpuHdr += " ";
+          table.Set(1, colIdx, "%s", gpuHdr.c_str());
+          table.SetColAlignment((int)c + 2, Utils::TableHelper::ALIGN_LEFT);
         }
 
-        // Row headers and data
+        // STotal / Actual column headers (centered, single-cell). Row 1 stays
+        // blank for these cols since they are scalar columns, not GPU groups.
+        table.DrawColBorder(sTotalCol);
+        table.DrawColBorder(actualCol);
+        table.Set(0, sTotalCol, " STotal ");
+        table.SetCellAlignment(0, sTotalCol, Utils::TableHelper::ALIGN_CENTER);
+        table.Set(0, actualCol, " Actual ");
+        table.SetCellAlignment(0, actualCol, Utils::TableHelper::ALIGN_CENTER);
+        table.Set(rTotalRow, 1, " RTotal ");
+        table.SetCellAlignment(rTotalRow, 1, Utils::TableHelper::ALIGN_CENTER);
+
+        // Per-(rank-col, dst-GPU-within-rank) running sums for the RTotal row.
+        std::vector<std::vector<double>> colTotal(colRanks.size());
+        for (size_t c = 0; c < colRanks.size(); c++)
+          colTotal[c].assign(localsPerCol[c].size(), 0.0);
+        double sTotalGrand = 0.0;
+        double actualGrand = 0.0;
+
         int rowPrevRank = -1;
-        for (int localI = 0; localI < groupSize; localI++) {
-          int rowIdx = 2 + localI;
-          int r = devices[groupBase + localI].memRank;
+        for (int disp = 0; disp < groupSize; disp++) {
+          int const localI = order[disp];
+          int const rowIdx = 2 + disp;
+          int const r = devices[groupBase + localI].memRank;
           if (r != rowPrevRank) {
             table.DrawRowBorder(rowIdx);
             table.Set(rowIdx, 0, " Rank %02d ", r);
             rowPrevRank = r;
+          } else {
+            table.Set(rowIdx, 0, " ");
           }
           table.Set(rowIdx, 1, " GPU %02d ", devices[groupBase + localI].memIndex);
-          for (int localJ = 0; localJ < groupSize; localJ++) {
-            if (groupBw[localI][localJ] >= 0)
-              table.Set(rowIdx, 2 + localJ, " %.2f ", groupBw[localI][localJ]);
-            else
-              table.Set(rowIdx, 2 + localJ, " N/A ");
+
+          double rowSum   = 0.0;
+          double rowMinBw = std::numeric_limits<double>::max();
+          int    rowCount = 0;
+          for (size_t c = 0; c < colRanks.size(); c++) {
+            std::string cell;
+            for (size_t k = 0; k < localsPerCol[c].size(); k++) {
+              int const localJ = localsPerCol[c][k];
+              char t[16];
+              if (groupBw[localI][localJ] >= 0) {
+                double const bw = groupBw[localI][localJ];
+                snprintf(t, sizeof(t), " %7.2f", bw);
+                rowSum         += bw;
+                colTotal[c][k] += bw;
+                rowMinBw        = std::min(rowMinBw, bw);
+                rowCount++;
+              } else {
+                snprintf(t, sizeof(t), " %7s", "N/A");
+              }
+              cell += t;
+            }
+            cell += " ";
+            int const colIdx = 2 + (int)c;
+            table.Set(rowIdx, colIdx, "%s", cell.c_str());
+            table.SetCellAlignment(rowIdx, colIdx, Utils::TableHelper::ALIGN_LEFT);
           }
+          double const rowActual = (rowCount > 0) ? rowCount * rowMinBw : 0.0;
+          table.Set(rowIdx, sTotalCol, " %.2f ", rowSum);
+          table.Set(rowIdx, actualCol, " %.2f ", rowActual);
+          sTotalGrand += rowSum;
+          actualGrand += rowActual;
         }
+
+        // RTotal row: per-dst-GPU column sums (packed per rank-col), plus grand
+        // totals under STotal / Actual.
+        for (size_t c = 0; c < colRanks.size(); c++) {
+          std::string cell;
+          for (size_t k = 0; k < localsPerCol[c].size(); k++) {
+            char t[16];
+            snprintf(t, sizeof(t), " %7.2f", colTotal[c][k]);
+            cell += t;
+          }
+          cell += " ";
+          int const colIdx = 2 + (int)c;
+          table.Set(rTotalRow, colIdx, "%s", cell.c_str());
+          table.SetCellAlignment(rTotalRow, colIdx, Utils::TableHelper::ALIGN_LEFT);
+        }
+        table.Set(rTotalRow, sTotalCol, " %.2f ", sTotalGrand);
+        table.Set(rTotalRow, actualCol, " %.2f ", actualGrand);
+
         table.PrintTable(ev.outputToCsv, ev.showBorders);
       }
     }

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -4214,6 +4214,20 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 #else
       ERR_CHECK(hipDeviceGetAttribute(&exeInfo.wallClockRate, hipDeviceAttributeWallClockRate,
                                       exeDevice.exeIndex));
+      // Check that GPU wallclock rate is non-zero
+      if (exeInfo.wallClockRate == 0) {
+        if (getenv("TB_WALLCLOCK_RATE")) {
+          exeInfo.wallClockRate = atoi(getenv("TB_WALLCLOCK_RATE"));
+          return {ERR_WARN,
+            "GPU %d wallclock rate query returned 0 unexpectedly.  Setting to %d instead as specified by TB_WALLCLOCK_RATE",
+            exeDevice.exeIndex, exeInfo.wallClockRate};
+        } else {
+          exeInfo.wallClockRate = 100000;
+          return {ERR_WARN,
+            "GPU %d wallclock rate query returned 0 unexpectedly.  Setting to %d instead.  Use TB_WALLCLOCK_RATE to customize",
+            exeDevice.exeIndex, exeInfo.wallClockRate};
+        }
+      }
 #endif
       int transferOffset = 0;
       if (cfg.gfx.useMultiStream || cfg.gfx.blockOrder == 0) {
@@ -4278,21 +4292,6 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 #else
       return {ERR_FATAL, "RDMA executor is not supported"};
 #endif
-    }
-
-    // Check that GPU wallclock rate is non-zero
-    if (exeDevice.exeType == EXE_GPU_GFX && exeInfo.wallClockRate == 0) {
-      if (getenv("TB_WALLCLOCK_RATE")) {
-        exeInfo.wallClockRate = atoi(getenv("TB_WALLCLOCK_RATE"));
-        return {ERR_WARN,
-          "GPU %d wallclock rate query returned 0 unexpectedly.  Setting to %d instead as specified by TB_WALLCLOCK_RATE",
-          exeDevice.exeIndex, exeInfo.wallClockRate};
-      } else {
-        exeInfo.wallClockRate = 100000;
-        return {ERR_WARN,
-          "GPU %d wallclock rate query returned 0 unexpectedly.  Setting to %d instead.  Use TB_WALLCLOCK_RATE to customize",
-          exeDevice.exeIndex, exeInfo.wallClockRate};
-      }
     }
 
     return ERR_NONE;


### PR DESCRIPTION
## Motivation

- Make all groups in a pod run all-to-all in parallel, previously execution of groups are serial
- Modify output able to reflect pod A2A group members
- Modify NIC A2A grouping logic: 

  - Using `Util::StrideGenerate` like all other functions, we generate orbits based on number of groups/planes and strides input by user. Concatenating orbits to reorder NICs, before further separating them into groups/planes
  - For NIC A2A, we generate two levels of grouping using the function. 
     First level of grouping is NIC **plane**s. 
     For all NICs within the same plane, we further split them into second level of **group**s. 
     All groups then execute internal all-to-all operations in parallel.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

poda2a: Tested on 8 GB200 devices (2 node with 4 GPU each launched by MPI) in a single pod, multi-pod scenario yet investigated. On AMD platform tested (2 x 8 devices) with `TB_FORCE_SINGLE_POD`

nica2a: Tested on 2x8 devices

## Test Result

### poda2a Example Output from a 2 x 4G cluster
#### Default (1 Group of size 8 in natural order)
```
[AllToAll Related]
A2A_LOCAL            =            0 : Exclude local transfers
A2A_MODE             =            0 : Copy
MEM_TYPE             =            0 : Using default GPU GPU memory (0=default, 1=fine-grained, 2=uncached, 3=managed)
NUM_GPU_DEVICES      =            4 : Using 4 GPUs
NUM_QUEUE_PAIRS      =            0 : Using 0 queue pairs for NIC transfers
NUM_SUB_EXEC         =            8 : Using 8 subexecutors/CUs per Transfer
USE_DMA_EXEC         =            0 : Using GFX executor
USE_REMOTE_READ      =            0 : Using SRC as executor
STRIDE               =            1 : Reordering devices by taking 1 steps
GROUP_SIZE           =            8 : Dividing all devices into groups of 8 for a2a

GPU-GFX IntraPod All-To-All benchmark:
==============================
[268435456 bytes per Transfer] [GFX:8] [1 Read(s) 1 Write(s)] [MemType:default GPU] [NIC QueuePairs:0] [#Ranks:2]
A2A group 0: R0:G0, R0:G1, R0:G2, R0:G3, R1:G0, R1:G1, R1:G2, R1:G3

--- Pod AllToAll Group 0 ---
┌-------------┬------------┬------------------------------------┬------------------------------------┐
│ SRC+EXE\DST │            │ Rank 00                            │ Rank 01                            │
├-------------┼------------┼------------------------------------┼------------------------------------┤
│             │ Mem Device │  GPU 00   GPU 01   GPU 02   GPU 03 │  GPU 00   GPU 01   GPU 02   GPU 03 │
├-------------┼------------┼------------------------------------┼------------------------------------┤
│     Rank 00 │     GPU 00 │     N/A    74.21    74.43    87.73 │   87.64   102.58   102.74   103.02 │
│             │     GPU 01 │   83.21      N/A    82.99    83.27 │   83.29   103.38   103.55   103.92 │
│             │     GPU 02 │   96.29    95.45      N/A    95.50 │   95.73    95.96    96.31    96.59 │
│             │     GPU 03 │   87.71    87.75    87.83      N/A │   88.18   111.02   111.10   111.25 │
├-------------┼------------┼------------------------------------┼------------------------------------┤
│     Rank 01 │     GPU 00 │   90.73    89.91    91.06    89.90 │     N/A    89.77    89.74    91.05 │
│             │     GPU 01 │   83.53    83.73    83.59    83.69 │  102.92      N/A   103.05   103.21 │
│             │     GPU 02 │   83.82    83.67    83.92    84.07 │  103.17   103.28      N/A   103.53 │
│             │     GPU 03 │   77.40    77.71    90.59    90.64 │   90.56    93.93    94.02      N/A │
└-------------┴------------┴------------------------------------┴------------------------------------┘
```
#### 2 Groups with Stride 2
```
[AllToAll Related]
A2A_LOCAL            =            0 : Exclude local transfers
A2A_MODE             =            0 : Copy
MEM_TYPE             =            0 : Using default GPU GPU memory (0=default, 1=fine-grained, 2=uncached, 3=managed)
NUM_GPU_DEVICES      =            4 : Using 4 GPUs
NUM_QUEUE_PAIRS      =            0 : Using 0 queue pairs for NIC transfers
NUM_SUB_EXEC         =            8 : Using 8 subexecutors/CUs per Transfer
USE_DMA_EXEC         =            0 : Using GFX executor
USE_REMOTE_READ      =            0 : Using SRC as executor
STRIDE               =            2 : Reordering devices by taking 2 steps
GROUP_SIZE           =            4 : Dividing all devices into groups of 4 for a2a

GPU-GFX IntraPod All-To-All benchmark:
==============================
[268435456 bytes per Transfer] [GFX:8] [1 Read(s) 1 Write(s)] [MemType:default GPU] [NIC QueuePairs:0] [#Ranks:2]
A2A group 0: R0:G0, R0:G1, R1:G0, R1:G1
A2A group 1: R0:G2, R0:G3, R1:G2, R1:G3

--- Pod AllToAll Group 0 ---
┌-------------┬------------┬------------------┬------------------┐
│ SRC+EXE\DST │            │ Rank 00          │ Rank 01          │
├-------------┼------------┼------------------┼------------------┤
│             │ Mem Device │  GPU 00   GPU 01 │  GPU 00   GPU 01 │
├-------------┼------------┼------------------┼------------------┤
│     Rank 00 │     GPU 00 │     N/A  104.90  │  104.78  105.07  │
│             │     GPU 01 │  104.01     N/A  │  103.89  104.01  │
├-------------┼------------┼------------------┼------------------┤
│     Rank 01 │     GPU 00 │  104.33  104.55  │     N/A  104.64  │
│             │     GPU 01 │  104.42  104.54  │  103.98     N/A  │
└-------------┴------------┴------------------┴------------------┘

--- Pod AllToAll Group 1 ---
┌-------------┬------------┬------------------┬------------------┐
│ SRC+EXE\DST │            │ Rank 00          │ Rank 01          │
├-------------┼------------┼------------------┼------------------┤
│             │ Mem Device │  GPU 02   GPU 03 │  GPU 02   GPU 03 │
├-------------┼------------┼------------------┼------------------┤
│     Rank 00 │     GPU 02 │     N/A  103.63  │  103.44  103.71  │
│             │     GPU 03 │  107.86     N/A  │  108.52  108.92  │
├-------------┼------------┼------------------┼------------------┤
│     Rank 01 │     GPU 02 │  106.24  106.01  │     N/A  106.28  │
│             │     GPU 03 │  105.08  106.18  │  106.10     N/A  │
└-------------┴------------┴------------------┴------------------┘
```

### nica2a Example Output from a 2 x 8G cluster
<img width="1639" height="678" alt="image" src="https://github.com/user-attachments/assets/3efc0fcd-a62a-4470-b84c-68d747c24344" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
