### PR TITLE
Help preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Documentation for TransferBench is available at
 - Added new bmasweep preset that compares DMA to batched DMA execution for parallel transfers to other GPUs
 - Added new wallclock preset that compares wallclock counters across XCCs within a GPU
 - Added new smoketest preset that runs a variety of DMA/GFX tests for simple correctness tests
+- Added new help preset to show config file examples
+- Added new presets preset to show available presets and their descriptions
+- Added new envvars preset to show environment variables that can change TransferBench behavior
+- Adding information on how to run multi-rank with TransferBench, when run with no args
 
 ### Modified
 - DMA-BUF support enablement in CMake changed to ENABLE_DMA_BUF to be more similar to other compile-time options
@@ -30,6 +34,7 @@ Documentation for TransferBench is available at
 - Dynamically size CQs for NIC transfers in high QPs case
 - Switch to using hipMemcpyDeviceToDeviceNoCU instead of hipMemcpyDefault for DMA Executor if available (requires HIP >= 6.0)
 - Allow for multiple destination memory locations for DMA/Batched-DMA Transfers
+- Removed env vars printing and preset print when running TransferBench with no args
 
 ## v1.66.02
 ### Added

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -43,7 +43,6 @@ int main(int argc, char **argv)
       if (!ev.outputToCsv) {
         DisplayVersion();
         DisplayUsage(argv[0]);
-        DisplayPresets();
       }
       DisplayTopology(ev.outputToCsv, ev.showBorders);
     }
@@ -71,7 +70,7 @@ int main(int argc, char **argv)
 
   // Run preset benchmark if requested
   int retCode = 0;
-  if (RunPreset(ev, numBytesPerTransfer, argc, argv, retCode)) return retCode;
+  if (RunPreset(ev, numBytesPerTransfer, argc, argv, retCode, argv[0])) return retCode;
 
   // Read input from command line or configuration file
   bool isDryRun = !strcmp(argv[1], "dryrun");
@@ -256,16 +255,6 @@ void DisplayUsage(char const* cmdName)
     exit(1);
   }
 
-  Print("Usage: %s config <N>\n", cmdName);
-  Print("  config: Either:\n");
-  Print("          - Filename of configFile containing Transfers to execute (see example.cfg for format)\n");
-  Print("          - Name of preset config:\n");
-  Print("  N     : (Optional) Number of bytes to copy per Transfer.\n");
-  Print("          If not specified, defaults to %lu bytes. Must be a multiple of 4 bytes\n",
-        DEFAULT_BYTES_PER_TRANSFER);
-  Print("          If 0 is specified, a range of Ns will be benchmarked\n");
-  Print("          May append a suffix ('K', 'M', 'G') for kilobytes / megabytes / gigabytes\n");
+  DisplayBasicUsage(cmdName);
   Print("\n");
-
-  EnvVars::DisplayUsage();
 };

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -255,6 +255,28 @@ void DisplayUsage(char const* cmdName)
     exit(1);
   }
 
-  DisplayBasicUsage(cmdName);
+  Print("Usage: %s config <N>\n", cmdName);
+  Print("  config: Either:\n");
+  Print("          - Filename of config file containing Transfers to execute\n");
+  Print("          - Name of preset config\n");
+  Print("          - 'cmdline' followed by one transfer expression\n");
+  Print("          - 'dryrun' followed by one transfer expression (prints parsed transfers only)\n");
+  Print("  N     : (Optional) Number of bytes to copy per Transfer.\n");
+  Print("          If not specified, defaults to %lu. Must be a multiple of 4 bytes\n", DEFAULT_BYTES_PER_TRANSFER);
+  Print("          If 0 is specified, a range of Ns will be benchmarked\n");
+  Print("          May append a suffix ('K', 'M', 'G') for kilobytes / megabytes / gigabytes\n");
   Print("\n");
+  Print("- Use \"%s help\"    for more information about how to create config files / describe Transfers\n", cmdName);
+  Print("- Use \"%s envvars\" for more information about environment variables that customize behavior\n", cmdName);
+  Print("- Use \"%s presets\" to display list of available presets\n", cmdName);
+  Print("\n");
+  Print("For multi-rank usage, TransferBench must either be compiled with MPI support or rely on sockets\n");
+  Print("It is recommended to only run one process per node\n");
+  Print(" - MPI approach:\n");
+  Print("   Node 0> mpirun –np 4 –host node0,node1,node2,node3 ./TransferBench a2a\n");
+  Print(" - Socket approach:\n");
+  Print("   Node 0> TB_RANK=0 TB_NUM_RANKS=4 TB_MASTER_ADDR=X.X.X.X ./TransferBench a2a\n");
+  Print("   Node 1> TB_RANK=1 TB_NUM_RANKS=4 TB_MASTER_ADDR=X.X.X.X ./TransferBench a2a\n");
+  Print("   Node 2> TB_RANK=2 TB_NUM_RANKS=4 TB_MASTER_ADDR=X.X.X.X ./TransferBench a2a\n");
+  Print("   Node 3> TB_RANK=3 TB_NUM_RANKS=4 TB_MASTER_ADDR=X.X.X.X ./TransferBench a2a\n");
 };

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
 
   // Run preset benchmark if requested
   int retCode = 0;
-  if (RunPreset(ev, numBytesPerTransfer, argc, argv, retCode, argv[0])) return retCode;
+  if (RunPreset(ev, numBytesPerTransfer, argc, argv, retCode)) return retCode;
 
   // Read input from command line or configuration file
   bool isDryRun = !strcmp(argv[1], "dryrun");

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -273,7 +273,7 @@ void DisplayUsage(char const* cmdName)
   Print("For multi-rank usage, TransferBench must either be compiled with MPI support or rely on sockets\n");
   Print("It is recommended to only run one process per node\n");
   Print(" - MPI approach:\n");
-  Print("   Node 0> mpirun –np 4 –host node0,node1,node2,node3 ./TransferBench a2a\n");
+  Print("   Node 0> mpirun -np 4 -host node0,node1,node2,node3 ./TransferBench a2a\n");
   Print(" - Socket approach:\n");
   Print("   Node 0> TB_RANK=0 TB_NUM_RANKS=4 TB_MASTER_ADDR=X.X.X.X ./TransferBench a2a\n");
   Print("   Node 1> TB_RANK=1 TB_NUM_RANKS=4 TB_MASTER_ADDR=X.X.X.X ./TransferBench a2a\n");

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -353,7 +353,7 @@ public:
     printf(" ROCE_VERSION        - RoCE version (default=2)\n");
 #endif
     printf(" SAMPLING_FACTOR     - Add this many samples (when possible) between powers of 2 when auto-generating data sizes\n");
-    printf(" SHOW_BORDERS        - Show ASCII box-drawing characaters in tables\n");
+    printf(" SHOW_BORDERS        - Show ASCII box-drawing characters in tables\n");
     printf(" SHOW_ITERATIONS     - Show per-iteration timing info\n");
     printf(" USE_HIP_EVENTS      - Use HIP events for GFX executor timing\n");
     printf(" USE_HSA_DMA         - Use hsa_amd_async_copy instead of hipMemcpy for non-targeted DMA execution\n");

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -338,7 +338,7 @@ public:
     printf(" IB_PORT_NUMBER      - RDMA port count for RDMA NIC (default=1)\n");
     printf(" IP_ADDRESS_FAMILY   - IP address family (4=v4, 6=v6, default=v4)\n");
 #endif
-    printf(" MIN_VAR_SUBEXEC     - Minumum # of subexecutors to use for variable subExec Transfers\n");
+    printf(" MIN_VAR_SUBEXEC     - Minimum # of subexecutors to use for variable subExec Transfers\n");
     printf(" MAX_VAR_SUBEXEC     - Maximum # of subexecutors to use for variable subExec Transfers (0 for device limits)\n");
 #if NIC_EXEC_ENABLED
     printf(" NIC_CHUNK_BYTES     - Number of bytes to send at a time using NIC (default = 1GB)\n");

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -314,55 +314,69 @@ public:
   }
 
   // Display info on the env vars that can be used
-  static void DisplayUsage()
+  static void DisplayEnvVarsList()
   {
-    printf("Environment variables:\n");
+    printf("Environment variables (client):\n");
     printf("======================\n");
-    printf(" ALWAYS_VALIDATE   - Validate after each iteration instead of once after all iterations\n");
-    printf(" BLOCK_BYTES       - Controls granularity of how work is divided across subExecutors\n");
-    printf(" BYTE_OFFSET       - Initial byte-offset for memory allocations.  Must be multiple of 4\n");
-    printf(" CU_MASK           - CU mask for streams. Can specify ranges e.g '5,10-12,14'\n");
-    printf(" FILL_COMPRESS     - Percentages of 64B lines to be filled by random/1B0/2B0/4B0/32B0\n");
-    printf(" FILL_PATTERN      - Big-endian pattern for source data, specified in hex digits. Must be even # of digits\n");
-    printf(" GFX_BLOCK_ORDER   - How blocks for transfers are ordered. 0=sequential, 1=interleaved\n");
-    printf(" GFX_BLOCK_SIZE    - # of threads per threadblock (Must be multiple of 64)\n");
-    printf(" GFX_SE_TYPE       - SubExecutor granularity type (0=threadblock, 1=warp)\n");
-    printf(" GFX_TEMPORAL      - Use of non-temporal loads or stores (0=none 1=loads 2=stores 3=both)\n");
-    printf(" GFX_UNROLL        - Unroll factor for GFX kernel (0=auto), must be less than %d\n", TransferBench::GetIntAttribute(ATR_GFX_MAX_UNROLL));
-    printf(" GFX_SINGLE_TEAM   - Have subexecutors work together on full array instead of working on disjoint subarrays\n");
-    printf(" GFX_WAVE_ORDER    - Stride pattern for GFX kernel (0=UWC,1=UCW,2=WUC,3=WCU,4=CUW,5=CWU)\n");
-    printf(" GFX_WORD_SIZE     - GFX kernel packed data size (4=DWORDx4, 2=DWORDx2, 1=DWORDx1)\n");
-    printf(" HIDE_ENV          - Hide environment variable value listing\n");
+    printf(" ALWAYS_VALIDATE     - Validate after each iteration instead of once after all iterations\n");
+    printf(" BLOCK_BYTES         - Controls granularity of how work is divided across subExecutors\n");
+    printf(" BYTE_OFFSET         - Initial byte-offset for memory allocations.  Must be multiple of 4\n");
+    printf(" CU_MASK             - CU mask for streams. Can specify ranges e.g '5,10-12,14'\n");
+    printf(" FILL_COMPRESS       - Percentages of 64B lines to be filled by random/1B0/2B0/4B0/32B0\n");
+    printf(" FILL_PATTERN        - Big-endian pattern for source data, specified in hex digits. Must be even # of digits\n");
+    printf(" GFX_BLOCK_ORDER     - How blocks for transfers are ordered. 0=sequential, 1=interleaved\n");
+    printf(" GFX_BLOCK_SIZE      - # of threads per threadblock (Must be multiple of 64)\n");
+    printf(" GFX_SE_TYPE         - SubExecutor granularity type (0=threadblock, 1=warp)\n");
+    printf(" GFX_TEMPORAL        - Use of non-temporal loads or stores (0=none 1=loads 2=stores 3=both)\n");
+    printf(" GFX_UNROLL          - Unroll factor for GFX kernel (0=auto), must be less than %d\n", TransferBench::GetIntAttribute(ATR_GFX_MAX_UNROLL));
+    printf(" GFX_SINGLE_TEAM     - Have subexecutors work together on full array instead of working on disjoint subarrays\n");
+    printf(" GFX_WAVE_ORDER      - Stride pattern for GFX kernel (0=UWC,1=UCW,2=WUC,3=WCU,4=CUW,5=CWU)\n");
+    printf(" GFX_WORD_SIZE       - GFX kernel packed data size (4=DWORDx4, 2=DWORDx2, 1=DWORDx1)\n");
+    printf(" HIDE_ENV            - Hide environment variable value listing\n");
 #if NIC_EXEC_ENABLED
-    printf(" IB_GID_INDEX      - Required for RoCE NICs (default=-1/auto)\n");
-    printf(" IB_PORT_NUMBER    - RDMA port count for RDMA NIC (default=1)\n");
-    printf(" IP_ADDRESS_FAMILY - IP address family (4=v4, 6=v6, default=v4)\n");
+    printf(" IB_GID_INDEX        - Required for RoCE NICs (default=-1/auto)\n");
+    printf(" IB_PORT_NUMBER      - RDMA port count for RDMA NIC (default=1)\n");
+    printf(" IP_ADDRESS_FAMILY   - IP address family (4=v4, 6=v6, default=v4)\n");
 #endif
-    printf(" MIN_VAR_SUBEXEC   - Minumum # of subexecutors to use for variable subExec Transfers\n");
-    printf(" MAX_VAR_SUBEXEC   - Maximum # of subexecutors to use for variable subExec Transfers (0 for device limits)\n");
+    printf(" MIN_VAR_SUBEXEC     - Minumum # of subexecutors to use for variable subExec Transfers\n");
+    printf(" MAX_VAR_SUBEXEC     - Maximum # of subexecutors to use for variable subExec Transfers (0 for device limits)\n");
 #if NIC_EXEC_ENABLED
-    printf(" NIC_CHUNK_BYTES   - Number of bytes to send at a time using NIC (default = 1GB)\n");
-    printf(" NIC_CQ_POLL_BATCH - Number of CQ entries to poll per ibv_poll_cq call (default = 4)\n");
-    printf(" NIC_RELAX_ORDER   - Set to non-zero to use relaxed ordering");
+    printf(" NIC_CHUNK_BYTES     - Number of bytes to send at a time using NIC (default = 1GB)\n");
+    printf(" NIC_CQ_POLL_BATCH   - Number of CQ entries to poll per ibv_poll_cq call (default = 4)\n");
+    printf(" NIC_RELAX_ORDER     - Set to non-zero to use relaxed ordering\n");
 #endif
-    printf(" NUM_ITERATIONS    - # of timed iterations per test. If negative, run for this many seconds instead\n");
-    printf(" NUM_SUBITERATIONS - # of sub-iterations to run per iteration. Must be non-negative\n");
-    printf(" NUM_WARMUPS       - # of untimed warmup iterations per test\n");
-    printf(" OUTPUT_TO_CSV     - Outputs to CSV format if set\n");
+    printf(" NUM_ITERATIONS      - # of timed iterations per test. If negative, run for this many seconds instead\n");
+    printf(" NUM_SUBITERATIONS   - # of sub-iterations to run per iteration. Must be non-negative\n");
+    printf(" NUM_WARMUPS         - # of untimed warmup iterations per test\n");
+    printf(" OUTPUT_TO_CSV       - Outputs to CSV format if set\n");
 #if NIC_EXEC_ENABLED
-    printf(" ROCE_VERSION      - RoCE version (default=2)\n");
+    printf(" ROCE_VERSION        - RoCE version (default=2)\n");
 #endif
-    printf(" SAMPLING_FACTOR   - Add this many samples (when possible) between powers of 2 when auto-generating data sizes\n");
-    printf(" SHOW_BORDERS      - Show ASCII box-drawing characaters in tables\n");
-    printf(" SHOW_ITERATIONS   - Show per-iteration timing info\n");
-    printf(" USE_HIP_EVENTS    - Use HIP events for GFX executor timing\n");
-    printf(" USE_HSA_DMA       - Use hsa_amd_async_copy instead of hipMemcpy for non-targeted DMA execution\n");
-    printf(" USE_INTERACTIVE   - Pause for user-input before starting transfer loop\n");
-    printf(" USE_SINGLE_STREAM - Use a single stream per GPU GFX executor instead of stream per Transfer\n");
-    printf(" VALIDATE_DIRECT   - Validate GPU destination memory directly instead of staging GPU memory on host\n");
-    printf(" VALIDATE_SOURCE   - Validate GPU src memory immediately after preparation\n");
+    printf(" SAMPLING_FACTOR     - Add this many samples (when possible) between powers of 2 when auto-generating data sizes\n");
+    printf(" SHOW_BORDERS        - Show ASCII box-drawing characaters in tables\n");
+    printf(" SHOW_ITERATIONS     - Show per-iteration timing info\n");
+    printf(" USE_HIP_EVENTS      - Use HIP events for GFX executor timing\n");
+    printf(" USE_HSA_DMA         - Use hsa_amd_async_copy instead of hipMemcpy for non-targeted DMA execution\n");
+    printf(" USE_INTERACTIVE     - Pause for user-input before starting transfer loop\n");
+    printf(" USE_SINGLE_STREAM   - Use a single stream per GPU GFX executor instead of stream per Transfer\n");
+    printf(" VALIDATE_DIRECT     - Validate GPU destination memory directly instead of staging GPU memory on host\n");
+    printf(" VALIDATE_SOURCE     - Validate GPU src memory immediately after preparation\n");
+    printf("\n");
+    printf("Environment variables (back-end):\n");
+    printf("====================================\n");
+    printf(" TB_RANK             - Used to specify the rank of this process (0-based, socket communicator)\n");
+    printf(" TB_NUM_RANKS        - Used to specific the total number of ranks (socket communicator)\n");
+    printf(" TB_MASTER_ADDR      - Used to set Rank 0 IP/hostname for socket communicator\n");
+    printf(" TB_MASTER_PORT      - Used to set Rank 0 port for socket communicator (default: 29500)\n");
+    printf(" TB_SINGLE_LOG       - In socket mode, only rank 0 logs when set\n");
+    printf(" TB_VERBOSE          - Enables additional internal logging\n");
+    printf(" TB_DUMP_CFG_FILE    - Writes executed transfers to a config file\n");
+    printf(" TB_DUMP_LINES       - Dumps randomized input-line statistics for FILL_COMPRESS setup\n");
+    printf(" TB_NIC_FILTER       - Regex filter to limit NIC visibility for NIC executors\n");
+    printf(" TB_FORCE_SINGLE_POD - Forces all ranks into one pod (skips pod query)\n");
+    printf(" TB_WALLCLOCK_RATE   - Overrides queried GPU wallclock rate if needed\n");
+    printf(" TB_PAUSE            - Pauses startup for debugger attachment\n");
   }
-
 
   void Print(std::string const& name, int32_t const value, const char* format, ...) const
   {

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -365,7 +365,7 @@ public:
     printf("Environment variables (back-end):\n");
     printf("====================================\n");
     printf(" TB_RANK             - Used to specify the rank of this process (0-based, socket communicator)\n");
-    printf(" TB_NUM_RANKS        - Used to specific the total number of ranks (socket communicator)\n");
+    printf(" TB_NUM_RANKS        - Used to specify the total number of ranks (socket communicator)\n");
     printf(" TB_MASTER_ADDR      - Used to set Rank 0 IP/hostname for socket communicator\n");
     printf(" TB_MASTER_PORT      - Used to set Rank 0 port for socket communicator (default: 29500)\n");
     printf(" TB_SINGLE_LOG       - In socket mode, only rank 0 logs when set\n");

--- a/src/client/Presets/EnvVarsList.hpp
+++ b/src/client/Presets/EnvVarsList.hpp
@@ -20,10 +20,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-int EnvVarsPreset(EnvVars&          ev,
-                  size_t      const numBytesPerTransfer,
-                  std::string const presetName,
-                  bool        const bytesSpecified)
+int EnvVarsPreset([[maybe_unused]] EnvVars&          ev,
+                  [[maybe_unused]] size_t      const numBytesPerTransfer,
+                  [[maybe_unused]] std::string const presetName,
+                  [[maybe_unused]] bool        const bytesSpecified)
 {
   if (!Utils::RankDoesOutput()) return 0;
   EnvVars::DisplayEnvVarsList();

--- a/src/client/Presets/EnvVarsList.hpp
+++ b/src/client/Presets/EnvVarsList.hpp
@@ -1,0 +1,31 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+int EnvVarsPreset(EnvVars&          ev,
+                  size_t      const numBytesPerTransfer,
+                  std::string const presetName,
+                  bool        const bytesSpecified)
+{
+  if (!Utils::RankDoesOutput()) return 0;
+  EnvVars::DisplayEnvVarsList();
+  return 0;
+}

--- a/src/client/Presets/Help.hpp
+++ b/src/client/Presets/Help.hpp
@@ -62,7 +62,7 @@ int HelpPreset(EnvVars&          ev,
   printf("\n");
   printf("# Argument Details:\n");
   printf("#   #Transfers:   Number of Transfers to be run in parallel\n");
-  printf("#   #SEs      :   Number of SubExectors to use (CPU threads/ GPU threadblocks)\n");
+  printf("#   #SEs      :   Number of SubExecutors to use (CPU threads/ GPU threadblocks)\n");
   printf("#   srcMemL   :   Source memory locations (Where the data is to be read from)\n");
   printf("#   Executor  :   Executor is specified by a character indicating type, followed by device index (0-indexed)\n");
   printf("#                 - C:    CPU-executed          (Indexed from 0 to # NUMA nodes - 1)\n");

--- a/src/client/Presets/Help.hpp
+++ b/src/client/Presets/Help.hpp
@@ -1,0 +1,123 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+int HelpPreset(EnvVars&          ev,
+               size_t      const numBytesPerTransfer,
+               std::string const presetName,
+               bool        const bytesSpecified)
+{
+  if (!Utils::RankDoesOutput()) return 0;
+
+  printf("# ConfigFile Format:\n");
+  printf("# ==================\n");
+  printf("# A Transfer is defined as a single operation where an Executor reads and adds together\n");
+  printf("# values from Source (SRC) memory locations, then writes the sum to destination (DST) memory locations.\n");
+  printf("# This simplifies to a simple copy operation when dealing with single SRC/DST.\n");
+  printf("#\n");
+  printf("#                SRC 0                DST 0\n");
+  printf("#                SRC 1 -> Executor -> DST 1\n");
+  printf("#                SRC X                DST Y\n");
+  printf("\n");
+  printf("# Five Executors are supported by TransferBench\n");
+  printf("#   Executor:        SubExecutor:\n");
+  printf("#   1) CPU           CPU thread\n");
+  printf("#   2) GPU           GPU threadblock/Compute Unit (CU)\n");
+  printf("#   3) DMA           N/A.                                 (Must have single SRC, at least one DST)\n");
+  printf("#   4) NIC           Queue Pair\n");
+  printf("#   5) Batched-DMA   Batch item                           (Must have single SRC, at least one DST)\n");
+  printf("\n");
+  printf("# Each single line in the configuration file defines a set of Transfers (a Test) to run in parallel\n");
+  printf("\n");
+  printf("# There are two ways to specify a Test:\n");
+  printf("\n");
+  printf("# 1) Basic\n");
+  printf("#    The basic specification assumes the same number of SubExecutors (SE) used per Transfer\n");
+  printf("#    A positive number of Transfers is specified followed by that number of triplets describing each Transfer\n");
+  printf("\n");
+  printf("#    #Transfers #SEs (srcMem1->Executor1->dstMem1) ... (srcMemL->ExecutorL->dstMemL)\n");
+  printf("\n");
+  printf("# 2) Advanced\n");
+  printf("#    A negative number of Transfers is specified, followed by quintuplets describing each Transfer\n");
+  printf("#    A non-zero number of bytes specified will override any provided value\n");
+  printf("#    -#Transfers (srcMem1->Executor1->dstMem1 #SEs1 Bytes1) ... (srcMemL->ExecutorL->dstMemL #SEsL BytesL)\n");
+  printf("\n");
+  printf("# Argument Details:\n");
+  printf("#   #Transfers:   Number of Transfers to be run in parallel\n");
+  printf("#   #SEs      :   Number of SubExectors to use (CPU threads/ GPU threadblocks)\n");
+  printf("#   srcMemL   :   Source memory locations (Where the data is to be read from)\n");
+  printf("#   Executor  :   Executor is specified by a character indicating type, followed by device index (0-indexed)\n");
+  printf("#                 - C:    CPU-executed          (Indexed from 0 to # NUMA nodes - 1)\n");
+  printf("#                 - G:    GPU-executed          (Indexed from 0 to # GPUs - 1)\n");
+  printf("#                 - D:    DMA-executor          (Indexed from 0 to # GPUs - 1)\n");
+  printf("#                 - B:    Batched-DMA-executor  (Indexed from 0 to # GPUs - 1)\n");
+  printf("#                 - I#.#: NIC executor          (Indexed from 0 to # NICs - 1)\n");
+  printf("#                 - N#.#: Nearest NIC executor  (Indexed from 0 to # GPUs - 1)\n");
+  printf("#   dstMemL   :   Destination memory locations (Where the data is to be written to)\n");
+  printf("#   bytesL    :   Number of bytes to copy (0 means use command-line specified size)\n");
+  printf("#                 Must be a multiple of 4 and may be suffixed with ('K','M', or 'G')\n");
+  printf("#\n");
+  printf("#                 Memory locations are specified by one or more (device character / device index) pairs\n");
+  printf("#                 Character indicating memory type followed by device index (0-indexed)\n");
+  printf("#                 Supported memory locations are:\n");
+  printf("#                 - C:    Pinned host memory              (on NUMA node, indexed from 0 to [# NUMA nodes-1])\n");
+  printf("#                 - P:    Pinned host memory              (on NUMA node, indexed by closest GPU [# GPUs -1])\n");
+  printf("#                 - B:    Coherent pinned host memory     (on NUMA node, indexed from 0 to [# NUMA nodes-1])\n");
+  printf("#                 - D:    Non-coherent pinned host memory (on NUMA node, indexed from 0 to [# NUMA nodes-1])\n");
+  printf("#                 - K:    Uncached pinned host memory     (on NUMA node, indexed from 0 to [# NUMA nodes-1])\n");
+  printf("#                 - H:    Unpinned host memory            (on NUMA node, indexed from 0 to [# NUMA nodes-1])\n");
+  printf("#                 - G:    Global device memory            (on GPU device indexed from 0 to [# GPUs - 1])\n");
+  printf("#                 - F:    Fine-grain device memory        (on GPU device indexed from 0 to [# GPUs - 1])\n");
+  printf("#                 - U:    Uncached device memory          (on GPU device indexed from 0 to [# GPUs - 1])\n");
+  printf("#                 - N:    Null memory                     (index ignored)\n");
+  printf("\n");
+  printf("\n");
+  printf("# Examples:\n");
+  printf("# 1 4 (G0->G0->G1)                   Uses 4 CUs on GPU0 to copy from GPU0 to GPU1\n");
+  printf("# 1 4 (C1->G2->G0)                   Uses 4 CUs on GPU2 to copy from CPU1 to GPU0\n");
+  printf("# 2 4 G0->G0->G1 G1->G1->G0          Copes from GPU0 to GPU1, and GPU1 to GPU0, each with 4 SEs\n");
+  printf("# -2 (G0 G0 G1 4 1M) (G1 G1 G0 2 2M) Copies 1Mb from GPU0 to GPU1 with 4 SEs, and 2Mb from GPU1 to GPU0 with 2 SEs\n");
+  printf("# 1 2 (F0->I0.2->F1)                 Uses 2 QPs to transfer data from GPU0 via NIC0 to GPU1 via NIC2\n");
+  printf("# 1 1 (F0->N0.1->F1)                 Uses 1 QP to transfer data from GPU0 via GPU0's closest NIC to GPU1 via GPU1's closest NIC\n");
+  printf("# -2 (G0->N0.1->G1 2 128M) (G1->N1.0->G0 1 256M) Uses Nearest NIC executor to copy 128Mb from GPU0 to GPU1 with 2 QPs,\n");
+  printf("#                                                and 256Mb from GPU1 to GPU0 with 1 QP\n");
+  printf("# Round brackets and arrows' ->' may be included for human clarity, but will be ignored and are unnecessary\n");
+  printf("# Lines starting with # will be ignored. Lines starting with ## will be echoed to output\n");
+  printf("\n");
+  printf("## Single GPU-executed Transfer between GPUs 0 and 1 using 4 CUs\n");
+  printf("1 4 (G0->G0->G1)\n");
+  printf("\n");
+  printf("## Single DMA executed Transfer between GPUs 0 and 1\n");
+  printf("1 1 (G0->D0->G1)\n");
+  printf("\n");
+  printf("## Copy 1Mb from GPU0 to GPU1 with 4 CUs, and 2Mb from GPU1 to GPU0 with 8 CUs\n");
+  printf("-2 (G0->G0->G1 4 1M) (G1->G1->G0 8 2M)\n");
+  printf("\n");
+  printf("## \"Memset\" by GPU 0 to GPU 0 memory\n");
+  printf("1 32 (N0->G0->G0)\n");
+  printf("\n");
+  printf("## \"Read-only\" by CPU 0\n");
+  printf("1 4 (C0->C0->N0)\n");
+  printf("\n");
+  printf("## Broadcast from GPU 0 to GPU 0 and GPU 1\n");
+  printf("1 16 (G0->G0->G0G1)\n");
+  return 0;
+}

--- a/src/client/Presets/Help.hpp
+++ b/src/client/Presets/Help.hpp
@@ -93,7 +93,7 @@ int HelpPreset([[maybe_unused]] EnvVars&          ev,
   printf("# Examples:\n");
   printf("# 1 4 (G0->G0->G1)                   Uses 4 CUs on GPU0 to copy from GPU0 to GPU1\n");
   printf("# 1 4 (C1->G2->G0)                   Uses 4 CUs on GPU2 to copy from CPU1 to GPU0\n");
-  printf("# 2 4 G0->G0->G1 G1->G1->G0          Copes from GPU0 to GPU1, and GPU1 to GPU0, each with 4 SEs\n");
+  printf("# 2 4 G0->G0->G1 G1->G1->G0          Copies from GPU0 to GPU1, and GPU1 to GPU0, each with 4 SEs\n");
   printf("# -2 (G0 G0 G1 4 1M) (G1 G1 G0 2 2M) Copies 1Mb from GPU0 to GPU1 with 4 SEs, and 2Mb from GPU1 to GPU0 with 2 SEs\n");
   printf("# 1 2 (F0->I0.2->F1)                 Uses 2 QPs to transfer data from GPU0 via NIC0 to GPU1 via NIC2\n");
   printf("# 1 1 (F0->N0.1->F1)                 Uses 1 QP to transfer data from GPU0 via GPU0's closest NIC to GPU1 via GPU1's closest NIC\n");

--- a/src/client/Presets/Help.hpp
+++ b/src/client/Presets/Help.hpp
@@ -20,10 +20,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-int HelpPreset(EnvVars&          ev,
-               size_t      const numBytesPerTransfer,
-               std::string const presetName,
-               bool        const bytesSpecified)
+int HelpPreset([[maybe_unused]] EnvVars&          ev,
+               [[maybe_unused]] size_t      const numBytesPerTransfer,
+               [[maybe_unused]] std::string const presetName,
+               [[maybe_unused]] bool        const bytesSpecified)
 {
   if (!Utils::RankDoesOutput()) return 0;
 

--- a/src/client/Presets/Presets.hpp
+++ b/src/client/Presets/Presets.hpp
@@ -32,9 +32,11 @@ THE SOFTWARE.
 #include "AllToAllN.hpp"
 #include "AllToAllSweep.hpp"
 #include "BmaSweep.hpp"
+#include "EnvVarsList.hpp"
 #include "GfxSweep.hpp"
 #include "HbmBandwidth.hpp"
 #include "HealthCheck.hpp"
+#include "Help.hpp"
 #include "NicRings.hpp"
 #include "NicPeerToPeer.hpp"
 #include "OneToAll.hpp"
@@ -55,110 +57,45 @@ typedef int (*PresetFunc)(EnvVars&          ev,
 struct PresetInfo
 {
   PresetFunc   func;
-  bool         multiRankCompatible;
   std::string  description;
-  std::string  details;
 };
 
 std::map<std::string, PresetInfo> presetFuncMap =
 {
-  {"a2a",         {AllToAllPreset,      true,  "Tests parallel transfers between all pairs of GPU devices",
-                   "Runs dense all-to-all copies across all visible GPUs (and ranks when present)."}},
-  {"a2a_n",       {AllToAllRdmaPreset,  false, "Tests parallel transfers between all pairs of GPU devices using Nearest NIC RDMA transfers",
-                   "Exercises nearest-NIC RDMA path for all GPU pairs (single rank only)."}},
-  {"a2asweep",    {AllToAllSweepPreset, false, "Test GFX-based all-to-all transfers swept across different CU and GFX unroll counts",
-                   "Sweeps CU and unroll settings to tune GFX all-to-all behavior."}},
-  {"bmasweep",    {BmaSweepPreset,      false, "Test and compare batched DMA executor for multi destination copies",
-                   "Compares batched DMA strategies for fan-out copy patterns."}},
-  {"gfxsweep",    {GfxSweepPreset,      true,  "Sweep over various GFX kernel options for a given GFX Transfer",
-                   "Sweeps GFX kernel parameters and reports best-performing combinations."}},
-  {"hbm",         {HbmBandwidthPreset,  true,  "Tests HBM bandwidth",
-                   "Measures sustained HBM read/write/copy behavior per GPU."}},
-  {"healthcheck", {HealthCheckPreset,   false, "Simple bandwidth health check (MI300X series only)",
-                   "Quick functional and bandwidth sanity test for supported MI300X setups."}},
-  {"nicrings",    {NicRingsPreset,      true,  "Tests NIC rings created across identical NIC indices across ranks",
-                   "Builds rank-wise NIC rings and measures collective ring bandwidth."}},
-  {"nicp2p",      {NicPeerToPeerPreset, true,  "Multi-node peer-to-peer RDMA transfer test between all NICs",
-                   "Runs exhaustive NIC-to-NIC RDMA throughput checks across ranks."}},
-  {"one2all",     {OneToAllPreset,      false, "Test all subsets of parallel transfers from one GPU to all others",
-                   "Evaluates one-source to many-destination transfer combinations."}},
-  {"p2p"   ,      {PeerToPeerPreset,    false, "Peer-to-peer device memory bandwidth test",
-                   "Benchmarks direct GPU-to-GPU memory transfer throughput."}},
-  {"poda2a",      {PodAllToAllPreset,   true,  "All-to-all transfers between subgroups of ranks within a pod",
-                   "Runs all-to-all over pod-scoped rank groups using detected pod membership."}},
-  {"podp2p",      {PodPeerToPeerPreset, true,  "Peer-to-peer transfers test among ranks within a pod",
-                   "Benchmarks pod-local peer transfer patterns across participating ranks."}},
-  {"rsweep",      {SweepPreset,         false, "Randomly sweep through sets of Transfers",
-                   "Randomized transfer sweep for broad spot-checking of transfer combinations."}},
-  {"scaling",     {ScalingPreset,       false, "Run scaling test from one GPU to other devices",
-                   "Measures scaling as destination count grows from a source GPU."}},
-  {"schmoo",      {SchmooPreset,        false, "Scaling tests for local/remote read/write/copy",
-                   "Runs schmoo-style sweeps over size and transfer type combinations."}},
-  {"smoketest",   {SmokeTestPreset,     true,  "Simple correctness smoke-test",
-                   "Fast correctness and sanity checks before running longer benchmarks."}},
-  {"sweep",       {SweepPreset,         false, "Ordered sweep through sets of Transfers",
-                   "Deterministic ordered sweep through predefined transfer combinations."}},
-  {"wallclock",   {WallClockPreset,     true,  "Tests wallclock consistency across XCCs within a GPU",
-                   "Checks GPU wallclock consistency and timing alignment across XCCs."}},
+  {"a2a",         {AllToAllPreset,      "Tests parallel transfers between all pairs of GPU devices"}},
+  {"a2a_n",       {AllToAllRdmaPreset,  "Tests parallel transfers between all pairs of GPU devices using Nearest NIC RDMA transfers"}},
+  {"a2asweep",    {AllToAllSweepPreset, "Test GFX-based all-to-all transfers swept across different CU and GFX unroll counts"}},
+  {"bmasweep",    {BmaSweepPreset,      "Test and compare batched DMA executor for multi destination copies"}},
+  {"envvars",     {EnvVarsPreset,       "Show list of environment variables that can be used to modify behavior"}},
+  {"gfxsweep",    {GfxSweepPreset,      "Sweep over various GFX kernel options for a given GFX Transfer"}},
+  {"hbm",         {HbmBandwidthPreset,  "Tests HBM bandwidth"}},
+  {"healthcheck", {HealthCheckPreset,   "Simple bandwidth health check (MI300X series only)"}},
+  {"help",        {HelpPreset,          "Shows example usage details"}},
+  {"nicrings",    {NicRingsPreset,      "Tests NIC rings created across identical NIC indices across ranks"}},
+  {"nicp2p",      {NicPeerToPeerPreset, "Multi-node peer-to-peer RDMA transfer test between all NICs"}},
+  {"one2all",     {OneToAllPreset,      "Test all subsets of parallel transfers from one GPU to all others"}},
+  {"p2p"   ,      {PeerToPeerPreset,    "Peer-to-peer device memory bandwidth test"}},
+  {"poda2a",      {PodAllToAllPreset,   "All-to-all transfers between subgroups of ranks within a pod"}},
+  {"podp2p",      {PodPeerToPeerPreset, "Peer-to-peer transfers test among ranks within a pod"}},
+  {"rsweep",      {SweepPreset,         "Randomly sweep through sets of Transfers"}},
+  {"scaling",     {ScalingPreset,       "Run scaling test from one GPU to other devices"}},
+  {"schmoo",      {SchmooPreset,        "Scaling tests for local/remote read/write/copy"}},
+  {"smoketest",   {SmokeTestPreset,     "Simple correctness smoke-test"}},
+  {"sweep",       {SweepPreset,         "Ordered sweep through sets of Transfers"}},
+  {"wallclock",   {WallClockPreset,     "Tests wallclock consistency across XCCs within a GPU"}},
 };
-
-void DisplayBasicUsage(char const* cmdName)
-{
-  printf("Usage: %s config <N>\n", cmdName);
-  printf("  config: Either:\n");
-  printf("          - Filename of config file containing Transfers to execute (see example.cfg for format)\n");
-  printf("          - Name of preset config (run '%s presets' to list available presets)\n", cmdName);
-  printf("          - 'cmdline' followed by one transfer expression\n");
-  printf("          - 'dryrun' followed by one transfer expression (prints parsed transfers only)\n");
-  printf("  N     : (Optional) Number of bytes to copy per Transfer.\n");
-  printf("          If not specified, defaults to 268435456 bytes. Must be a multiple of 4 bytes\n");
-  printf("          If 0 is specified, a range of Ns will be benchmarked\n");
-  printf("          May append a suffix ('K', 'M', 'G') for kilobytes / megabytes / gigabytes\n");
-}
-
-void DisplayTbEnvVarUsage()
-{
-  printf("\nInternal TB_* environment variables:\n");
-  printf("====================================\n");
-  printf(" TB_RANK            - Rank of this process (0-based, socket communicator)\n");
-  printf(" TB_NUM_RANKS       - Total number of ranks (socket communicator)\n");
-  printf(" TB_MASTER_ADDR     - Rank 0 IP/hostname for socket communicator\n");
-  printf(" TB_MASTER_PORT     - Rank 0 port for socket communicator (default: 29500)\n");
-  printf(" TB_SINGLE_LOG      - In socket mode, only rank 0 logs when set\n");
-  printf(" TB_VERBOSE         - Enables additional internal logging\n");
-  printf(" TB_DUMP_CFG_FILE   - Writes executed transfers to a config file\n");
-  printf(" TB_DUMP_LINES      - Dumps randomized input-line statistics for FILL_COMPRESS setup\n");
-  printf(" TB_NIC_FILTER      - Regex filter to limit NIC visibility for NIC executors\n");
-  printf(" TB_FORCE_SINGLE_POD- Forces all ranks into one pod (skips pod query)\n");
-  printf(" TB_WALLCLOCK_RATE  - Overrides queried GPU wallclock rate if needed\n");
-  printf(" TB_PAUSE           - Pauses startup for debugger attachment\n");
-}
 
 void DisplayPresets()
 {
-  printf("\nAvailable Presets:\n");
-  printf("======================================================================================================================\n");
-  printf(" %-12s | %-18s | %-56s\n", "Preset", "Multi-rank", "What it does");
-  printf("======================================================================================================================\n");
+  if (!Utils::RankDoesOutput()) return;
+  printf(" %-12s | %-56s\n", "Preset", "Description");
+  printf("=============================================================================================================\n");
   for (auto const& x : presetFuncMap) {
-    printf(" %-12s | %-18s | %-56s\n",
+    printf(" %-12s | %-56s\n",
            x.first.c_str(),
-           x.second.multiRankCompatible ? "Yes (see notes)" : "No",
-           x.second.details.c_str());
+           x.second.description.c_str());
   }
-  printf(" %-12s | %-18s | %-56s\n", "help", "N/A", "Shows usage details, public env vars, and internal TB_* env vars");
-  printf(" %-12s | %-18s | %-56s\n", "presets", "N/A", "Shows this preset table with compatibility and descriptions");
-  printf("======================================================================================================================\n");
-}
-
-void DisplayHelp(char const* cmdName)
-{
-  DisplayBasicUsage(cmdName);
-  printf("\n");
-  EnvVars::DisplayUsage();
-  DisplayTbEnvVarUsage();
-  printf("\n");
-  printf("Run '%s presets' for preset compatibility/details.\n", cmdName);
+  printf("=============================================================================================================\n");
 }
 
 int RunPreset(EnvVars&       ev,
@@ -170,15 +107,11 @@ int RunPreset(EnvVars&       ev,
 {
   std::string preset = (argc > 1 ? argv[1] : "");
   bool bytesSpecified = (argc > 2);
-  if (preset == "help") {
-    DisplayHelp(cmdName);
-    retCode = 0;
-    return 1;
-  }
+
   if (preset == "presets") {
-    DisplayPresets();
-    retCode = 0;
-    return 1;
+      DisplayPresets();
+      retCode = 0;
+      return 1;
   }
   if (presetFuncMap.count(preset)) {
     retCode = (presetFuncMap[preset].func)(ev, numBytesPerTransfer, preset, bytesSpecified);

--- a/src/client/Presets/Presets.hpp
+++ b/src/client/Presets/Presets.hpp
@@ -102,8 +102,7 @@ int RunPreset(EnvVars&       ev,
               size_t   const numBytesPerTransfer,
               int      const argc,
               char**   const argv,
-              int&           retCode,
-              char const*    cmdName)
+              int&           retCode)
 {
   std::string preset = (argc > 1 ? argv[1] : "");
   bool bytesSpecified = (argc > 2);

--- a/src/client/Presets/Presets.hpp
+++ b/src/client/Presets/Presets.hpp
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 #pragma once
 #include <map>
+#include <vector>
 
 // EnvVars is available to all presets
 #include "EnvVars.hpp"
@@ -51,47 +52,136 @@ typedef int (*PresetFunc)(EnvVars&          ev,
                           std::string const presetName,
                           [[maybe_unused]] bool const bytesSpecified);
 
-std::map<std::string, std::pair<PresetFunc, std::string>> presetFuncMap =
+struct PresetInfo
 {
-  {"a2a",         {AllToAllPreset,      "Tests parallel transfers between all pairs of GPU devices"}},
-  {"a2a_n",       {AllToAllRdmaPreset,  "Tests parallel transfers between all pairs of GPU devices using Nearest NIC RDMA transfers"}},
-  {"a2asweep",    {AllToAllSweepPreset, "Test GFX-based all-to-all transfers swept across different CU and GFX unroll counts"}},
-  {"bmasweep",    {BmaSweepPreset,      "Test and compare batched DMA executor for multi destination copies"}},
-  {"gfxsweep",    {GfxSweepPreset,      "Sweep over various GFX kernel options for a given GFX Transfer"}},
-  {"hbm",         {HbmBandwidthPreset,  "Tests HBM bandwidth"}},
-  {"healthcheck", {HealthCheckPreset,   "Simple bandwidth health check (MI300X series only)"}},
-  {"nicrings",    {NicRingsPreset,      "Tests NIC rings created across identical NIC indices across ranks"}},
-  {"nicp2p",      {NicPeerToPeerPreset, "Multi-node peer-to-peer RDMA transfer test between all NICs"}},
-  {"one2all",     {OneToAllPreset,      "Test all subsets of parallel transfers from one GPU to all others"}},
-  {"p2p"   ,      {PeerToPeerPreset,    "Peer-to-peer device memory bandwidth test"}},
-  {"poda2a",      {PodAllToAllPreset,   "All-to-all transfers between subgroups of ranks within a pod"}},
-  {"podp2p",      {PodPeerToPeerPreset, "Peer-to-peer transfers test among ranks within a pod"}},
-  {"rsweep",      {SweepPreset,         "Randomly sweep through sets of Transfers"}},
-  {"scaling",     {ScalingPreset,       "Run scaling test from one GPU to other devices"}},
-  {"schmoo",      {SchmooPreset,        "Scaling tests for local/remote read/write/copy"}},
-  {"smoketest",   {SmokeTestPreset,     "Simple correctness smoke-test"}},
-  {"sweep",       {SweepPreset,         "Ordered sweep through sets of Transfers"}},
-  {"wallclock",   {WallClockPreset,     "Tests wallclock consistency across XCCs within a GPU"}},
+  PresetFunc   func;
+  bool         multiRankCompatible;
+  std::string  description;
+  std::string  details;
 };
+
+std::map<std::string, PresetInfo> presetFuncMap =
+{
+  {"a2a",         {AllToAllPreset,      true,  "Tests parallel transfers between all pairs of GPU devices",
+                   "Runs dense all-to-all copies across all visible GPUs (and ranks when present)."}},
+  {"a2a_n",       {AllToAllRdmaPreset,  false, "Tests parallel transfers between all pairs of GPU devices using Nearest NIC RDMA transfers",
+                   "Exercises nearest-NIC RDMA path for all GPU pairs (single rank only)."}},
+  {"a2asweep",    {AllToAllSweepPreset, false, "Test GFX-based all-to-all transfers swept across different CU and GFX unroll counts",
+                   "Sweeps CU and unroll settings to tune GFX all-to-all behavior."}},
+  {"bmasweep",    {BmaSweepPreset,      false, "Test and compare batched DMA executor for multi destination copies",
+                   "Compares batched DMA strategies for fan-out copy patterns."}},
+  {"gfxsweep",    {GfxSweepPreset,      true,  "Sweep over various GFX kernel options for a given GFX Transfer",
+                   "Sweeps GFX kernel parameters and reports best-performing combinations."}},
+  {"hbm",         {HbmBandwidthPreset,  true,  "Tests HBM bandwidth",
+                   "Measures sustained HBM read/write/copy behavior per GPU."}},
+  {"healthcheck", {HealthCheckPreset,   false, "Simple bandwidth health check (MI300X series only)",
+                   "Quick functional and bandwidth sanity test for supported MI300X setups."}},
+  {"nicrings",    {NicRingsPreset,      true,  "Tests NIC rings created across identical NIC indices across ranks",
+                   "Builds rank-wise NIC rings and measures collective ring bandwidth."}},
+  {"nicp2p",      {NicPeerToPeerPreset, true,  "Multi-node peer-to-peer RDMA transfer test between all NICs",
+                   "Runs exhaustive NIC-to-NIC RDMA throughput checks across ranks."}},
+  {"one2all",     {OneToAllPreset,      false, "Test all subsets of parallel transfers from one GPU to all others",
+                   "Evaluates one-source to many-destination transfer combinations."}},
+  {"p2p"   ,      {PeerToPeerPreset,    false, "Peer-to-peer device memory bandwidth test",
+                   "Benchmarks direct GPU-to-GPU memory transfer throughput."}},
+  {"poda2a",      {PodAllToAllPreset,   true,  "All-to-all transfers between subgroups of ranks within a pod",
+                   "Runs all-to-all over pod-scoped rank groups using detected pod membership."}},
+  {"podp2p",      {PodPeerToPeerPreset, true,  "Peer-to-peer transfers test among ranks within a pod",
+                   "Benchmarks pod-local peer transfer patterns across participating ranks."}},
+  {"rsweep",      {SweepPreset,         false, "Randomly sweep through sets of Transfers",
+                   "Randomized transfer sweep for broad spot-checking of transfer combinations."}},
+  {"scaling",     {ScalingPreset,       false, "Run scaling test from one GPU to other devices",
+                   "Measures scaling as destination count grows from a source GPU."}},
+  {"schmoo",      {SchmooPreset,        false, "Scaling tests for local/remote read/write/copy",
+                   "Runs schmoo-style sweeps over size and transfer type combinations."}},
+  {"smoketest",   {SmokeTestPreset,     true,  "Simple correctness smoke-test",
+                   "Fast correctness and sanity checks before running longer benchmarks."}},
+  {"sweep",       {SweepPreset,         false, "Ordered sweep through sets of Transfers",
+                   "Deterministic ordered sweep through predefined transfer combinations."}},
+  {"wallclock",   {WallClockPreset,     true,  "Tests wallclock consistency across XCCs within a GPU",
+                   "Checks GPU wallclock consistency and timing alignment across XCCs."}},
+};
+
+void DisplayBasicUsage(char const* cmdName)
+{
+  printf("Usage: %s config <N>\n", cmdName);
+  printf("  config: Either:\n");
+  printf("          - Filename of config file containing Transfers to execute (see example.cfg for format)\n");
+  printf("          - Name of preset config (run '%s presets' to list available presets)\n", cmdName);
+  printf("          - 'cmdline' followed by one transfer expression\n");
+  printf("          - 'dryrun' followed by one transfer expression (prints parsed transfers only)\n");
+  printf("  N     : (Optional) Number of bytes to copy per Transfer.\n");
+  printf("          If not specified, defaults to 268435456 bytes. Must be a multiple of 4 bytes\n");
+  printf("          If 0 is specified, a range of Ns will be benchmarked\n");
+  printf("          May append a suffix ('K', 'M', 'G') for kilobytes / megabytes / gigabytes\n");
+}
+
+void DisplayTbEnvVarUsage()
+{
+  printf("\nInternal TB_* environment variables:\n");
+  printf("====================================\n");
+  printf(" TB_RANK            - Rank of this process (0-based, socket communicator)\n");
+  printf(" TB_NUM_RANKS       - Total number of ranks (socket communicator)\n");
+  printf(" TB_MASTER_ADDR     - Rank 0 IP/hostname for socket communicator\n");
+  printf(" TB_MASTER_PORT     - Rank 0 port for socket communicator (default: 29500)\n");
+  printf(" TB_SINGLE_LOG      - In socket mode, only rank 0 logs when set\n");
+  printf(" TB_VERBOSE         - Enables additional internal logging\n");
+  printf(" TB_DUMP_CFG_FILE   - Writes executed transfers to a config file\n");
+  printf(" TB_DUMP_LINES      - Dumps randomized input-line statistics for FILL_COMPRESS setup\n");
+  printf(" TB_NIC_FILTER      - Regex filter to limit NIC visibility for NIC executors\n");
+  printf(" TB_FORCE_SINGLE_POD- Forces all ranks into one pod (skips pod query)\n");
+  printf(" TB_WALLCLOCK_RATE  - Overrides queried GPU wallclock rate if needed\n");
+  printf(" TB_PAUSE           - Pauses startup for debugger attachment\n");
+}
 
 void DisplayPresets()
 {
-  printf("\nAvailable Preset Benchmarks:\n");
-  printf("============================\n");
-  for (auto const& x : presetFuncMap)
-    printf("   %15s - %s\n", x.first.c_str(), x.second.second.c_str());
+  printf("\nAvailable Presets:\n");
+  printf("======================================================================================================================\n");
+  printf(" %-12s | %-18s | %-56s\n", "Preset", "Multi-rank", "What it does");
+  printf("======================================================================================================================\n");
+  for (auto const& x : presetFuncMap) {
+    printf(" %-12s | %-18s | %-56s\n",
+           x.first.c_str(),
+           x.second.multiRankCompatible ? "Yes (see notes)" : "No",
+           x.second.details.c_str());
+  }
+  printf(" %-12s | %-18s | %-56s\n", "help", "N/A", "Shows usage details, public env vars, and internal TB_* env vars");
+  printf(" %-12s | %-18s | %-56s\n", "presets", "N/A", "Shows this preset table with compatibility and descriptions");
+  printf("======================================================================================================================\n");
+}
+
+void DisplayHelp(char const* cmdName)
+{
+  DisplayBasicUsage(cmdName);
+  printf("\n");
+  EnvVars::DisplayUsage();
+  DisplayTbEnvVarUsage();
+  printf("\n");
+  printf("Run '%s presets' for preset compatibility/details.\n", cmdName);
 }
 
 int RunPreset(EnvVars&       ev,
               size_t   const numBytesPerTransfer,
               int      const argc,
               char**   const argv,
-              int&           retCode)
+              int&           retCode,
+              char const*    cmdName)
 {
   std::string preset = (argc > 1 ? argv[1] : "");
   bool bytesSpecified = (argc > 2);
+  if (preset == "help") {
+    DisplayHelp(cmdName);
+    retCode = 0;
+    return 1;
+  }
+  if (preset == "presets") {
+    DisplayPresets();
+    retCode = 0;
+    return 1;
+  }
   if (presetFuncMap.count(preset)) {
-    retCode = (presetFuncMap[preset].first)(ev, numBytesPerTransfer, preset, bytesSpecified);
+    retCode = (presetFuncMap[preset].func)(ev, numBytesPerTransfer, preset, bytesSpecified);
     return 1;
   }
   return 0;


### PR DESCRIPTION
## Motivation
With the recent increase of presets, introduce a new `presets` preset to list them instead of showing them when TransferBench is run with no args.  Similarly, a `help` preset is added to provide details on how to create a config / how Transfers are described, as well as and `envvars` preset to list all the environment variables that can alter TransferBench behavior

## Technical details
No core functionality changed - purely documentation related refactor