### PR TITLE
ci: fix S3 metadata sync without requiring DeleteObject permission

### DIFF
--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -120,10 +120,14 @@ jobs:
         run: |
           set -euo pipefail
           WORK="$(mktemp -d)"
-          aws s3 sync "${S3_DEB_PATH}/" "${WORK}/" --exclude "*" --include "*.deb"
-          pushd "${WORK}" >/dev/null
-          dpkg-scanpackages -m . /dev/null > Packages
-          gzip -kf Packages
+          echo "Downloading existing DEBs from ${S3_DEB_PATH}/ ..."
+          aws s3 sync "${S3_DEB_PATH}/" "${WORK}/" \
+            --exclude "Packages*" --exclude "Release*" --exclude "InRelease" \
+            --no-progress || true
+          cp build/amdrocm*-transferbench*.deb "${WORK}/" 2>/dev/null || true
+          cd "${WORK}"
+          dpkg-scanpackages --multiversion . /dev/null > Packages
+          gzip -k -f Packages
           {
             echo "Origin: ROCm-TransferBench"
             echo "Label: ROCm TransferBench Packages"
@@ -134,10 +138,9 @@ jobs:
             echo "Description: TransferBench DEB packages built from TheRock SDK"
             echo "Date: $(date -Ru)"
           } > Release
-          aws s3 cp Packages    "${S3_DEB_PATH}/Packages"
-          aws s3 cp Packages.gz "${S3_DEB_PATH}/Packages.gz"
-          aws s3 cp Release     "${S3_DEB_PATH}/Release"
-          popd >/dev/null
+          aws s3 sync "${WORK}/" "${S3_DEB_PATH}/" --no-progress
+          echo "=== DEB repo metadata uploaded to ${S3_DEB_PATH}/ ==="
+          aws s3 ls "${S3_DEB_PATH}/" --human-readable
 
   # ============================================================
   # manylinux_2_28 (AlmaLinux 8) — RPM + TGZ
@@ -236,9 +239,13 @@ jobs:
           set -euo pipefail
           dnf install -y createrepo_c || yum install -y createrepo_c
           WORK="$(mktemp -d)"
-          aws s3 sync "${S3_RPM_PATH}/" "${WORK}/" --exclude "*" --include "*.rpm"
+          echo "Downloading existing RPMs from s3://${AWS_S3_BUCKET}/${S3_RPM_PATH#s3://${AWS_S3_BUCKET}/}/ ..."
+          aws s3 sync "${S3_RPM_PATH}/" "${WORK}/" --exclude "repodata/*" --no-progress || true
+          cp build/amdrocm*-transferbench*.rpm "${WORK}/" 2>/dev/null || true
           createrepo_c "${WORK}"
-          aws s3 sync "${WORK}/repodata/" "${S3_RPM_PATH}/repodata/" --delete
+          aws s3 sync "${WORK}/" "${S3_RPM_PATH}/" --no-progress
+          echo "=== RPM repodata uploaded to ${S3_RPM_PATH}/repodata/ ==="
+          aws s3 ls "${S3_RPM_PATH}/repodata/" --human-readable
 
   # ============================================================
   # Build report — collects S3 paths for browsing

--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -122,8 +122,8 @@ jobs:
           WORK="$(mktemp -d)"
           echo "Downloading existing DEBs from ${S3_DEB_PATH}/ ..."
           aws s3 sync "${S3_DEB_PATH}/" "${WORK}/" \
-            --exclude "Packages*" --exclude "Release*" --exclude "InRelease" \
-            --no-progress || true
+            --exclude "*" --include "*.deb" \
+            --no-progress
           cp build/amdrocm*-transferbench*.deb "${WORK}/" 2>/dev/null || true
           cd "${WORK}"
           dpkg-scanpackages --multiversion . /dev/null > Packages
@@ -240,11 +240,11 @@ jobs:
           dnf install -y createrepo_c || yum install -y createrepo_c
           WORK="$(mktemp -d)"
           echo "Downloading existing RPMs from s3://${AWS_S3_BUCKET}/${S3_RPM_PATH#s3://${AWS_S3_BUCKET}/}/ ..."
-          aws s3 sync "${S3_RPM_PATH}/" "${WORK}/" --exclude "repodata/*" --no-progress || true
+          aws s3 sync "${S3_RPM_PATH}/" "${WORK}/" --exclude "repodata/*" --no-progress
           cp build/amdrocm*-transferbench*.rpm "${WORK}/" 2>/dev/null || true
           createrepo_c "${WORK}"
           aws s3 sync "${WORK}/" "${S3_RPM_PATH}/" --no-progress
-          echo "=== RPM repodata uploaded to ${S3_RPM_PATH}/repodata/ ==="
+          echo "=== RPM repository contents (RPMs + repodata) synced to ${S3_RPM_PATH}/ ==="
           aws s3 ls "${S3_RPM_PATH}/repodata/" --human-readable
 
   # ============================================================


### PR DESCRIPTION
## Summary

Fixes the S3 sync failure in the `build-relocatable-packages` workflow by removing the `--delete` flag that requires `s3:DeleteObject` permission.

## Problem

The workflow fails when generating yum repo metadata:
```
delete failed: s3://rocm-transferbench-releases/nightly/transferbench/rpm/repodata/...
An error occurred (AccessDenied) when calling the DeleteObject operation: 
User: arn:aws:sts::317668459450:assumed-role/therock-rocm-transferbench-releases-s3-oidc/GitHubActions 
is not authorized to perform: s3:DeleteObject
```

The `--delete` flag in `aws s3 sync` was being used to remove old metadata files, but the IAM role lacks `s3:DeleteObject` permission.

## Solution

Follow the RVS pattern (ROCm/ROCmValidationSuite workflow):
1. Download **all existing packages** from S3 first
2. Copy the new package into the staging directory
3. Regenerate metadata for **all packages** (existing + new)
4. Sync everything back using `aws s3 sync` (without `--delete`)
5. Metadata files naturally overwrite old ones without explicit deletion

## Changes

### apt metadata (Ubuntu):
- Use `aws s3 sync` instead of individual `aws s3 cp` commands
- Exclude metadata files when syncing down (Packages*, Release*, InRelease)
- Add `--multiversion` flag to `dpkg-scanpackages` for consistency with RVS

### yum metadata (manylinux):
- Remove `--delete` flag from final sync
- Exclude `repodata/*` when syncing down existing RPMs
- Copy current build RPM explicitly before running `createrepo_c`

### Both:
- Add `--no-progress` flags for cleaner logs
- Add human-readable output listing at the end

## Testing

The workflow will be tested via GitHub Actions on this PR. The changes align with the proven RVS workflow pattern that has been working successfully.

## References

- Failed run: https://github.com/ROCm/TransferBench/actions/runs/24906780525/job/72938051747
- RVS workflow: https://github.com/ROCm/ROCmValidationSuite/blob/master/.github/workflows/build-relocatable-packages.yml
- RVS apt metadata: lines 175-204
- RVS yum metadata: lines 342-370