### PR TITLE
Fix SHOW_ITERATIONS table truncation with multiple transfers

### DIFF
--- a/src/client/Utilities.hpp
+++ b/src/client/Utilities.hpp
@@ -521,7 +521,7 @@ namespace TransferBench::Utils
       ExeResult const& exeResult = exeInfoPair.second;
       numRows += 1 + exeResult.transferIdx.size();
       if (ev.showIterations) {
-        numRows += (numTimedIterations + 1);
+        numRows += (numTimedIterations + 1) * exeResult.transferIdx.size();
 
         // Check that per-iteration information exists
         for (int idx : exeResult.transferIdx) {


### PR DESCRIPTION

## Motivation

SHOW_ITERATIONS output malformation when executing multiple transfers/using wildcard for transfer patterns

## Technical Details

`numRows` budget counted `(numTimedIterations + 1)` once per executor, but the render loop emits that many rows per transfer. With `N` transfers, the table ran out of pre-allocated rows after the first one or two, silently dropping the rest.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
