### PR TITLE
Fix portability for AlmaLinux 8 / manylinux_2_28 (gcc 8)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,10 @@ target_link_libraries(TransferBench PRIVATE dl)
 target_link_libraries(TransferBench PRIVATE ${NUMA_LIBRARY})
 target_link_libraries(TransferBench PRIVATE ${HSA_LIBRARY})
 
+# gcc <9 ships std::filesystem in a separate library (libstdc++fs).
+# Required on AlmaLinux 8 / manylinux_2_28; harmless no-op stub on newer toolchains.
+target_link_libraries(TransferBench PRIVATE stdc++fs)
+
 rocm_install(TARGETS TransferBench COMPONENT devel)
 rocm_setup_version(VERSION ${VERSION_STRING})
 

--- a/src/client/Presets/AllToAll.hpp
+++ b/src/client/Presets/AllToAll.hpp
@@ -20,6 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#include <limits>
+
 int AllToAllPreset(EnvVars&           ev,
                     size_t      const  numBytesPerTransfer,
                     std::string const  presetName)

--- a/src/client/Presets/AllToAllN.hpp
+++ b/src/client/Presets/AllToAllN.hpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#include <limits>
 #include "EnvVars.hpp"
 
 int AllToAllRdmaPreset(EnvVars&           ev,

--- a/src/client/Presets/NicPeerToPeer.hpp
+++ b/src/client/Presets/NicPeerToPeer.hpp
@@ -20,6 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#include <numeric>
+
 // Helper functions
 
 // Returns a schedule of round robin pairing of N elements, using Circle Method

--- a/src/client/Utilities.hpp
+++ b/src/client/Utilities.hpp
@@ -21,6 +21,7 @@ THE SOFTWARE.
 */
 
 #pragma once
+#include <iomanip>
 #include <unordered_map>
 #include <unordered_set>
 #include "TransferBench.hpp"

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #include <algorithm>
 #include <arpa/inet.h>
 #include <atomic>
-#include <barrier>
 #include <cstring>
 #include <fcntl.h>
 #include <filesystem>


### PR DESCRIPTION
## Summary

gcc 8.5 (AlmaLinux 8 base, used by manylinux_2_28) is older than what Ubuntu 22.04 ships and doesn't pull in some headers transitively or expose `std::filesystem` from the default libstdc++. This PR makes TransferBench actually build on those toolchains.

- Drop unused `#include <barrier>` from `src/header/TransferBench.hpp`. `<barrier>` is C++20 and requires libstdc++ ≥ 10. `std::barrier` was never used.
- Add explicit `#include <iomanip>`, `<numeric>`, `<limits>` to `Utilities.hpp`, `NicPeerToPeer.hpp`, `AllToAll.hpp`, `AllToAllN.hpp`. Older libstdc++ doesn't pull these in via other standard headers.
- Link `libstdc++fs` unconditionally for `std::filesystem`. gcc < 9 ships it as a separate static archive in a gcc-private libdir (e.g. `/usr/lib/gcc/x86_64-redhat-linux/8/libstdc++fs.a`), which CMake's `find_library` does not search. Bare `target_link_libraries(... stdc++fs)` lets the compiler driver find it. On gcc 9+ it resolves to a no-op stub archive shipped for compatibility, so it's harmless elsewhere.

## Context

This is the portability slice of the original #260, split out so it can land independently. A follow-up PR will add the GitHub Actions workflow + `build_packages_local.sh` for building relocatable packages against TheRock SDK on top of these fixes.

## Test plan

- [x] Reproduced original link/compile failures inside `quay.io/pypa/manylinux_2_28_x86_64` (AlmaLinux 8, gcc 8.5)
- [x] Build succeeds inside the same container after this patch
- [x] No effect on the existing Azure DevOps Ubuntu/ROCm CI (changes are toolchain-portability only; on gcc ≥ 9 the stdc++fs link is a no-op and the extra includes are redundant but harmless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)