### PR TITLE
Adding new experimental copy-only GFX kernel, gfxsweep update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Documentation for TransferBench is available at
 - Added new "envvars" preset to show environment variables that can change TransferBench behavior
 - Adding information on how to run multi-rank with TransferBench, when run with no args
 - Added new "nica2a" preset (NIC all-to-all over GPUs via NIC executors, multi-node)
+- Added new GFX_KERNEL to allow experimenting with copy-only GFX kernel.  Currently this is opt-in only
 
 ### Modified
 - DMA-BUF support enablement in CMake changed to ENABLE_DMA_BUF to be more similar to other compile-time options

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -35,6 +35,8 @@ THE SOFTWARE.
   } while (0)
 
 #include <algorithm>
+#include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <numa.h>
 #include <random>
@@ -87,18 +89,19 @@ public:
   int useHsaDma;                     // Use hsa_amd_async_copy instead of hipMemcpy for non-targetted DMA executions
 
   // GFX options
+  vector<uint32_t> cuMask;           // Bit-vector representing the CU mask
   int gfxBlockOrder;                 // How threadblocks for multiple Transfers are ordered 0=sequential 1=interleaved
   int gfxBlockSize;                  // Size of each threadblock (must be multiple of 64)
-  vector<uint32_t> cuMask;           // Bit-vector representing the CU mask
-  vector<vector<int>> prefXccTable;  // Specifies XCC to use for given exe->dst pair
+  int gfxKernel;                     // GFX Kernel to use (-1=auto, 0=reduce, 1=copy-only)
   int gfxSeType;                     // GFX subexecutor type (0=threadblock, 1=warp)
+  int gfxSingleTeam;                 // Team all subExecutors across the data array
   int gfxTemporal;                   // Non-temporal load/store mode (0=none, 1=load, 2=store, 3=both)
   int gfxUnroll;                     // GFX-kernel unroll factor
-  int useHipEvents;                  // Use HIP events for timing GFX/DMA Executor
-  int useSingleStream;               // Use a single stream per GPU GFX executor instead of stream per Transfer
-  int gfxSingleTeam;                 // Team all subExecutors across the data array
   int gfxWaveOrder;                  // GFX-kernel wavefront ordering
   int gfxWordSize;                   // GFX-kernel packed data size (4=DWORDx4, 2=DWORDx2, 1=DWORDx1)
+  vector<vector<int>> prefXccTable;  // Specifies XCC to use for given exe->dst pair
+  int useHipEvents;                  // Use HIP events for timing GFX/DMA Executor
+  int useSingleStream;               // Use a single stream per GPU GFX executor instead of stream per Transfer
 
   // Client options
   int hideEnv;                       // Skip printing environment variable
@@ -147,6 +150,7 @@ public:
     fillCompress      = GetEnvVarArray("FILL_COMPRESS"  , {});
     gfxBlockOrder     = GetEnvVar("GFX_BLOCK_ORDER"     , 0);
     gfxBlockSize      = GetEnvVar("GFX_BLOCK_SIZE"      , 256);
+    gfxKernel         = GetEnvVar("GFX_KERNEL"          , 0);
     gfxSeType         = GetEnvVar("GFX_SE_TYPE"         , 0);
     gfxSingleTeam     = GetEnvVar("GFX_SINGLE_TEAM"     , 0);
     gfxTemporal       = GetEnvVar("GFX_TEMPORAL"        , 0);
@@ -328,6 +332,7 @@ public:
     printf(" FILL_PATTERN        - Big-endian pattern for source data, specified in hex digits. Must be even # of digits\n");
     printf(" GFX_BLOCK_ORDER     - How blocks for transfers are ordered. 0=sequential, 1=interleaved\n");
     printf(" GFX_BLOCK_SIZE      - # of threads per threadblock (Must be multiple of 64)\n");
+    printf(" GFX_KERNEL          - -1=auto, 0=force GpuReduceKernel, 1=force GpuCopyKernel (may error if ineligible)\n");
     printf(" GFX_SE_TYPE         - SubExecutor granularity type (0=threadblock, 1=warp)\n");
     printf(" GFX_TEMPORAL        - Use of non-temporal loads or stores (0=none 1=loads 2=stores 3=both)\n");
     printf(" GFX_UNROLL          - Unroll factor for GFX kernel (0=auto), must be less than %d\n", TransferBench::GetIntAttribute(ATR_GFX_MAX_UNROLL));
@@ -431,6 +436,9 @@ public:
           "Thread block ordering: %s", gfxBlockOrder == 0 ? "Sequential" : "Interleaved");
     Print("GFX_BLOCK_SIZE", gfxBlockSize,
           "Threadblock size of %d", gfxBlockSize);
+    Print("GFX_KERNEL", gfxKernel,
+          "%s", gfxKernel == -1 ? "auto" :
+                gfxKernel == 0 ? "force GpuReduceKernel" : "force GpuCopyKernel");
     Print("GFX_SE_TYPE", gfxSeType,
           "SubExecutor granularity: %s", gfxSeType == 0 ? "Threadblock" : "Warp");
     Print("GFX_SINGLE_TEAM", gfxSingleTeam,
@@ -684,6 +692,7 @@ public:
     cfg.gfx.blockOrder             = gfxBlockOrder;
     cfg.gfx.blockSize              = gfxBlockSize;
     cfg.gfx.cuMask                 = cuMask;
+    cfg.gfx.gfxKernel              = gfxKernel;
     cfg.gfx.prefXccTable           = prefXccTable;
     cfg.gfx.seType                 = gfxSeType;
     cfg.gfx.unrollFactor           = gfxUnroll;

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -335,7 +335,7 @@ public:
     printf(" GFX_KERNEL          - -1=auto, 0=force GpuReduceKernel, 1=force GpuCopyKernel (may error if ineligible)\n");
     printf(" GFX_SE_TYPE         - SubExecutor granularity type (0=threadblock, 1=warp)\n");
     printf(" GFX_TEMPORAL        - Use of non-temporal loads or stores (0=none 1=loads 2=stores 3=both)\n");
-    printf(" GFX_UNROLL          - Unroll factor for GFX kernel (0=auto), must be less than %d\n", TransferBench::GetIntAttribute(ATR_GFX_MAX_UNROLL));
+    printf(" GFX_UNROLL          - Unroll factor for GFX kernel\n");
     printf(" GFX_SINGLE_TEAM     - Have subexecutors work together on full array instead of working on disjoint subarrays\n");
     printf(" GFX_WAVE_ORDER      - Stride pattern for GFX kernel (0=UWC,1=UCW,2=WUC,3=WCU,4=CUW,5=CWU)\n");
     printf(" GFX_WORD_SIZE       - GFX kernel packed data size (4=DWORDx4, 2=DWORDx2, 1=DWORDx1)\n");
@@ -438,7 +438,8 @@ public:
           "Threadblock size of %d", gfxBlockSize);
     Print("GFX_KERNEL", gfxKernel,
           "%s", gfxKernel == -1 ? "auto" :
-                gfxKernel == 0 ? "force GpuReduceKernel" : "force GpuCopyKernel");
+                gfxKernel ==  0 ? "force GpuReduceKernel" :
+                gfxKernel ==  1 ? "force GpuCopyKernel"   : "unknown");
     Print("GFX_SE_TYPE", gfxSeType,
           "SubExecutor granularity: %s", gfxSeType == 0 ? "Threadblock" : "Warp");
     Print("GFX_SINGLE_TEAM", gfxSingleTeam,

--- a/src/client/Presets/AllToAll.hpp
+++ b/src/client/Presets/AllToAll.hpp
@@ -53,7 +53,6 @@ int AllToAllPreset(EnvVars&          ev,
   int numSubExecs   = EnvVars::GetEnvVar("NUM_SUB_EXEC"   , 8);
   int showDetails   = EnvVars::GetEnvVar("SHOW_DETAILS"   , 0);
   int useDmaExec    = EnvVars::GetEnvVar("USE_DMA_EXEC"   , 0);
-  int useFineGrain  = EnvVars::GetEnvVar("USE_FINE_GRAIN" , -999); // Deprecated
   int useRemoteRead = EnvVars::GetEnvVar("USE_REMOTE_READ", 0);
 
   // Check that all ranks have at least the number of GPUs requested
@@ -63,7 +62,7 @@ int AllToAllPreset(EnvVars&          ev,
   for (int rank = 0; rank < numRanks; rank++) {
     if (numGpus > TransferBench::GetNumExecutors(EXE_GPU_GFX, rank)) {
       Utils::Print("[ERROR] All-to-All preset requires each rank to have the same number of GPUs\n");
-      return 1;
+      return ERR_FATAL;
     }
     if (numQueuePairs > 0 && numNics != TransferBench::GetNumExecutors(EXE_NIC, rank))
       nicDifference = true;
@@ -80,15 +79,10 @@ int AllToAllPreset(EnvVars&          ev,
     a2aMode = EnvVars::GetEnvVar("A2A_MODE", 0);
     if (a2aMode < 0 || a2aMode > 2) {
       Utils::Print("[ERROR] a2aMode must be between 0 and 2, or else numSrcs:numDsts\n");
-      return 1;
+      return ERR_FATAL;
     }
     numSrcs = (a2aMode == A2A_WRITE_ONLY ? 0 : 1);
     numDsts = (a2aMode == A2A_READ_ONLY  ? 0 : 1);
-  }
-
-  // Deprecated env var check
-  if (useFineGrain != -999) {
-    memTypeIdx = useFineGrain ? 2 : 0;
   }
 
   MemType memType = Utils::GetGpuMemType(memTypeIdx);
@@ -119,15 +113,15 @@ int AllToAllPreset(EnvVars&          ev,
   // Validate env vars
   if (numGpus < 0 || numGpus > numDetectedGpus) {
     Utils::Print("[ERROR] Cannot use %d GPUs.  Detected %d GPUs\n", numGpus, numDetectedGpus);
-    return 1;
+    return ERR_FATAL;
   }
   if (useDmaExec && (numSrcs != 1 || numDsts != 1)) {
     Utils::Print("[ERROR] DMA execution can only be used for copies (A2A_MODE=0)\n");
-    return 1;
+    return ERR_FATAL;
   }
   if (numResults * 2 > numRanks) {
     Utils::Print("[ERROR] Number of extrema results requested exceeds number of ranks.  NUM_RESULTS should be at most half the number of ranks\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   // Collect the number of GPU devices to use
@@ -200,14 +194,14 @@ int AllToAllPreset(EnvVars&          ev,
   if (!TransferBench::RunTransfers(cfg, transfers, results)) {
     for (auto const& err : results.errResults)
       Utils::Print("%s\n", err.errMsg.c_str());
-    return 1;
+    return ERR_FATAL;
   } else if (showDetails) {
     Utils::PrintResults(ev, 1, transfers, results);
     Utils::Print("\n");
   }
 
   // Only ranks that actually do output will compile results
-  if (!Utils::RankDoesOutput()) return 0;
+  if (!Utils::RankDoesOutput()) return ERR_NONE;
 
   // Prepare table of results
   int numRows   = 2 + (numGpus + 1) * (1 + 2*numResults);
@@ -490,10 +484,5 @@ int AllToAllPreset(EnvVars&          ev,
     printf("[WARN] It is recommended to run TransferBench with one rank per host to avoid potential aliasing of executors\n");
   }
 
-  if (useFineGrain != -999) {
-    Utils::Print("[WARN] USE_FINE_GRAIN has been deprecated and replaced by MEM_TYPE\n");
-    Utils::Print("[WARN] MEM_TYPE has been set to %d to correspond to previous use of USE_FINE_GRAIN=%d\n", memTypeIdx, useFineGrain);
-  }
-
-  return 0;
+  return ERR_NONE;
 }

--- a/src/client/Presets/AllToAllN.hpp
+++ b/src/client/Presets/AllToAllN.hpp
@@ -29,7 +29,7 @@ int AllToAllRdmaPreset(EnvVars&          ev,
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR]a2an preset currently not supported for multi-node\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   int numDetectedGpus = TransferBench::GetNumExecutors(EXE_GPU_GFX);
@@ -38,12 +38,6 @@ int AllToAllRdmaPreset(EnvVars&          ev,
   int numGpus       = EnvVars::GetEnvVar("NUM_GPU_DEVICES", numDetectedGpus);
   int numQueuePairs = EnvVars::GetEnvVar("NUM_QUEUE_PAIRS", 1);
   int memTypeIdx    = EnvVars::GetEnvVar("MEM_TYPE"       , 2);
-  int useFineGrain  = EnvVars::GetEnvVar("USE_FINE_GRAIN" , -999); // Deprecated
-
-  // Deprecated env var check
-  if (useFineGrain != -999) {
-    memTypeIdx = useFineGrain ? 2 : 0;
-  }
 
   MemType memType = Utils::GetGpuMemType(memTypeIdx);
   std::string memTypeStr = Utils::GetGpuMemTypeStr(memTypeIdx);
@@ -63,7 +57,7 @@ int AllToAllRdmaPreset(EnvVars&          ev,
   // Validate env vars
   if (numGpus < 0 || numGpus > numDetectedGpus) {
     Utils::Print("[ERROR] Cannot use %d GPUs.  Detected %d GPUs\n", numGpus, numDetectedGpus);
-    return 1;
+    return ERR_FATAL;
   }
 
 
@@ -97,7 +91,7 @@ int AllToAllRdmaPreset(EnvVars&          ev,
   if (!TransferBench::RunTransfers(cfg, transfers, results)) {
     for (auto const& err : results.errResults)
       Utils::Print("%s\n", err.errMsg.c_str());
-    return 1;
+    return ERR_FATAL;
   } else {
     Utils::PrintResults(ev, 1, transfers, results);
   }
@@ -154,5 +148,5 @@ int AllToAllRdmaPreset(EnvVars&          ev,
 
   Utils::PrintErrors(results.errResults);
 
-  return 0;
+  return ERR_NONE;
 }

--- a/src/client/Presets/AllToAllSweep.hpp
+++ b/src/client/Presets/AllToAllSweep.hpp
@@ -29,7 +29,7 @@ int AllToAllSweepPreset(EnvVars&          ev,
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR] All to All Sweep preset currently not supported for multi-node\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   enum
@@ -54,7 +54,6 @@ int AllToAllSweepPreset(EnvVars&          ev,
   int memTypeIdx    = EnvVars::GetEnvVar("MEM_TYPE"       , 2);
   int numGpus       = EnvVars::GetEnvVar("NUM_GPU_DEVICES", numDetectedGpus);
   int showMinOnly   = EnvVars::GetEnvVar("SHOW_MIN_ONLY",   1);
-  int useFineGrain  = EnvVars::GetEnvVar("USE_FINE_GRAIN" , -999); // Deprecated
   int useRemoteRead = EnvVars::GetEnvVar("USE_REMOTE_READ", 0);
   int useSpray      = EnvVars::GetEnvVar("USE_SPRAY",       0);
   int verbose       = EnvVars::GetEnvVar("VERBOSE",         0);
@@ -78,11 +77,6 @@ int AllToAllSweepPreset(EnvVars&          ev,
     numDsts = (a2aMode == A2A_READ_ONLY  ? 0 : 1);
   }
 
-  // Deprecated env var check
-  if (useFineGrain != -999) {
-    memTypeIdx = useFineGrain ? 2 : 0;
-  }
-
   MemType memType = Utils::GetGpuMemType(memTypeIdx);
   std::string devMemTypeStr = Utils::GetGpuMemTypeStr(memTypeIdx);
 
@@ -101,9 +95,6 @@ int AllToAllSweepPreset(EnvVars&          ev,
     ev.Print("NUM_SUB_EXECS"  , numSesList.size(), EnvVars::ToStr(numSesList).c_str());
     ev.Print("SHOW_MIN_ONLY"  , showMinOnly      , showMinOnly ? "Showing only slowest GPU results" : "Showing slowest and fastest GPU results");
     ev.Print("UNROLLS"        , unrollList.size(), EnvVars::ToStr(unrollList).c_str());
-    if (useFineGrain != -999) {
-      ev.Print("USE_FINE_GRAIN", useFineGrain    , "[DEPRECATED] Using %s-grained memory; prefer MEM_TYPE", useFineGrain ? "fine" : "coarse");
-    }
     ev.Print("USE_REMOTE_READ", useRemoteRead    , "Using %s as executor", useRemoteRead ? "DST" : "SRC");
     ev.Print("USE_SPRAY"      , useSpray         , "%s per SubExecutor", useSpray ? "All targets" : "One target");
     ev.Print("VERBOSE"        , verbose          , verbose ? "Display test results" : "Display summary only");
@@ -300,10 +291,5 @@ int AllToAllSweepPreset(EnvVars&          ev,
     Utils::Print("          NumSubExec : %7d\n", bestNumSes);
   }
 
-  if (useFineGrain != -999) {
-    Utils::Print("[WARN] USE_FINE_GRAIN has been deprecated and replaced by MEM_TYPE\n");
-    Utils::Print("[WARN] MEM_TYPE has been set to %d to correspond to previous use of USE_FINE_GRAIN=%d\n", memTypeIdx, useFineGrain);
-  }
-
-  return 0;
+  return ERR_NONE;
 }

--- a/src/client/Presets/BmaSweep.hpp
+++ b/src/client/Presets/BmaSweep.hpp
@@ -27,12 +27,12 @@ int BmaSweepPreset(EnvVars&          ev,
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR] BMA sweep preset currently not supported for multi-node\n");
-    return 1;
+    return ERR_FATAL;
   }
 
 #ifndef BMA_EXEC_ENABLED
   Utils::Print("[ERROR] BMA executor requires ROCm 7.1 or newer\n");
-  return 1;
+  return ERR_FATAL;
 #endif
 
   int numDetectedGpus = TransferBench::GetNumExecutors(EXE_GPU_GFX);
@@ -66,7 +66,7 @@ int BmaSweepPreset(EnvVars&          ev,
 
   if (exeIndex < 0 || exeIndex >= numGpuDevices) {
     Utils::Print("EXE_INDEX must be between 0 and %d inclusively\n", numGpuDevices - 1);
-    return 1;
+    return ERR_FATAL;
   }
 
   int numTransfers  = numGpuDevices - 1 + (localCopy ? 1 : 0);
@@ -137,7 +137,7 @@ int BmaSweepPreset(EnvVars&          ev,
     if (!TransferBench::RunTransfers(cfg, transfers, results)) {
       for (auto const& err : results.errResults)
         Utils::Print("%s\n", err.errMsg.c_str());
-      return 1;
+      return ERR_FATAL;
     }
 
     table.Set(currRow, 1, " %6.2f ", numTransfers * results.tfrResults[0].avgBandwidthGbPerSec);
@@ -150,7 +150,7 @@ int BmaSweepPreset(EnvVars&          ev,
       if (!TransferBench::RunTransfers(cfg, transfers, results)) {
         for (auto const& err : results.errResults)
           Utils::Print("%s\n", err.errMsg.c_str());
-        return 1;
+        return ERR_FATAL;
       }
 
       table.Set(currRow, 2+i, " %6.2f ", numTransfers * results.tfrResults[0].avgBandwidthGbPerSec);
@@ -164,7 +164,7 @@ int BmaSweepPreset(EnvVars&          ev,
       if (!TransferBench::RunTransfers(cfg, transfers, results)) {
         for (auto const& err : results.errResults)
           Utils::Print("%s\n", err.errMsg.c_str());
-        return 1;
+        return ERR_FATAL;
       }
 
       table.Set(currRow, 2+numBmaSubExec+i, " %6.2f ", results.tfrResults[0].avgBandwidthGbPerSec);
@@ -178,5 +178,5 @@ int BmaSweepPreset(EnvVars&          ev,
   table.PrintTable(ev.outputToCsv, ev.showBorders);
   Utils::Print("Reported numbers are all GB/s, normalized for per Transfer for %d Transfers\n", numTransfers);
 
-  return 0;
+  return ERR_NONE;
 }

--- a/src/client/Presets/GfxSweep.hpp
+++ b/src/client/Presets/GfxSweep.hpp
@@ -27,6 +27,14 @@ int GfxSweepPreset(EnvVars&          ev,
                    std::string const presetName,
                    bool        const bytesSpecified)
 {
+  enum TimingMode
+  {
+    TimingModeAuto = -1,
+    TimingModeCpu  =  0,
+    TimingModeHip  =  1,
+    TimingModeGpu  =  2
+  };
+
   // Collect environment variables for this preset
   vector<int> blockList      = EnvVars::GetEnvVarArray("BLOCKSIZES",   {256,512,768,1024});
   std::string transferStr    = EnvVars::GetEnvVar(     "GFX_TRANSFER", "R0G0->R0G0->R0G0");
@@ -34,7 +42,7 @@ int GfxSweepPreset(EnvVars&          ev,
   vector<int> numSesList     = EnvVars::GetEnvVarArray("NUM_SUB_EXECS",    {4,8,16,32,64});
   int         numTransfers   = EnvVars::GetEnvVar(     "NUM_TRANSFERS",                 1);
   vector<int> temporalList   = EnvVars::GetEnvVarArray("TEMPORAL_MODES",              {0});
-  int         timingMode     = EnvVars::GetEnvVar(     "TIMING_MODE",                  -1);
+  int         timingMode     = EnvVars::GetEnvVar(     "TIMING_MODE",      TimingModeAuto);
   vector<int> unrollList     = EnvVars::GetEnvVarArray("UNROLLS",            {1,2,4,8,16});
   vector<int> waveOrderList  = EnvVars::GetEnvVarArray("WAVE_ORDERS",                 {0});
   vector<int> wordSizeList   = EnvVars::GetEnvVarArray("WORDSIZES",                   {4});
@@ -59,9 +67,14 @@ int GfxSweepPreset(EnvVars&          ev,
     }
   }
 
+  if (timingMode < TimingModeAuto || timingMode > TimingModeGpu) {
+    Utils::Print("TIMING_MODE value is invalid (%d)\n", timingMode);
+    return ERR_FATAL;
+  }
+
   if (numSesList.empty()){
     Utils::Print("NUM_SUB_EXECS should not be empty\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   std::vector<Transfer> transfers;
@@ -72,9 +85,9 @@ int GfxSweepPreset(EnvVars&          ev,
   }
 
   // Automatically pick timing method
-  if (timingMode == -1) {
+  if (timingMode == TimingModeAuto) {
     // Use Transfer timing if there is only one Transfer
-    if (transfers.size() == 1) timingMode = 2;
+    if (transfers.size() == 1) timingMode = TimingModeGpu;
     // Use Executor timing if there is only one executor
     else {
       bool singleExecutor = true;
@@ -87,19 +100,19 @@ int GfxSweepPreset(EnvVars&          ev,
           break;
         }
       }
-      timingMode = singleExecutor ? 1 : 0;
+      timingMode = singleExecutor ? TimingModeHip : TimingModeCpu;
     }
   }
   if (timingMode < 0 || timingMode > 2) {
     Utils::Print("[ERROR] Invalid timing mode %d\n", timingMode);
-    return 1;
+    return ERR_FATAL;
   }
 
   // Print out the Transfers being run
   Utils::Print("GFX sweep: (%lu bytes per Transfer). All values are %s-timed GB/s\n", numBytesPerTransfer,
-               timingMode == 0 ? "Aggregate-CPU" :
-               timingMode == 1 ? "HIP-event"     :
-                                 "GPU wallclock");
+               timingMode == TimingModeCpu ? "Aggregate-CPU" :
+               timingMode == TimingModeHip ? "HIP-event"     :
+                                             "GPU wallclock");
   Utils::Print("=======================================================================================\n");
 
   bool isMultiNode = GetNumRanks() > 1;
@@ -115,7 +128,7 @@ int GfxSweepPreset(EnvVars&          ev,
 
     if (t.exeDevice.exeType != EXE_GPU_GFX) {
       Utils::Print("[ERROR] gfxsweep preset only works on Transfers that are using GFX executor\n");
-      return 1;
+      return ERR_FATAL;
     }
     t.numBytes = numBytesPerTransfer;
   }
@@ -181,7 +194,7 @@ int GfxSweepPreset(EnvVars&          ev,
                 } else {
                   Utils::Print("\n");
                   Utils::PrintErrors(result.errResults);
-                  return 1;
+                  return ERR_FATAL;
                 }
               }
               Utils::Print("\n");
@@ -201,15 +214,15 @@ int GfxSweepPreset(EnvVars&          ev,
 
   if (bestSe == -1) {
     Utils::Print("[WARN] No transfers executed - make sure sweep parameters lists are not empty\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   // Print combination that produced highest bandwidth
   Utils::Print("=======================================================================================\n");
   Utils::Print("Highest bandwidth found: %7.2f GB/s (%s-timed)\n", overallBestBw,
-               timingMode == 0 ? "Aggregate-CPU" :
-               timingMode == 1 ? "HIP-event"     :
-                                 "GPU wallclock");
+               timingMode == TimingModeCpu ? "Aggregate-CPU" :
+               timingMode == TimingModeHip ? "HIP-event"     :
+                                             "GPU wallclock");
   Utils::Print("          WaveOrder    : %7d  [GFX_WAVE_ORDER=%d]\n", best[bestSe][0], best[bestSe][0]);
   Utils::Print("          WordSize     : %7d  [GFX_WORD_SIZE=%d]\n",  best[bestSe][1], best[bestSe][1]);
   Utils::Print("          Temporal Mode: %7d  [GFX_TEMPORAL=%d]\n",   best[bestSe][2], best[bestSe][2]);
@@ -222,5 +235,5 @@ int GfxSweepPreset(EnvVars&          ev,
                "GFX_UNROLL=%d GFX_KERNEL=%d ./TransferBench cmdline %lu \"%d %d %s\"\n",
                best[bestSe][0], best[bestSe][1], best[bestSe][2], best[bestSe][3],
                best[bestSe][4], best[bestSe][5], numBytesPerTransfer, numTransfers, best[bestSe][6], transferStr.c_str());
-  return 0;
+  return ERR_NONE;
 }

--- a/src/client/Presets/GfxSweep.hpp
+++ b/src/client/Presets/GfxSweep.hpp
@@ -51,7 +51,7 @@ int GfxSweepPreset(EnvVars&          ev,
       ev.Print("NUM_TRANSFERS",  numTransfers,         "Number of Transfers specified in GFX_TRANSFER");
       ev.Print("NUM_SUB_EXECS",  numSesList.size(),    EnvVars::ToStr(numSesList).c_str());
       ev.Print("TEMPORAL_MODES", temporalList.size(),  EnvVars::ToStr(temporalList).c_str());
-      ev.Print("TIMING_MODE",    timingMode,           "0=Aggregate CPU, 1=Executor Time, 2=Transfer Time");
+      ev.Print("TIMING_MODE",    timingMode,           "-1=auto 0=Aggregate CPU, 1=Executor Time, 2=Transfer Time");
       ev.Print("UNROLLS",        unrollList.size(),    EnvVars::ToStr(unrollList).c_str());
       ev.Print("WAVE_ORDERS",    waveOrderList.size(), EnvVars::ToStr(waveOrderList).c_str());
       ev.Print("WORDSIZES",      wordSizeList.size(),  EnvVars::ToStr(wordSizeList).c_str());
@@ -59,8 +59,17 @@ int GfxSweepPreset(EnvVars&          ev,
     }
   }
 
+  if (numSesList.empty()){
+    Utils::Print("NUM_SUB_EXECS should not be empty\n");
+    return 1;
+  }
+
   std::vector<Transfer> transfers;
   Utils::CheckForError(ParseTransfers(std::to_string(numTransfers) + " 1 " + transferStr, transfers));
+  if (transfers.size() == 0) {
+    Utils::Print("[WARN] No valid Transfers found in GFX_TRANSFER\n");
+    return 0;
+  }
 
   // Automatically pick timing method
   if (timingMode == -1) {
@@ -69,7 +78,7 @@ int GfxSweepPreset(EnvVars&          ev,
     // Use Executor timing if there is only one executor
     else {
       bool singleExecutor = true;
-      for (auto i = 1; i < transfers.size(); i++) {
+      for (size_t i = 1; i < transfers.size(); i++) {
         if (transfers[i].exeDevice   <  transfers[0].exeDevice   ||
             transfers[0].exeDevice   <  transfers[i].exeDevice   ||
             transfers[i].exeSubIndex != transfers[0].exeSubIndex ||
@@ -80,6 +89,10 @@ int GfxSweepPreset(EnvVars&          ev,
       }
       timingMode = singleExecutor ? 1 : 0;
     }
+  }
+  if (timingMode < 0 || timingMode > 2) {
+    Utils::Print("[ERROR] Invalid timing mode %d\n", timingMode);
+    return 1;
   }
 
   // Print out the Transfers being run
@@ -186,9 +199,17 @@ int GfxSweepPreset(EnvVars&          ev,
   }
   Utils::Print("\n");
 
+  if (bestSe == -1) {
+    Utils::Print("[WARN] No transfers executed - make sure sweep parameters lists are not empty\n");
+    return 1;
+  }
+
   // Print combination that produced highest bandwidth
   Utils::Print("=======================================================================================\n");
-  Utils::Print("Highest bandwidth found: %7.2f GB/s (CPU-timed)\n", overallBestBw);
+  Utils::Print("Highest bandwidth found: %7.2f GB/s (%s-timed)\n", overallBestBw,
+               timingMode == 0 ? "Aggregate-CPU" :
+               timingMode == 1 ? "HIP-event"     :
+                                 "GPU wallclock");
   Utils::Print("          WaveOrder    : %7d  [GFX_WAVE_ORDER=%d]\n", best[bestSe][0], best[bestSe][0]);
   Utils::Print("          WordSize     : %7d  [GFX_WORD_SIZE=%d]\n",  best[bestSe][1], best[bestSe][1]);
   Utils::Print("          Temporal Mode: %7d  [GFX_TEMPORAL=%d]\n",   best[bestSe][2], best[bestSe][2]);

--- a/src/client/Presets/GfxSweep.hpp
+++ b/src/client/Presets/GfxSweep.hpp
@@ -30,9 +30,11 @@ int GfxSweepPreset(EnvVars&          ev,
   // Collect environment variables for this preset
   vector<int> blockList      = EnvVars::GetEnvVarArray("BLOCKSIZES",   {256,512,768,1024});
   std::string transferStr    = EnvVars::GetEnvVar(     "GFX_TRANSFER", "R0G0->R0G0->R0G0");
+  vector<int> kernelList     = EnvVars::GetEnvVarArray("KERNELS",                     {0});
   vector<int> numSesList     = EnvVars::GetEnvVarArray("NUM_SUB_EXECS",    {4,8,16,32,64});
-  int         numTransferStr = EnvVars::GetEnvVar(     "NUM_TRANSFERS",                 1);
+  int         numTransfers   = EnvVars::GetEnvVar(     "NUM_TRANSFERS",                 1);
   vector<int> temporalList   = EnvVars::GetEnvVarArray("TEMPORAL_MODES",              {0});
+  int         timingMode     = EnvVars::GetEnvVar(     "TIMING_MODE",                  -1);
   vector<int> unrollList     = EnvVars::GetEnvVarArray("UNROLLS",            {1,2,4,8,16});
   vector<int> waveOrderList  = EnvVars::GetEnvVarArray("WAVE_ORDERS",                 {0});
   vector<int> wordSizeList   = EnvVars::GetEnvVarArray("WORDSIZES",                   {4});
@@ -45,9 +47,11 @@ int GfxSweepPreset(EnvVars&          ev,
         Utils::Print("[GFX Sweep Related]\n");
       ev.Print("BLOCKSIZES",     blockList.size(),     EnvVars::ToStr(blockList).c_str());
       ev.Print("GFX_TRANSFER",   transferStr,          "GFX Transfer to sweep (see config file format)");
-      ev.Print("NUM_TRANSFERS",  numTransferStr,       "Number of Transfers specified in GFX_TRANSFER");
+      ev.Print("KERNELS",        kernelList.size(),    EnvVars::ToStr(kernelList).c_str());
+      ev.Print("NUM_TRANSFERS",  numTransfers,         "Number of Transfers specified in GFX_TRANSFER");
       ev.Print("NUM_SUB_EXECS",  numSesList.size(),    EnvVars::ToStr(numSesList).c_str());
       ev.Print("TEMPORAL_MODES", temporalList.size(),  EnvVars::ToStr(temporalList).c_str());
+      ev.Print("TIMING_MODE",    timingMode,           "0=Aggregate CPU, 1=Executor Time, 2=Transfer Time");
       ev.Print("UNROLLS",        unrollList.size(),    EnvVars::ToStr(unrollList).c_str());
       ev.Print("WAVE_ORDERS",    waveOrderList.size(), EnvVars::ToStr(waveOrderList).c_str());
       ev.Print("WORDSIZES",      wordSizeList.size(),  EnvVars::ToStr(wordSizeList).c_str());
@@ -56,10 +60,33 @@ int GfxSweepPreset(EnvVars&          ev,
   }
 
   std::vector<Transfer> transfers;
-  Utils::CheckForError(ParseTransfers(std::to_string(numTransferStr) + " 1 " + transferStr, transfers));
+  Utils::CheckForError(ParseTransfers(std::to_string(numTransfers) + " 1 " + transferStr, transfers));
+
+  // Automatically pick timing method
+  if (timingMode == -1) {
+    // Use Transfer timing if there is only one Transfer
+    if (transfers.size() == 1) timingMode = 2;
+    // Use Executor timing if there is only one executor
+    else {
+      bool singleExecutor = true;
+      for (auto i = 1; i < transfers.size(); i++) {
+        if (transfers[i].exeDevice   <  transfers[0].exeDevice   ||
+            transfers[0].exeDevice   <  transfers[i].exeDevice   ||
+            transfers[i].exeSubIndex != transfers[0].exeSubIndex ||
+            transfers[i].exeSubSlot  != transfers[0].exeSubSlot) {
+          singleExecutor = false;
+          break;
+        }
+      }
+      timingMode = singleExecutor ? 1 : 0;
+    }
+  }
 
   // Print out the Transfers being run
-  Utils::Print("GFX sweep: (%lu bytes per Transfer). All values are CPU-timed GB/s\n", numBytesPerTransfer);
+  Utils::Print("GFX sweep: (%lu bytes per Transfer). All values are %s-timed GB/s\n", numBytesPerTransfer,
+               timingMode == 0 ? "Aggregate-CPU" :
+               timingMode == 1 ? "HIP-event"     :
+                                 "GPU wallclock");
   Utils::Print("=======================================================================================\n");
 
   bool isMultiNode = GetNumRanks() > 1;
@@ -86,13 +113,15 @@ int GfxSweepPreset(EnvVars&          ev,
 
   // Print header
   char sep = ev.outputToCsv ? ',' : ' ';
-  Utils::Print(" WvO %c WSz %c TpM %c BlkS %c UnR ", sep, sep, sep, sep);
+  Utils::Print(" WvO %c WSz %c TpM %c BlkS %c UnR %c KrN ", sep, sep, sep, sep, sep);
   for  (int numSubExec : numSesList)
     Utils::Print("%c  SE %03d", sep, numSubExec);
   Utils::Print("\n");
 
-  double bestBw = 0.0;
-  vector<int> best(6);
+  int bestSe = -1;
+  double overallBestBw = 0;
+  vector<double> bestBw(numSesList.size(), 0.0);
+  vector<vector<int>> best(numSesList.size(), vector<int>(7));
 
   // Loop over all combinations
   for (int waveOrder : waveOrderList) {         cfg.gfx.waveOrder    = waveOrder;
@@ -100,43 +129,77 @@ int GfxSweepPreset(EnvVars&          ev,
       for (int temporalMode : temporalList) {   cfg.gfx.temporalMode = temporalMode;
         for (int blockSize : blockList) {       cfg.gfx.blockSize    = blockSize;
           for (int unroll : unrollList) {       cfg.gfx.unrollFactor = unroll;
-            Utils::Print("  %d  %c  %d  %c  %d  %c %4d %c %3d ",
-                         waveOrder, sep, wordSize, sep, temporalMode, sep, blockSize, sep, unroll, sep);
+            for (int kernelIdx : kernelList) {  cfg.gfx.gfxKernel    = kernelIdx;
+              Utils::Print("  %1d  %c  %1d  %c  %1d  %c %4d %c %2d  %c  %1d  ",
+                           waveOrder, sep, wordSize, sep,  temporalMode, sep,
+                           blockSize, sep, unroll, sep, kernelIdx, sep);
 
-            for (int numSubExec : numSesList) {
-              for (Transfer& t : transfers) t.numSubExecs = numSubExec;
+              for (auto s = 0; s < numSesList.size(); s++) {
+                int numSubExec = numSesList[s];
+                for (Transfer& t : transfers) t.numSubExecs = numSubExec;
 
-              TestResults result;
-              if (RunTransfers(cfg, transfers, result)) {
-                double bw = result.avgTotalBandwidthGbPerSec;
-                if (bw > bestBw) {
-                  bestBw = bw;
-                  best = {waveOrder, wordSize, temporalMode, blockSize, unroll, numSubExec};
+                TestResults result;
+                if (RunTransfers(cfg, transfers, result)) {
+                  double bw = 0.0;
+                  switch (timingMode) {
+                  case 0: bw = result.avgTotalBandwidthGbPerSec; break;
+                  case 1:
+                    for (auto const& e : result.exeResults) {
+                      bw = std::max(bw, e.second.avgBandwidthGbPerSec);
+                    }
+                    break;
+                  case 2: default:
+                    for (auto const& t : result.tfrResults) {
+                      bw = std::max(bw, t.avgBandwidthGbPerSec);
+                    }
+                    break;
+                  }
+
+                  if (bw > bestBw[s]) {
+                    bestBw[s] = bw;
+                    best[s] = {waveOrder, wordSize, temporalMode, blockSize, unroll, kernelIdx, numSubExec};
+                    if (bw > overallBestBw) {
+                      overallBestBw = bw;
+                      bestSe = s;
+                    }
+                  }
+                  Utils::Print("%c%8.2f", sep, bw);
+                  fflush(stdout);
+                } else {
+                  Utils::Print("\n");
+                  Utils::PrintErrors(result.errResults);
+                  return 1;
                 }
-                Utils::Print("%c%8.2f", sep, bw);
-                fflush(stdout);
-              } else {
-                Utils::Print("\n");
-                Utils::PrintErrors(result.errResults);
-                return 1;
               }
+              Utils::Print("\n");
+              fflush(stdout);
             }
-            Utils::Print("\n");
-            fflush(stdout);
           }
         }
       }
     }
   }
 
+  Utils::Print(" WvO %c WSz %c TpM %c BlkS %c UnR %c KrN ", sep, sep, sep, sep, sep);
+  for (auto s = 0; s < numSesList.size(); s++) {
+    Utils::Print("%c%8.2f", sep, bestBw[s]);
+  }
+  Utils::Print("\n");
+
   // Print combination that produced highest bandwidth
   Utils::Print("=======================================================================================\n");
-  Utils::Print("Highest bandwidth found: %7.2f GB/s (CPU-timed)\n", bestBw);
-  Utils::Print("          WaveOrder    : %7d\n", best[0]);
-  Utils::Print("          WordSize     : %7d\n", best[1]);
-  Utils::Print("          Temporal Mode: %7d\n", best[2]);
-  Utils::Print("          BlockSize    : %7d\n", best[3]);
-  Utils::Print("          Unroll       : %7d\n", best[4]);
-  Utils::Print("          NumSubExec   : %7d\n", best[5]);
+  Utils::Print("Highest bandwidth found: %7.2f GB/s (CPU-timed)\n", overallBestBw);
+  Utils::Print("          WaveOrder    : %7d  [GFX_WAVE_ORDER=%d]\n", best[bestSe][0], best[bestSe][0]);
+  Utils::Print("          WordSize     : %7d  [GFX_WORD_SIZE=%d]\n",  best[bestSe][1], best[bestSe][1]);
+  Utils::Print("          Temporal Mode: %7d  [GFX_TEMPORAL=%d]\n",   best[bestSe][2], best[bestSe][2]);
+  Utils::Print("          BlockSize    : %7d  [GFX_BLOCK_SIZE=%d]\n", best[bestSe][3], best[bestSe][3]);
+  Utils::Print("          Unroll       : %7d  [GFX_UNROLL=%d]\n",     best[bestSe][4], best[bestSe][4]);
+  Utils::Print("          Kernel       : %7d  [GFX_KERNEL=%d]\n"    , best[bestSe][5], best[bestSe][5]);
+  Utils::Print("          NumSubExec   : %7d\n", best[bestSe][6]);
+  Utils::Print("Command to run best result:\n");
+  Utils::Print("GFX_WAVE_ORDER=%d GFX_WORD_SIZE=%d GFX_TEMPORAL=%d GFX_BLOCK_SIZE=%d "
+               "GFX_UNROLL=%d GFX_KERNEL=%d ./TransferBench cmdline %lu \"%d %d %s\"\n",
+               best[bestSe][0], best[bestSe][1], best[bestSe][2], best[bestSe][3],
+               best[bestSe][4], best[bestSe][5], numBytesPerTransfer, numTransfers, best[bestSe][6], transferStr.c_str());
   return 0;
 }

--- a/src/client/Presets/HbmBandwidth.hpp
+++ b/src/client/Presets/HbmBandwidth.hpp
@@ -183,7 +183,7 @@ int HbmBandwidthPreset(EnvVars&          ev,
   for (int rank = 0; rank < numRanks; rank++) {
     if (TransferBench::GetNumExecutors(EXE_GPU_GFX, rank) == 0) {
       Utils::Print("[ERROR] Each rank must have at least GPU.  Rank %d has no GPUs\n", rank);
-      return 1;
+      return ERR_FATAL;
     }
   }
   int defSubExec = TransferBench::GetNumSubExecutors({EXE_GPU_GFX, 0});
@@ -233,28 +233,28 @@ int HbmBandwidthPreset(EnvVars&          ev,
   // Validate environment variables and set defaults
   if (blockSizes.empty()) {
     Utils::Print("[ERROR] BLOCKSIZES may not be empty\n");
-    return 1;
+    return ERR_FATAL;
   }
   for (auto blockSize : blockSizes) {
     if (blockSize <= 0 || blockSize % 128 != 0 || blockSize > 1024) {
       Utils::Print("[ERROR] BLOCKSIZES must only contain positive multiples of 128 up to 1024 (not %d)\n", blockSize);
-      return 1;
+      return ERR_FATAL;
     }
   }
 
   if (criteria < 0 || criteria > 2) {
     Utils::Print("[ERROR] CRITERIA must be either 0 (for MAX), 1 (for AVG), or 2 (for MIN) (not %d)\n", criteria);
-    return 1;
+    return ERR_FATAL;
   }
 
   if (elemBytes.empty()) {
     Utils::Print("[ERROR] ELEM_BYTES may not be empty\n");
-    return 1;
+    return ERR_FATAL;
   }
   for (auto elemByte : elemBytes) {
     if (elemByte != 4 && elemByte != 8 && elemByte != 16) {
       Utils::Print("[ERROR] ELEM_BYTES may only contain {4,8 or 16}\n");
-      return 1;
+      return ERR_FATAL;
     }
   }
 
@@ -263,18 +263,18 @@ int HbmBandwidthPreset(EnvVars&          ev,
     for (auto gpuIdx : gpuIndices) {
       if (gpuIdx < 0 || gpuIdx >= numDetectedGpus) {
         Utils::Print("[ERROR] GPU_INDICES index out of range (%d) (rank %d)\n", gpuIdx, myRank);
-        return 1;
+        return ERR_FATAL;
       }
     }
   }
 
   if (numBuffers < 1) {
     Utils::Print("[ERROR] NUM_BUFFERS must be a positive number (not %d)\n", numBuffers);
-    return 1;
+    return ERR_FATAL;
   }
   if (numIterations <= 0) {
     Utils::Print("[ERROR] NUM_ITERATIONS must be positive (not %d)\n", numIterations);
-    return 1;
+    return ERR_FATAL;
   }
   if (numBuffers > numIterations) {
     Utils::Print("[WARN] NUM_BUFFERS (%d) exceeds NUM_ITERATIONS (%d), so some buffers will not be used\n",
@@ -289,29 +289,29 @@ int HbmBandwidthPreset(EnvVars&          ev,
     for (auto x : numSesList) {
       if (x <= 0 || x > defSubExec) {
         Utils::Print("[ERROR] Number of subexecutors must be positive and less than %d\n", defSubExec);
-        return 1;
+        return ERR_FATAL;
       }
     }
   }
 
   if (prewarmMsec < 0) {
     Utils::Print("[ERROR] PREWARM_MSEC must be non-negative (not %d)\n", prewarmMsec);
-    return 1;
+    return ERR_FATAL;
   }
 
   if (temporalMask < 1 || temporalMask > 3) {
     Utils::Print("[ERROR] TEMPORAL_MASK must be between 1 to 3 (not %d)\n", temporalMask);
-    return 1;
+    return ERR_FATAL;
   }
 
   if (unrolls.empty()) {
     Utils::Print("[ERROR] UNROLLS may not be empty");
-    return 1;
+    return ERR_FATAL;
   }
   for (auto unroll : unrolls) {
     if (unroll != 1 && unroll != 2 && unroll != 4 && unroll != 8 && unroll != 16) {
       Utils::Print("[ERROR] UNROLLS must only contain {1,2,4,8 or 16} (not %d)\n", unroll);
-      return 1;
+      return ERR_FATAL;
     }
   }
 
@@ -404,7 +404,7 @@ int HbmBandwidthPreset(EnvVars&          ev,
       if (Utils::AllocateMemory({MEM_CPU_CLOSEST, gpuIdx, myRank}, sizeof(int64_t), (void**)&minStartCycle) ||
           Utils::AllocateMemory({MEM_CPU_CLOSEST, gpuIdx, myRank}, sizeof(int64_t), (void**)&maxStopCycle)) {
         Utils::Print("[ERROR] Unable to allocate pinned host memory on rank %d closest to GPU %d\n", myRank, gpuIdx);
-        return 1;
+        return ERR_FATAL;
       }
     }
 
@@ -415,7 +415,7 @@ int HbmBandwidthPreset(EnvVars&          ev,
       ErrResult err = AllocateMemory(memDevice, largestTotalBytesPerBuffer, &inputBuffers[bufferIdx]);
       if (err.errType != ERR_NONE) {
         Utils::Print("[ERROR] Error when allocating memory (%s)\n", err.errMsg.c_str());
-        return 1;
+        return ERR_FATAL;
       }
       FillPsuedoRandomData<<<32, 256, 0, stream>>>(largestTotalBytesPerBuffer / sizeof(uint32_t),
                                                    (uint32_t*)inputBuffers[bufferIdx], bufferIdx);
@@ -535,7 +535,7 @@ int HbmBandwidthPreset(EnvVars&          ev,
       ErrResult err = DeallocateMemory(memType, inputBuffers[bufferIdx], largestTotalBytesPerBuffer);
       if (err.errType != ERR_NONE) {
         Utils::Print("[ERROR] Error when deallocating memory (%s)\n", err.errMsg.c_str());
-        return 1;
+        return ERR_FATAL;
       }
     }
 
@@ -543,7 +543,7 @@ int HbmBandwidthPreset(EnvVars&          ev,
       if (Utils::DeallocateMemory(MEM_CPU_CLOSEST, minStartCycle, sizeof(int64_t)) ||
           Utils::DeallocateMemory(MEM_CPU_CLOSEST, maxStopCycle,  sizeof(int64_t))) {
         Utils::Print("[ERROR] Unable to deallocate pinned host memory on rank %d closest to GPU %d\n", myRank, gpuIdx);
-        return 1;
+        return ERR_FATAL;
       }
     }
 
@@ -615,5 +615,5 @@ int HbmBandwidthPreset(EnvVars&          ev,
   }
   table.PrintTable(outputToCsv, showBorders);
 
-  return 0;
+  return ERR_NONE;
 }

--- a/src/client/Presets/HbmBandwidth.hpp
+++ b/src/client/Presets/HbmBandwidth.hpp
@@ -272,17 +272,15 @@ int HbmBandwidthPreset(EnvVars&          ev,
     Utils::Print("[ERROR] NUM_BUFFERS must be a positive number (not %d)\n", numBuffers);
     return 1;
   }
+  if (numIterations <= 0) {
+    Utils::Print("[ERROR] NUM_ITERATIONS must be positive (not %d)\n", numIterations);
+    return 1;
+  }
   if (numBuffers > numIterations) {
     Utils::Print("[WARN] NUM_BUFFERS (%d) exceeds NUM_ITERATIONS (%d), so some buffers will not be used\n",
                  numBuffers, numIterations);
     numBuffers = numIterations;
   }
-
-  if (numIterations <= 0) {
-    Utils::Print("[ERROR] NUM_ITERATIONS must be positive (not %d)\n", numIterations);
-    return 1;
-  }
-
 
   if (numSesList.empty()) {
     // By default, use all available sub executors

--- a/src/client/Presets/HealthCheck.hpp
+++ b/src/client/Presets/HealthCheck.hpp
@@ -446,13 +446,13 @@ int HealthCheckPreset(EnvVars&          ev,
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR] Healthcheck preset currently not supported for multi-node\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   // Check for supported platforms
 #if defined(__NVCC__)
   printf("[WARN] healthcheck preset not supported on NVIDIA hardware\n");
-  return 0;
+  return ERR_NONE;
 #endif
 
   printf("Disclaimer:\n");
@@ -474,5 +474,5 @@ int HealthCheckPreset(EnvVars&          ev,
   numFails += TestUnidir(modelId, verbose);
   numFails += TestBidir(modelId, verbose);
   numFails += TestAllToAll(modelId, verbose);
-  return numFails ? 1 : 0;
+  return numFails ? ERR_FATAL : ERR_NONE;
 }

--- a/src/client/Presets/NicPeerToPeer.hpp
+++ b/src/client/Presets/NicPeerToPeer.hpp
@@ -37,14 +37,14 @@ int NicPeerToPeerPreset(EnvVars&          ev,
     Utils::Print("[ERROR] NIC p2p preset can only be run across ranks that are homogenous\n");
     Utils::Print("[ERROR] Run ./TransferBench without any args to display topology information\n");
     Utils::Print("[ERROR] TB_NIC_FILTER may also be used to limit NIC visibility\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   int numRanks = TransferBench::GetNumRanks();
   int numNicsPerRank = TransferBench::GetNumExecutors(EXE_NIC);
   if (numNicsPerRank == 0) {
     Utils::Print("No NIC detected, NICs are required to run this preset\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   // Collect env vars for this preset
@@ -144,7 +144,7 @@ int NicPeerToPeerPreset(EnvVars&          ev,
           if (srcMemIndex == -1 || dstMemIndex == -1) {
             Utils::Print("[ERROR] No proper GPU device can be found for transfer R%dN%d - R%dN%d\n",
                          srcRank, srcNicIdx, dstRank, dstNicIdx);
-            return 1;
+            return ERR_FATAL;
           }
           transfer.numBytes = numBytesPerTransfer;
           transfer.srcs.push_back({srcTypeActual, srcMemIndex, srcRank});
@@ -160,7 +160,7 @@ int NicPeerToPeerPreset(EnvVars&          ev,
       if (!TransferBench::RunTransfers(cfg, transfers, results)) {
         for (auto const& err : results.errResults)
           Utils::Print("%s\n", err.errMsg.c_str());
-        return 1;
+        return ERR_FATAL;
       }
 
       counter += transfers.size();
@@ -315,5 +315,5 @@ int NicPeerToPeerPreset(EnvVars&          ev,
   }
   summaryTable.PrintTable(ev.outputToCsv, ev.showBorders);
 
-  return 0;
+  return ERR_NONE;
 }

--- a/src/client/Presets/NicRings.hpp
+++ b/src/client/Presets/NicRings.hpp
@@ -31,7 +31,7 @@ int NicRingsPreset(EnvVars&          ev,
     Utils::Print("[ERROR] NIC-rings preset can only be run across ranks that are homogenous\n");
     Utils::Print("[ERROR] Run ./TransferBench without any args to display topology information\n");
     Utils::Print("[ERROR] TB_NIC_FILTER may also be used to limit NIC visibility\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   // Collect topology
@@ -105,7 +105,7 @@ int NicRingsPreset(EnvVars&          ev,
   if (!TransferBench::RunTransfers(cfg, transfers, results)) {
     for (auto const& err : results.errResults)
       Utils::Print("%s\n", err.errMsg.c_str());
-    return 1;
+    return ERR_FATAL;
   } else if (showDetails) {
     Utils::PrintResults(ev, 1, transfers, results);
     Utils::Print("\n");
@@ -205,5 +205,5 @@ int NicRingsPreset(EnvVars&          ev,
   if (Utils::HasDuplicateHostname()) {
     printf("[WARN] It is recommended to run TransferBench with one rank per host to avoid potential aliasing of executors\n");
   }
-  return 0;
+  return ERR_NONE;
 }

--- a/src/client/Presets/OneToAll.hpp
+++ b/src/client/Presets/OneToAll.hpp
@@ -27,13 +27,13 @@ int OneToAllPreset(EnvVars&          ev,
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR] One-to-All preset currently not supported for multi-node\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   int numDetectedGpus = TransferBench::GetNumExecutors(EXE_GPU_GFX);
   if (numDetectedGpus < 2) {
     printf("[ERROR] One-to-all benchmark requires machine with at least 2 GPUs\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   // Collect env vars for this preset
@@ -67,7 +67,7 @@ int OneToAllPreset(EnvVars&          ev,
   for (auto ch : sweepExe) {
     if (ch != 'G' && ch != 'D') {
       printf("[ERROR] Unrecognized executor type '%c' specified\n", ch);
-      return 1;
+      return ERR_FATAL;
     }
   }
 
@@ -130,7 +130,7 @@ int OneToAllPreset(EnvVars&          ev,
         }
         if (!TransferBench::RunTransfers(cfg, transfers, results)) {
           Utils::PrintErrors(results.errResults);
-          return 1;
+          return ERR_FATAL;
         }
 
         int counter = 0;
@@ -152,5 +152,5 @@ int OneToAllPreset(EnvVars&          ev,
       }
     }
   }
-  return 0;
+  return ERR_NONE;
 }

--- a/src/client/Presets/PeerToPeer.hpp
+++ b/src/client/Presets/PeerToPeer.hpp
@@ -27,7 +27,7 @@ int PeerToPeerPreset(EnvVars&          ev,
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR] Peer-to-peer preset currently not supported for multi-node\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   int numDetectedCpus = TransferBench::GetNumExecutors(EXE_CPU);
@@ -43,7 +43,6 @@ int PeerToPeerPreset(EnvVars&          ev,
   int numGpuDevices  = EnvVars::GetEnvVar("NUM_GPU_DEVICES", numDetectedGpus);
   int numGpuSubExecs = EnvVars::GetEnvVar("NUM_GPU_SE",      useDmaCopy ? 1 : TransferBench::GetNumSubExecutors({EXE_GPU_GFX, 0}));
   int p2pMode        = EnvVars::GetEnvVar("P2P_MODE",        0);
-  int useFineGrain   = EnvVars::GetEnvVar("USE_FINE_GRAIN",  -999); // Deprecated
   int useRemoteRead  = EnvVars::GetEnvVar("USE_REMOTE_READ", 0);
 
   MemType cpuMemType = Utils::GetCpuMemType(cpuMemTypeIdx);
@@ -71,12 +70,6 @@ int PeerToPeerPreset(EnvVars&          ev,
       ev.Print("USE_REMOTE_READ", useRemoteRead,  "Using %s as executor", useRemoteRead ? "DST" : "SRC");
       printf("\n");
     }
-  }
-
-  // Check for deprecated env vars
-  if (useFineGrain != -999) {
-    Utils::Print("[ERROR] USE_FINE_GRAIN has been deprecated and replaced by CPU_MEM_TYPE and GPU_MEM_TYPE\n");
-    return 1;
   }
 
   char const separator = ev.outputToCsv ? ',' : ' ';
@@ -189,7 +182,7 @@ int PeerToPeerPreset(EnvVars&          ev,
           if (!TransferBench::RunTransfers(cfg, transfers, results)) {
             for (auto const& err : results.errResults)
               printf("%s\n", err.errMsg.c_str());
-            return 1;
+            return ERR_FATAL;
           }
 
           for (int dir = 0; dir <= isBidirectional; dir++) {
@@ -327,5 +320,5 @@ int PeerToPeerPreset(EnvVars&          ev,
       printf("\n\n");
     }
   }
-  return 0;
+  return ERR_NONE;
 }

--- a/src/client/Presets/PodAllToAll.hpp
+++ b/src/client/Presets/PodAllToAll.hpp
@@ -62,7 +62,7 @@ int PodAllToAllPreset(EnvVars&          ev,
   for (int rank = 0; rank < numRanks; rank++) {
     if (numGpus > TransferBench::GetNumExecutors(EXE_GPU_GFX, rank)) {
       Utils::Print("[ERROR] All-to-All preset requires each rank to have the same number of GPUs\n");
-      return 1;
+      return ERR_FATAL;
     }
     if (numQueuePairs > 0 && numNics != TransferBench::GetNumExecutors(EXE_NIC, rank))
       nicDifference = true;
@@ -79,7 +79,7 @@ int PodAllToAllPreset(EnvVars&          ev,
     a2aMode = EnvVars::GetEnvVar("A2A_MODE", 0);
     if (a2aMode < 0 || a2aMode > 2) {
       Utils::Print("[ERROR] a2aMode must be between 0 and 2, or else numSrcs:numDsts\n");
-      return 1;
+      return ERR_FATAL;
     }
     numSrcs = (a2aMode == A2A_WRITE_ONLY ? 0 : 1);
     numDsts = (a2aMode == A2A_READ_ONLY  ? 0 : 1);
@@ -111,16 +111,16 @@ int PodAllToAllPreset(EnvVars&          ev,
   // Validate env vars
   if (numGpus < 0 || numGpus > numDetectedGpus) {
     Utils::Print("[ERROR] Cannot use %d GPUs.  Detected %d GPUs\n", numGpus, numDetectedGpus);
-    return 1;
+    return ERR_FATAL;
   }
   if (useDmaExec && (numSrcs != 1 || numDsts != 1)) {
     Utils::Print("[ERROR] DMA execution can only be used for copies (A2A_MODE=0)\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   if (numRanks * numDetectedGpus % groupSize) {
     Utils::Print("[ERROR] Group size %d cannot evenly divide %d total devices from %d ranks.\n", groupSize, numRanks * numDetectedGpus, numRanks);
-    return 1;
+    return ERR_FATAL;
   }
 
   Utils::Print("GPU-%s IntraPod All-To-All benchmark:\n", useDmaExec ? "DMA" : "GFX");
@@ -135,7 +135,7 @@ int PodAllToAllPreset(EnvVars&          ev,
   Utils::RankPerPodMap& rankToPod = Utils::GetRankPerPodMap();
   if (rankToPod.empty()) {
     Utils::Print("[ERROR] No pods detected. Set TB_FORCE_SINGLE_POD=1 to treat all ranks as a single pod.\n");
-    return 1;
+    return ERR_FATAL;
   }
   for (auto const& [pod, ranks] : rankToPod) {
     int n = ranks.size() * numGpus;
@@ -192,7 +192,7 @@ int PodAllToAllPreset(EnvVars&          ev,
       if (!TransferBench::RunTransfers(cfg, transfers, results)) {
         for (auto const& err : results.errResults)
           Utils::Print("%s\n", err.errMsg.c_str());
-        return 1;
+        return ERR_FATAL;
       }
       if (showDetails) {
         Utils::PrintResults(ev, 1, transfers, results);
@@ -266,5 +266,5 @@ int PodAllToAllPreset(EnvVars&          ev,
     printf("[WARN] It is recommended to run TransferBench with one rank per host to avoid potential aliasing of executors\n");
   }
 
-  return 0;
+  return ERR_NONE;
 }

--- a/src/client/Presets/PodPeerToPeer.hpp
+++ b/src/client/Presets/PodPeerToPeer.hpp
@@ -29,13 +29,13 @@ int PodPeerToPeerPreset(EnvVars&          ev,
     Utils::Print("[ERROR] Pod p2p preset can only be run across ranks that are homogenous\n");
     Utils::Print("[ERROR] All ranks currently have to be under the same physical and virtual pod\n");
     Utils::Print("[ERROR] Run ./TransferBench without any args to display topology information\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   Utils::RankPerPodMap& rankToPod = Utils::GetRankPerPodMap();
   if (rankToPod.empty()) {
     Utils::Print("[ERROR] No pods detected. Set TB_FORCE_SINGLE_POD=1 to treat all ranks as a single pod.\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   int numDetectedGpus = TransferBench::GetNumExecutors(EXE_GPU_GFX);
@@ -165,7 +165,7 @@ int PodPeerToPeerPreset(EnvVars&          ev,
         if (!TransferBench::RunTransfers(cfg, transfers, results)) {
           for (auto const& err : results.errResults)
             Utils::Print("%s\n", err.errMsg.c_str());
-          return 1;
+          return ERR_FATAL;
         }
 
         for (size_t k = 0; k < round.size(); k++) {
@@ -296,6 +296,5 @@ int PodPeerToPeerPreset(EnvVars&          ev,
     }
 
   }
-  return 0;
-
+  return ERR_NONE;
 }

--- a/src/client/Presets/Scaling.hpp
+++ b/src/client/Presets/Scaling.hpp
@@ -27,7 +27,7 @@ int ScalingPreset(EnvVars&          ev,
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR] Scaling preset currently not supported for multi-node\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   int numDetectedCpus = TransferBench::GetNumExecutors(EXE_CPU);
@@ -41,7 +41,6 @@ int ScalingPreset(EnvVars&          ev,
   int numGpuDevices = EnvVars::GetEnvVar("NUM_GPU_DEVICES", numDetectedGpus);
   int sweepMax      = EnvVars::GetEnvVar("SWEEP_MAX",       32);
   int sweepMin      = EnvVars::GetEnvVar("SWEEP_MIN",       1);
-  int useFineGrain   = EnvVars::GetEnvVar("USE_FINE_GRAIN",  -999); // Deprecated
 
   // Display environment variables
   MemType cpuMemType = Utils::GetCpuMemType(cpuMemTypeIdx);
@@ -64,13 +63,7 @@ int ScalingPreset(EnvVars&          ev,
   // Validate env vars
   if (localIdx >= numDetectedGpus) {
     printf("[ERROR] Cannot execute scaling test with local GPU device %d\n", localIdx);
-    return 1;
-  }
-
-  // Check for deprecated env vars
-  if (useFineGrain != -999) {
-    Utils::Print("[ERROR] USE_FINE_GRAIN has been deprecated and replaced by CPU_MEM_TYPE and GPU_MEM_TYPE\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   TransferBench::ConfigOptions cfg = ev.ToConfigOptions();
@@ -106,7 +99,7 @@ int ScalingPreset(EnvVars&          ev,
                  i < numCpuDevices ? i : i - numCpuDevices}};
       if (!RunTransfers(cfg, transfers, results)) {
         Utils::PrintErrors(results.errResults);
-        return 1;
+        return ERR_FATAL;
       }
       double bw = results.tfrResults[0].avgBandwidthGbPerSec;
       printf("%c%7.2f     ", separator, bw);
@@ -124,5 +117,5 @@ int ScalingPreset(EnvVars&          ev,
     printf("%c%7.2f(%3d)", separator, bestResult[i].first, bestResult[i].second);
   printf("\n");
 
-  return 0;
+  return ERR_NONE;
 }

--- a/src/client/Presets/Schmoo.hpp
+++ b/src/client/Presets/Schmoo.hpp
@@ -109,8 +109,6 @@ int SchmooPreset(EnvVars&          ev,
     // Local Copy
     t.srcs = {{gpuMemType, localIdx}};
     t.dsts = {{gpuMemType, localIdx}};
-    t.srcs = {};
-    t.dsts = {{gpuMemType, localIdx}};
     if (!TransferBench::RunTransfers(cfg, transfers, results)) {
       Utils::PrintErrors(results.errResults);
       return ERR_FATAL;

--- a/src/client/Presets/Schmoo.hpp
+++ b/src/client/Presets/Schmoo.hpp
@@ -26,46 +26,48 @@ int SchmooPreset(EnvVars&          ev,
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR] Schmoo preset currently not supported for multi-node\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   int numDetectedGpus = TransferBench::GetNumExecutors(EXE_GPU_GFX);
 
   if (numDetectedGpus < 2) {
     printf("[ERROR] Schmoo benchmark requires at least 2 GPUs\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   // Collect env vars for this preset
-  int localIdx     = EnvVars::GetEnvVar("LOCAL_IDX",      0);
-  int remoteIdx    = EnvVars::GetEnvVar("REMOTE_IDX",     1);
-  int sweepMax     = EnvVars::GetEnvVar("SWEEP_MAX",      32);
-  int sweepMin     = EnvVars::GetEnvVar("SWEEP_MIN",      1);
-  int useFineGrain = EnvVars::GetEnvVar("USE_FINE_GRAIN", 0);
+  int gpuMemTypeIdx = EnvVars::GetEnvVar("GPU_MEM_TYPE",    0);
+  int localIdx      = EnvVars::GetEnvVar("LOCAL_IDX",      0);
+  int remoteIdx     = EnvVars::GetEnvVar("REMOTE_IDX",     1);
+  int sweepMax      = EnvVars::GetEnvVar("SWEEP_MAX",      32);
+  int sweepMin      = EnvVars::GetEnvVar("SWEEP_MIN",      1);
+
+  MemType gpuMemType = Utils::GetGpuMemType(gpuMemTypeIdx);
 
   // Display environment variables
   ev.DisplayEnvVars();
   if (!ev.hideEnv) {
     int outputToCsv = ev.outputToCsv;
     if (!outputToCsv) printf("[Schmoo Related]\n");
+    ev.Print("GPU_MEM_TYPE"   , gpuMemTypeIdx,  "Using %s (%s)", Utils::GetGpuMemTypeStr(gpuMemTypeIdx).c_str(), Utils::GetAllGpuMemTypeStr().c_str());
     ev.Print("LOCAL_IDX",      localIdx,     "Local GPU index");
     ev.Print("REMOTE_IDX",     remoteIdx,    "Remote GPU index");
     ev.Print("SWEEP_MAX",      sweepMax,     "Max number of subExecutors to use");
     ev.Print("SWEEP_MIN",      sweepMin,     "Min number of subExecutors to use");
-    ev.Print("USE_FINE_GRAIN", useFineGrain, "Using %s-grained memory", useFineGrain ? "fine" : "coarse");
     printf("\n");
   }
 
   // Validate env vars
   if (localIdx >= numDetectedGpus || remoteIdx >= numDetectedGpus) {
     printf("[ERROR] Cannot execute schmoo test with local GPU device %d, remote GPU device %d\n", localIdx, remoteIdx);
-    return 1;
+    return ERR_FATAL;
   }
 
   TransferBench::ConfigOptions cfg = ev.ToConfigOptions();
   TransferBench::TestResults results;
 
-  char memChar = useFineGrain ? 'F' : 'G';
+  char memChar = MemTypeStr[gpuMemType];
   printf("Bytes to transfer: %lu Local GPU: %d Remote GPU: %d\n", numBytesPerTransfer, localIdx, remoteIdx);
   printf("       | Local Read  | Local Write | Local Copy  | Remote Read | Remote Write| Remote Copy |\n");
   printf("  #CUs |%c%02d->G%02d->N00|N00->G%02d->%c%02d|%c%02d->G%02d->%c%02d|%c%02d->G%02d->N00|N00->G%02d->%c%02d|%c%02d->G%02d->%c%02d|\n",
@@ -83,69 +85,67 @@ int SchmooPreset(EnvVars&          ev,
   t.exeSubIndex = -1;
   t.numBytes    = numBytesPerTransfer;
 
-  MemType memType = (useFineGrain ? MEM_GPU_FINE : MEM_GPU);
-
   for (int numCUs = sweepMin; numCUs <= sweepMax; numCUs++) {
     t.numSubExecs = numCUs;
 
     // Local Read
-    t.srcs = {{memType, localIdx}};
+    t.srcs = {{gpuMemType, localIdx}};
     t.dsts = {};
     if (!TransferBench::RunTransfers(cfg, transfers, results)) {
       Utils::PrintErrors(results.errResults);
-      return 1;
+      return ERR_FATAL;
     }
     double const localRead = results.tfrResults[0].avgBandwidthGbPerSec;
 
     // Local Write
     t.srcs = {};
-    t.dsts = {{memType, localIdx}};
+    t.dsts = {{gpuMemType, localIdx}};
     if (!TransferBench::RunTransfers(cfg, transfers, results)) {
       Utils::PrintErrors(results.errResults);
-      return 1;
+      return ERR_FATAL;
     }
     double const localWrite = results.tfrResults[0].avgBandwidthGbPerSec;
 
     // Local Copy
-    t.srcs = {{memType, localIdx}};
-    t.dsts = {{memType, localIdx}};
+    t.srcs = {{gpuMemType, localIdx}};
+    t.dsts = {{gpuMemType, localIdx}};
     t.srcs = {};
-    t.dsts = {{memType, localIdx}};
+    t.dsts = {{gpuMemType, localIdx}};
     if (!TransferBench::RunTransfers(cfg, transfers, results)) {
       Utils::PrintErrors(results.errResults);
-      return 1;
+      return ERR_FATAL;
     }
     double const localCopy = results.tfrResults[0].avgBandwidthGbPerSec;
 
     // Remote Read
-    t.srcs = {{memType, remoteIdx}};
+    t.srcs = {{gpuMemType, remoteIdx}};
     t.dsts = {};
     if (!TransferBench::RunTransfers(cfg, transfers, results)) {
       Utils::PrintErrors(results.errResults);
-      return 1;
+      return ERR_FATAL;
     }
     double const remoteRead = results.tfrResults[0].avgBandwidthGbPerSec;
 
     // Remote Write
     t.srcs = {};
-    t.dsts = {{memType, remoteIdx}};
+    t.dsts = {{gpuMemType, remoteIdx}};
     if (!TransferBench::RunTransfers(cfg, transfers, results)) {
       Utils::PrintErrors(results.errResults);
-      return 1;
+      return ERR_FATAL;
     }
     double const remoteWrite = results.tfrResults[0].avgBandwidthGbPerSec;
 
     // Remote Copy
-    t.srcs = {{memType, localIdx}};
-    t.dsts = {{memType, remoteIdx}};
+    t.srcs = {{gpuMemType, localIdx}};
+    t.dsts = {{gpuMemType, remoteIdx}};
     if (!TransferBench::RunTransfers(cfg, transfers, results)) {
       Utils::PrintErrors(results.errResults);
-      return 1;
+      return ERR_FATAL;
     }
     double const remoteCopy = results.tfrResults[0].avgBandwidthGbPerSec;
 
     printf("   %3d   %11.3f   %11.3f   %11.3f   %11.3f   %11.3f   %11.3f  \n",
            numCUs, localRead, localWrite, localCopy, remoteRead, remoteWrite, remoteCopy);
   }
-  return 0;
+  return ERR_NONE;
 }

--- a/src/client/Presets/SmokeTest.hpp
+++ b/src/client/Presets/SmokeTest.hpp
@@ -181,7 +181,7 @@ int SmokeTestPreset(EnvVars&          ev,
   if (Utils::GetRankPerPodMap().size() > 1) {
     Utils::Print("[ERROR] %s preset can only be run within a single pod\n", presetName.c_str());
     Utils::Print("[ERROR] Pod membership may be forced by setting TB_FORCE_SINGLE_POD=1\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   // Collect topology and check that all GPUs have the same number of subExecutors
@@ -194,7 +194,7 @@ int SmokeTestPreset(EnvVars&          ev,
     for (int gpu = 0; gpu < numGpus; gpu++) {
       if (numSubExec != TransferBench::GetNumSubExecutors({EXE_GPU_GFX, gpu, rank})) {
         Utils::Print("[ERROR] %s preset can only be run on GPUs with the same number of subexecutors\n", presetName.c_str());
-        return 1;
+        return ERR_FATAL;
       }
     }
   }
@@ -330,7 +330,7 @@ int SmokeTestPreset(EnvVars&          ev,
   if (Utils::HasDuplicateHostname()) {
     Utils::Print("[WARN] It is recommended to run TransferBench with one rank per host to avoid potential aliasing of executors\n");
   }
-  return testsFailed ? 1 : 0;
+  return testsFailed ? ERR_FATAL : ERR_NONE;
 }
 
 }

--- a/src/client/Presets/Sweep.hpp
+++ b/src/client/Presets/Sweep.hpp
@@ -46,7 +46,7 @@ int SweepPreset(EnvVars&          ev,
 {
   if (TransferBench::GetNumRanks() > 1) {
     Utils::Print("[ERROR] Sweep preset currently not supported for multi-node\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   bool const isRandom = (presetName == "rsweep");
@@ -104,33 +104,33 @@ int SweepPreset(EnvVars&          ev,
   for (auto ch : sweepSrc) {
     if (!strchr(MemTypeStr, ch)) {
       printf("[ERROR] Unrecognized memory type '%c' specified for sweep source\n", ch);
-      return 1;
+      return ERR_FATAL;
     }
     if (strchr(sweepSrc.c_str(), ch) != strrchr(sweepSrc.c_str(), ch)) {
       printf("[ERROR] Duplicate memory type '%c' specified for sweep source\n", ch);
-      return 1;
+      return ERR_FATAL;
     }
   }
 
   for (auto ch : sweepDst) {
     if (!strchr(MemTypeStr, ch)) {
       printf("[ERROR] Unrecognized memory type '%c' specified for sweep destination\n", ch);
-      return 1;
+      return ERR_FATAL;
     }
     if (strchr(sweepDst.c_str(), ch) != strrchr(sweepDst.c_str(), ch)) {
       printf("[ERROR] Duplicate memory type '%c' specified for sweep destination\n", ch);
-      return 1;
+      return ERR_FATAL;
     }
   }
 
   for (auto ch : sweepExe) {
     if (!strchr(ExeTypeStr, ch)) {
       printf("[ERROR] Unrecognized executor type '%c' specified for sweep executor\n", ch);
-      return 1;
+      return ERR_FATAL;
     }
     if (strchr(sweepExe.c_str(), ch) != strrchr(sweepExe.c_str(), ch)) {
       printf("[ERROR] Duplicate executor type '%c' specified for sweep executor\n", ch);
-      return 1;
+      return ERR_FATAL;
     }
   }
 
@@ -340,7 +340,7 @@ int SweepPreset(EnvVars&          ev,
 
     if (!TransferBench::RunTransfers(cfg, transfers, results)) {
       Utils::PrintErrors(results.errResults);
-      if (!continueOnErr) return 1;
+      if (!continueOnErr) return ERR_FATAL;
     } else {
       Utils::PrintResults(ev, numTestsRun, transfers, results);
     }
@@ -372,5 +372,5 @@ int SweepPreset(EnvVars&          ev,
     }
   }
   if (fp) fclose(fp);
-  return 0;
+  return ERR_NONE;
 }

--- a/src/client/Presets/WallClock.hpp
+++ b/src/client/Presets/WallClock.hpp
@@ -69,7 +69,7 @@ int WallClockPreset(EnvVars&          ev,
     Utils::Print("[ERROR] wallclock preset can only be run across ranks that are homogenous\n");
     Utils::Print("[ERROR] Run ./TransferBench without any args to display topology information\n");
     Utils::Print("[ERROR] TB_NIC_FILTER may also be used to limit NIC visibility\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   int numDetectedGpus = TransferBench::GetNumExecutors(EXE_GPU_GFX);
@@ -94,7 +94,7 @@ int WallClockPreset(EnvVars&          ev,
 
   if (numGpuDevices <= 0) {
     Utils::Print("[ERROR] wallclock preset requires at least one GPU\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   // Collect local results
@@ -125,11 +125,11 @@ int WallClockPreset(EnvVars&          ev,
     if (Utils::AllocateMemory({MEM_CPU_CLOSEST, deviceId}, numXccs * sizeof(uint64_t), (void**)&timestamps)) {
       Utils::Print("[ERROR] Unable to allocate pinned host memory for storing timestamps for GPU device %d on rank %d\n",
                    deviceId, myRank);
-      return 1;
+      return ERR_FATAL;
     }
     if (Utils::AllocateMemory({MEM_GPU, deviceId}, sizeof(int32_t), (void**)&readyFlag)) {
       Utils::Print("[ERROR] Unable to allocate readyFlag on GPU device %d on rank %d\n", deviceId, myRank);
-      return 1;
+      return ERR_FATAL;
     }
 
     for (int i = -ev.numWarmups; i < ev.numIterations; i++)
@@ -225,7 +225,7 @@ int WallClockPreset(EnvVars&          ev,
   if (Utils::HasDuplicateHostname()) {
     Utils::Print("[WARN] It is recommended to run TransferBench with one rank per host to avoid potential aliasing of executors\n");
   }
-  return 0;
+  return ERR_NONE;
 }
 
 #if defined(__NVCC__)

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3847,7 +3847,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
                               vector<Transfer> const&  transfers,
                               ExeInfo const&           exeInfo)
   {
-    // GpuReducKernel always works
+    // GpuReduceKernel always works
     if (gpuKernelIdx == GFX_KERNEL_REDUCE) return true;
 
     // CopyKernel works if all Transfers have at most one SRC / one DST with no warp subexecutors

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -157,9 +157,10 @@ namespace TransferBench
    */
   enum GfxKernelType
   {
-    GFX_KERNEL_REDUCE = 0,                     ///< Default kernel that supports any multiple input/output buffers
-    GFX_KERNEL_COPY   = 1,                     ///< Simpler kernel that supports copies only
-    NUM_GFX_KERNELS   = 2                      ///< Number of GFX kernels currently supported
+    GFX_KERNEL_AUTO   = -1,                     ///< Automatically choose a kernel
+    GFX_KERNEL_REDUCE =  0,                     ///< Default kernel that supports any multiple input/output buffers
+    GFX_KERNEL_COPY   =  1,                     ///< Simpler kernel that supports copies only
+    NUM_GFX_KERNELS   =  2                      ///< Number of GFX kernels currently supported
   };
 
   /**
@@ -658,16 +659,16 @@ namespace TransferBench
   #define hipStreamDestroy                                   cudaStreamDestroy
   #define hipStreamSynchronize                               cudaStreamSynchronize
   // cu* driver API returns CUresult; cast to cudaError_t so callers can use a single error variable
-  #define hipMemGetAllocationGranularity                     cuMemGetAllocationGranularity
-  #define hipMemCreate                                       cuMemCreate
-  #define hipMemAddressReserve                               cuMemAddressReserve
-  #define hipMemMap                                          cuMemMap
-  #define hipMemSetAccess                                    cuMemSetAccess
-  #define hipMemUnmap                                        cuMemUnmap
-  #define hipMemRelease                                      cuMemRelease
-  #define hipMemAddressFree                                  cuMemAddressFree
-  #define hipMemExportToShareableHandle                      cuMemExportToShareableHandle
-  #define hipMemImportFromShareableHandle                    cuMemImportFromShareableHandle
+#define hipMemGetAllocationGranularity(...)                  ((cudaError_t)cuMemGetAllocationGranularity(__VA_ARGS__))
+  #define hipMemCreate(...)                                  ((cudaError_t)cuMemCreate(__VA_ARGS__))
+  #define hipMemAddressReserve(...)                          ((cudaError_t)cuMemAddressReserve(__VA_ARGS__))
+  #define hipMemMap(...)                                     ((cudaError_t)cuMemMap(__VA_ARGS__))
+  #define hipMemSetAccess(...)                               ((cudaError_t)cuMemSetAccess(__VA_ARGS__))
+  #define hipMemUnmap(...)                                   ((cudaError_t)cuMemUnmap(__VA_ARGS__))
+  #define hipMemRelease(...)                                 ((cudaError_t)cuMemRelease(__VA_ARGS__))
+  #define hipMemAddressFree(...)                             ((cudaError_t)cuMemAddressFree(__VA_ARGS__))
+  #define hipMemExportToShareableHandle(...)                 ((cudaError_t)cuMemExportToShareableHandle(__VA_ARGS__))
+  #define hipMemImportFromShareableHandle(...)               ((cudaError_t)cuMemImportFromShareableHandle(__VA_ARGS__))
 
   using gpu_device_ptr = CUdeviceptr;
 
@@ -3849,7 +3850,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     // GpuReducKernel always works
     if (gpuKernelIdx == GFX_KERNEL_REDUCE) return true;
 
-    // CopyKernel only works if all Transfers are single SRC / single DST copies, with no warp subexecutors
+    // CopyKernel works if all Transfers have at most one SRC / one DST with no warp subexecutors
     if (gpuKernelIdx == GFX_KERNEL_COPY) {
       if (cfg.gfx.seType != 0) return false;
       if (exeInfo.resources.empty()) return false;
@@ -3868,14 +3869,14 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
   {
     // Decide on which GFX kernel to use
     // Auto-select - prefer copyKernel if eligible
-    if (cfg.gfx.gfxKernel == -1) {
+    if (cfg.gfx.gfxKernel == GFX_KERNEL_AUTO) {
       exeInfo.gfxKernelToUse = CanUseGfxKernel(GFX_KERNEL_COPY, cfg, transfers, exeInfo) ? 1 : 0;
     } else {
       exeInfo.gfxKernelToUse = cfg.gfx.gfxKernel;
     }
 
-    // Warn if using forcing copy kernel
-    if (exeInfo.gfxKernelToUse == GFX_KERNEL_COPY && !CanUseGfxKernel(GFX_KERNEL_COPY, cfg, transfers, exeInfo)) {
+    // Warn if using forcing copy kernel, but allow kernel to continue
+    if (cfg.gfx.gfxKernel == GFX_KERNEL_COPY && !CanUseGfxKernel(GFX_KERNEL_COPY, cfg, transfers, exeInfo)) {
       return {ERR_WARN,
         "GFX copy kernel forced even though deemed incompatible for current set of Transfers / config"};
     }
@@ -5202,23 +5203,32 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 
     int xccDim = exeInfo.useSubIndices ? exeInfo.numSubIndices : 1;
 
-    vector<std::future<ErrResult>> asyncTransfers;
-    for (int i = 0; i < exeInfo.streams.size(); i++) {
-      asyncTransfers.emplace_back(std::async(std::launch::async,
-                                             ExecuteGpuTransfer,
-                                             iteration,
-                                             exeInfo.totalSubExecs,
-                                             exeInfo.subExecParamGpu,
-                                             exeInfo.streams[i],
-                                             cfg.gfx.useHipEvents ? exeInfo.startEvents[i] : NULL,
-                                             cfg.gfx.useHipEvents ? exeInfo.stopEvents[i] : NULL,
-                                             xccDim,
-                                             std::cref(cfg),
-                                             exeInfo.gfxKernelToUse,
-                                             std::ref(exeInfo.resources[i])));
+    if (cfg.gfx.useMultiStream) {
+      // Launch one thread per Transfer in separate streams
+      vector<std::future<ErrResult>> asyncTransfers;
+      for (int i = 0; i < exeInfo.streams.size(); i++) {
+        asyncTransfers.emplace_back(std::async(std::launch::async,
+                                               ExecuteGpuTransfer,
+                                               iteration,
+                                               exeInfo.totalSubExecs,
+                                               exeInfo.subExecParamGpu,
+                                               exeInfo.streams[i],
+                                               cfg.gfx.useHipEvents ? exeInfo.startEvents[i] : NULL,
+                                               cfg.gfx.useHipEvents ? exeInfo.stopEvents[i] : NULL,
+                                               xccDim,
+                                               std::cref(cfg),
+                                               exeInfo.gfxKernelToUse,
+                                               std::ref(exeInfo.resources[i])));
+      }
+      for (auto& asyncTransfer : asyncTransfers)
+        ERR_CHECK(asyncTransfer.get());
+    } else {
+      // Launch all Transfers in one kernel launch (avoid extra thread creation)
+      ExecuteGpuTransfer(iteration, exeInfo.totalSubExecs, exeInfo.subExecParamGpu, exeInfo.streams[0],
+                         cfg.gfx.useHipEvents ? exeInfo.startEvents[0] : NULL,
+                         cfg.gfx.useHipEvents ? exeInfo.stopEvents[0] : NULL,
+                         xccDim, cfg, exeInfo.gfxKernelToUse, exeInfo.resources[0]);
     }
-    for (auto& asyncTransfer : asyncTransfers)
-      ERR_CHECK(asyncTransfer.get());
 
     auto cpuDelta = std::chrono::high_resolution_clock::now() - cpuStart;
 

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -231,7 +231,7 @@ namespace TransferBench
     int                 blockOrder     = 0;     ///< Determines how threadblocks are ordered (0=sequential, 1=interleaved, 2=random)
     int                 blockSize      = 256;   ///< Size of each threadblock (must be multiple of 64)
     vector<uint32_t>    cuMask         = {};    ///< Bit-vector representing the CU mask
-    int                 gfxKernel      = -1;    ///< Kernel selector: -1=auto, 0=reduce, 1=copy-only
+    int                 gfxKernel      = 0;     ///< Kernel selector: -1=auto, 0=reduce, 1=copy-only
     vector<vector<int>> prefXccTable   = {};    ///< 2D table with preferred XCD to use for a specific [src][dst] GPU device
     int                 seType         = 0;     ///< SubExecutor granularity type (0=threadblock, 1=warp)
     int                 temporalMode   = 0;     ///< Non-temporal load/store mode 0=none, 1=load, 2=store, 3=both
@@ -407,29 +407,10 @@ namespace TransferBench
                     vector<Transfer> const& transfers,
                     TestResults&            results);
 
-  /**
-   * Enumeration of implementation attributes
-   */
-  enum IntAttribute
-  {
-    ATR_GFX_MAX_BLOCKSIZE,                      ///< Maximum blocksize for GFX executor
-    ATR_GFX_MAX_UNROLL,                         ///< Maximum unroll factor for GFX executor
-  };
-
   enum StrAttribute
   {
     ATR_SRC_PREP_DESCRIPTION                    ///< Description of how source memory is prepared
   };
-
-  /**
-   * Query attributes (integer)
-   *
-   * @note This allows querying of implementation information such as limits
-   *
-   * @param[in] attribute   Attribute to query
-   * @returns Value of the attribute
-   */
-  int GetIntAttribute(IntAttribute attribute);
 
   /**
    * Query attributes (string)
@@ -677,16 +658,16 @@ namespace TransferBench
   #define hipStreamDestroy                                   cudaStreamDestroy
   #define hipStreamSynchronize                               cudaStreamSynchronize
   // cu* driver API returns CUresult; cast to cudaError_t so callers can use a single error variable
-   #define hipMemGetAllocationGranularity(...)               ((cudaError_t)(cuMemGetAllocationGranularity(__VA_ARGS__))
-  #define hipMemCreate(...)                                  ((cudaError_t)(cuMemCreate(__VA_ARGS__))
-  #define hipMemAddressReserve(...)                          ((cudaError_t)cuMemAddressReserve(__VA_ARGS__))
-  #define hipMemMap(...)                                     ((cudaError_t)cuMemMap(__VA_ARGS__))
-  #define hipMemSetAccess(...)                               ((cudaError_t)cuMemSetAccess(__VA_ARGS__))
-  #define hipMemUnmap(...)                                   ((cudaError_t)cuMemUnmap(__VA_ARGS__))
-  #define hipMemRelease(...)                                 ((cudaError_t)cuMemRelease(__VA_ARGS__))
-  #define hipMemAddressFree(...)                             ((cudaError_t)cuMemAddressFree(__VA_ARGS__))
-  #define hipMemExportToShareableHandle(...)                 ((cudaError_t)cuMemExportToShareableHandle(__VA_ARGS__))
-  #define hipMemImportFromShareableHandle(...)               ((cudaError_t)cuMemImportFromShareableHandle(__VA_ARGS__))
+  #define hipMemGetAllocationGranularity                     cuMemGetAllocationGranularity
+  #define hipMemCreate                                       cuMemCreate
+  #define hipMemAddressReserve                               cuMemAddressReserve
+  #define hipMemMap                                          cuMemMap
+  #define hipMemSetAccess                                    cuMemSetAccess
+  #define hipMemUnmap                                        cuMemUnmap
+  #define hipMemRelease                                      cuMemRelease
+  #define hipMemAddressFree                                  cuMemAddressFree
+  #define hipMemExportToShareableHandle                      cuMemExportToShareableHandle
+  #define hipMemImportFromShareableHandle                    cuMemImportFromShareableHandle
 
   using gpu_device_ptr = CUdeviceptr;
 
@@ -812,9 +793,7 @@ namespace {
 
 // Constants
 //========================================================================================
-
   int   constexpr MAX_BLOCKSIZE  = 1024;               // Max threadblock size
-  int   constexpr MAX_UNROLL     = 16;                 // Max unroll factor
   int   constexpr MAX_SRCS       = 8;                  // Max srcs per Transfer
   int   constexpr MAX_DSTS       = 8;                  // Max dsts per Transfer
   int   constexpr MEMSET_CHAR    = 75;                 // Value to memset (char)
@@ -1972,6 +1951,9 @@ namespace {
     #undef ADD_ERROR
   }
 
+  // Forward declaration
+  int GetGpuKernelUnrollIdx(int unroll);
+
   // Validate configuration options - return trues if and only if an fatal error is detected
   static bool ConfigOptionsHaveErrors(ConfigOptions const&    cfg,
                                       std::vector<ErrResult>& errors)
@@ -2010,11 +1992,10 @@ namespace {
     if (cfg.gfx.useMultiStream && cfg.gfx.blockOrder > 0)
       errors.push_back({ERR_WARN, "[gfx.blockOrder] will be ignored when running in multi-stream mode"});
 
-    int gfxMaxBlockSize = GetIntAttribute(ATR_GFX_MAX_BLOCKSIZE);
-    if (cfg.gfx.blockSize < 0 || cfg.gfx.blockSize % 64 || cfg.gfx.blockSize > gfxMaxBlockSize)
+    if (cfg.gfx.blockSize < 0 || cfg.gfx.blockSize % 64 || cfg.gfx.blockSize > MAX_BLOCKSIZE)
       errors.push_back({ERR_FATAL,
                         "[gfx.blockSize] must be positive multiple of 64 less than or equal to %d",
-                        gfxMaxBlockSize});
+                        MAX_BLOCKSIZE});
 
     if (cfg.gfx.temporalMode < 0 || cfg.gfx.temporalMode > 3)
       errors.push_back({ERR_FATAL,
@@ -2026,18 +2007,18 @@ namespace {
           "[gfx.temporalMode] is not supported on NVIDIA hardware"});
 #endif
 
-    int gfxMaxUnroll = GetIntAttribute(ATR_GFX_MAX_UNROLL);
-    if (cfg.gfx.unrollFactor < 0 || cfg.gfx.unrollFactor > gfxMaxUnroll)
+    if (GetGpuKernelUnrollIdx(cfg.gfx.unrollFactor) == -1) {
       errors.push_back({ERR_FATAL,
-                        "[gfx.unrollFactor] must be non-negative and less than or equal to %d",
-                        gfxMaxUnroll});
+          "[gfx.unrollFactor] unroll factor of %d is unsupported", cfg.gfx.unrollFactor});
+    }
     if (cfg.gfx.waveOrder < 0 || cfg.gfx.waveOrder >= 6)
       errors.push_back({ERR_FATAL,
                         "[gfx.waveOrder] must be non-negative and less than 6"});
 
     if (!(cfg.gfx.wordSize == 1 || cfg.gfx.wordSize == 2 || cfg.gfx.wordSize == 4))
       errors.push_back({ERR_FATAL, "[gfx.wordSize] must be either 1, 2 or 4"});
-    if (cfg.gfx.gfxKernel < -1 || cfg.gfx.gfxKernel > NUM_GFX_KERNELS)
+
+    if (cfg.gfx.gfxKernel < -1 || cfg.gfx.gfxKernel >= NUM_GFX_KERNELS)
       errors.push_back(
         {ERR_FATAL, "[gfx.gfxKernel] must be -1 for auto, or less than %d", NUM_GFX_KERNELS});
 
@@ -2732,10 +2713,6 @@ namespace {
     vector<double>             perIterMsec;       ///< Duration for each individual iteration
     vector<set<pair<int,int>>> perIterCUs;        ///< GFX-Executor only. XCC:CU used per iteration
   };
-
-
-
-
 
   // Internal resources allocated per Executor
   struct ExeInfo
@@ -4177,11 +4154,6 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       ERR_CHECK(PrepareSubExecParams(cfg, t, rss));
     }
 
-    // Select which GFX kernel to use for this executor
-    if (exeDevice.exeType == EXE_GPU_GFX) {
-      ERR_CHECK(SelectGfxKernel(cfg, transfers, exeInfo));
-    }
-
     // Prepare additional requirements for GPU-based executors
     if ((exeDevice.exeType == EXE_GPU_GFX || exeDevice.exeType == EXE_GPU_DMA || exeDevice.exeType == EXE_GPU_BDMA)
         && exeDevice.exeRank == localRank) {
@@ -4729,13 +4701,30 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 
   // Simplified Kernel for GFX execution for copies only
   template <typename PACKED_FLOAT, int LAUNCH_BOUND, int UNROLL, int TEMPORAL_MODE>
-  __global__ __launch_bounds__(LAUNCH_BOUND)
-    void GpuCopyKernel(SubExecParam* params, int numSubIterations)
+  __global__ void __launch_bounds__(LAUNCH_BOUND)
+    GpuCopyKernel(SubExecParam* params, int seType, int waveOrder, int numSubIterations)
   {
-    // Capture GPU wall-clock timestamp
     int64_t startCycle;
-    if (threadIdx.x == 0) startCycle = GetTimestamp();
-    SubExecParam& p = params[blockIdx.y];
+    // For warp-level, each warp's first thread records timing; for threadblock-level, only first thread of block
+    bool shouldRecordTiming = (seType == 1) ? (threadIdx.x % warpSize == 0) : (threadIdx.x == 0);
+    if (shouldRecordTiming) startCycle = GetTimestamp();
+
+    // seType: 0=threadblock, 1=warp
+    int subExecIdx;
+    if (seType == 0) {
+      // Threadblock-level: each threadblock is a subexecutor
+      subExecIdx = blockIdx.y;
+    } else {
+      // Warp-level: each warp is a subexecutor
+      int warpIdx       = threadIdx.x / warpSize;
+      int warpsPerBlock = blockDim.x  / warpSize;
+      subExecIdx = blockIdx.y * warpsPerBlock + warpIdx;
+    }
+
+    SubExecParam& p = params[subExecIdx];
+
+    // For warp-level dispatch, inactive warps should return early
+    if (seType == 1 && p.N == 0) return;
 
     // Filter by XCC
 #if !defined(__NVCC__)
@@ -4744,48 +4733,103 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     if (p.preferredXccId != -1 && xccId != p.preferredXccId) return;
 #endif
 
-    // Cast src/dst buffers to the packed float type
-    size_t const numPackedFloat = p.N / (sizeof(PACKED_FLOAT)/sizeof(float));
-    PACKED_FLOAT const* __restrict packedSrcBuffer = reinterpret_cast<PACKED_FLOAT const*>(p.src[0]);
-    PACKED_FLOAT*       __restrict packedDstBuffer = reinterpret_cast<PACKED_FLOAT*      >(p.dst[0]);
+    // Collect data information
+    bool hasSrc = p.numSrcs > 0;
+    bool hasDst = p.numDsts > 0;
+    PACKED_FLOAT const* __restrict__ srcFloatPacked = (PACKED_FLOAT const*)p.src[0];
+    PACKED_FLOAT*       __restrict__ dstFloatPacked = (PACKED_FLOAT*)p.dst[0];
+
+    // Operate on wavefront granularity
+    int32_t const nTeams  = p.teamSize;             // Number of threadblocks working together on this subarray
+    int32_t const teamIdx = p.teamIdx;              // Index of this threadblock within the team
+    int32_t nWaves, waveIdx;
+    if (seType == 0) {
+      // Threadblock-level: all wavefronts in block work together
+      nWaves  = blockDim.x  / warpSize;              // Number of wavefronts within this threadblock
+      waveIdx = threadIdx.x / warpSize;              // Index of this wavefront within the threadblock
+    } else {
+      // Warp-level: each warp works independently
+      nWaves  = 1;
+      waveIdx = 0;
+    }
+    int32_t const tIdx = threadIdx.x % warpSize;     // Thread index within wavefront
+
+    size_t  const numPackedFloat = p.N / (sizeof(PACKED_FLOAT)/sizeof(float));
+
+    int32_t teamStride, waveStride, unrlStride, teamStride2, waveStride2;
+    switch (waveOrder) {
+    case 0: /* U,W,C */ unrlStride = 1; waveStride = UNROLL; teamStride = UNROLL * nWaves;  teamStride2 = nWaves; waveStride2 = 1     ; break;
+    case 1: /* U,C,W */ unrlStride = 1; teamStride = UNROLL; waveStride = UNROLL * nTeams;  teamStride2 = 1;      waveStride2 = nTeams; break;
+    case 2: /* W,U,C */ waveStride = 1; unrlStride = nWaves; teamStride = nWaves * UNROLL;  teamStride2 = nWaves; waveStride2 = 1     ; break;
+    case 3: /* W,C,U */ waveStride = 1; teamStride = nWaves; unrlStride = nWaves * nTeams;  teamStride2 = nWaves; waveStride2 = 1     ; break;
+    case 4: /* C,U,W */ teamStride = 1; unrlStride = nTeams; waveStride = nTeams * UNROLL;  teamStride2 = 1;      waveStride2 = nTeams; break;
+    case 5: /* C,W,U */ teamStride = 1; waveStride = nTeams; unrlStride = nTeams * nWaves;  teamStride2 = 1;      waveStride2 = nTeams; break;
+    }
 
     int subIterations = 0;
     while (1) {
-      // First loop: Each thread copies UNROLL number of PACKED_FLOATs
-      size_t const loop1Stride = UNROLL * blockDim.x;
+      // First loop: Each wavefront in the team works on UNROLL PACKED_FLOAT per thread
+      size_t const loop1Stride = nTeams * nWaves * UNROLL * warpSize;
       size_t const loop1Limit  = numPackedFloat / loop1Stride * loop1Stride;
       {
-        PACKED_FLOAT tmp[UNROLL];
-        for (size_t idx = threadIdx.x; idx < loop1Limit; idx += loop1Stride) {
+        PACKED_FLOAT val[UNROLL];
+        if (!hasSrc) {
           #pragma unroll
           for (int u = 0; u < UNROLL; u++)
-            Load<TEMPORAL_MODE>(&packedSrcBuffer[idx + u * blockDim.x], tmp[u]);
-
-          #pragma unroll
-          for (int u = 0; u < UNROLL; u++)
-            Store<TEMPORAL_MODE>(tmp[u], &packedDstBuffer[idx + u * blockDim.x]);
+            val[u] = MemsetVal<PACKED_FLOAT>();
         }
-      }
 
-      // Second loop: Each thread copies a PACKED_FLOAT
-      {
-        if (loop1Limit < numPackedFloat) {
-          PACKED_FLOAT tmp;
-          for (size_t idx = loop1Limit + threadIdx.x; idx < numPackedFloat; idx += blockDim.x) {
-            Load<TEMPORAL_MODE>(&packedSrcBuffer[idx], tmp);
-            Store<TEMPORAL_MODE>(tmp, &packedDstBuffer[idx]);
+        for (size_t idx = (teamIdx * teamStride + waveIdx * waveStride) * warpSize + tIdx; idx < loop1Limit; idx += loop1Stride) {
+          // Read sources into memory and accumulate in registers
+          if (hasSrc) {
+            #pragma unroll
+            for (int u = 0; u < UNROLL; u++)
+              Load<TEMPORAL_MODE>(&srcFloatPacked[idx + u * unrlStride * warpSize], val[u]);
+          }
+
+          // Write accumulation to all outputs
+          if (hasDst) {
+            #pragma unroll
+            for (int u = 0; u < UNROLL; u++)
+              Store<TEMPORAL_MODE>(val[u], &dstFloatPacked[idx + u * unrlStride * warpSize]);
           }
         }
       }
 
-      // Third loop; Deal with tailing floats
+      // Second loop: Deal with remaining PACKED_FLOAT
       {
-        size_t const tailFloatStart = numPackedFloat * (sizeof(PACKED_FLOAT)/sizeof(float));
-        if (tailFloatStart < p.N) {
-          float tmp;
-          for (size_t idx = tailFloatStart + threadIdx.x; idx < p.N; idx += blockDim.x) {
-            Load<TEMPORAL_MODE>(&p.src[0][idx], tmp);
-            Store<TEMPORAL_MODE>(tmp, &p.dst[0][idx]);
+        if (loop1Limit < numPackedFloat) {
+          PACKED_FLOAT val;
+          if (!hasSrc) val = MemsetVal<PACKED_FLOAT>();
+
+          size_t const loop2Stride = nTeams * nWaves * warpSize;
+          for (size_t idx = loop1Limit + (teamIdx * teamStride2 + waveIdx * waveStride2) * warpSize + tIdx;
+               idx < numPackedFloat; idx += loop2Stride) {
+            if (hasSrc) {
+              Load<TEMPORAL_MODE>(&srcFloatPacked[idx], val);
+            }
+            if (hasDst) {
+              Store<TEMPORAL_MODE>(val, &dstFloatPacked[idx]);
+            }
+          }
+        }
+      }
+
+      // Third loop; Deal with remaining floats
+      {
+        if (numPackedFloat * (sizeof(PACKED_FLOAT)/sizeof(float)) < p.N) {
+          float val;
+          if (!hasSrc) val = MemsetVal<float>();
+
+          size_t const loop3Stride = nTeams * nWaves * warpSize;
+          for (size_t idx = numPackedFloat * (sizeof(PACKED_FLOAT)/sizeof(float)) + (teamIdx * teamStride2 + waveIdx * waveStride2) * warpSize + tIdx; idx < p.N; idx += loop3Stride) {
+            if (hasSrc) {
+              Load<TEMPORAL_MODE>(&p.src[0][idx], val);
+            }
+
+            if (hasDst) {
+              Store<TEMPORAL_MODE>(val, &p.dst[0][idx]);
+            }
           }
         }
       }
@@ -4794,9 +4838,19 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
 
     // Wait for all threads to finish
-    __syncthreads();
+    if (seType == 1) {
+      // For warp-level, sync within warp only
+#if defined(__HIP_PLATFORM_AMD__) && (HIP_VERSION_MAJOR < 7)
+      __builtin_amdgcn_wave_barrier();
+#else
+      __syncwarp();
+#endif
+    } else {
+      // For threadblock-level, sync all threads
+      __syncthreads();
+    }
 
-    if (threadIdx.x == 0) {
+    if (shouldRecordTiming) {
       __threadfence_system();
       p.stopCycle  = GetTimestamp();
       p.startCycle = startCycle;
@@ -4964,12 +5018,12 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     // Wait for all threads to finish
     if (seType == 1) {
       // For warp-level, sync within warp only
- #if defined(__HIP_PLATFORM_AMD__) && (HIP_VERSION_MAJOR < 7)
+#if defined(__HIP_PLATFORM_AMD__) && (HIP_VERSION_MAJOR < 7)
       __builtin_amdgcn_wave_barrier();
- #else
+#else
 
       __syncwarp();
- #endif
+#endif
     } else {
       // For threadblock-level, sync all threads
       __syncthreads();
@@ -4984,17 +5038,40 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
   }
 
-#define GPU_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, DWORD)           \
-  {GpuReduceKernel<DWORD, LAUNCH_BOUND, UNROLL, TEMPORAL_NONE>,      \
-   GpuReduceKernel<DWORD, LAUNCH_BOUND, UNROLL, TEMPORAL_LOAD>,      \
-   GpuReduceKernel<DWORD, LAUNCH_BOUND, UNROLL, TEMPORAL_STORE>,     \
-   GpuReduceKernel<DWORD, LAUNCH_BOUND, UNROLL, TEMPORAL_BOTH>}
+  // Must match ordering in GfxKernelType
+#define GPU_KERNEL_KERNEL_DECL(LAUNCH_BOUND, UNROLL, DWORD, TEMPORAL) \
+  {GpuReduceKernel<DWORD, LAUNCH_BOUND, UNROLL, TEMPORAL>,            \
+   GpuCopyKernel  <DWORD, LAUNCH_BOUND, UNROLL, TEMPORAL>}
 
+  // Must match mapping in GetGpuKernelTemporalIdx
+#define GPU_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, DWORD)           \
+  {GPU_KERNEL_KERNEL_DECL(LAUNCH_BOUND, UNROLL, DWORD, TEMPORAL_NONE),  \
+   GPU_KERNEL_KERNEL_DECL(LAUNCH_BOUND, UNROLL, DWORD, TEMPORAL_LOAD),  \
+   GPU_KERNEL_KERNEL_DECL(LAUNCH_BOUND, UNROLL, DWORD, TEMPORAL_STORE), \
+   GPU_KERNEL_KERNEL_DECL(LAUNCH_BOUND, UNROLL, DWORD, TEMPORAL_BOTH)}
+
+  int GetGpuKernelTemporalIdx(int temporalMode) {
+    if (temporalMode == TEMPORAL_NONE)  return 0;
+    if (temporalMode == TEMPORAL_LOAD)  return 1;
+    if (temporalMode == TEMPORAL_STORE) return 2;
+    if (temporalMode == TEMPORAL_BOTH)  return 3;
+    return -1;
+  }
+
+  // Must match mapping in GetGpuKernelWordsizeIdx
 #define GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND, UNROLL)        \
   {GPU_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, float),  \
    GPU_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, float2), \
    GPU_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, float4)}
 
+  int GetGpuKernelWordsizeIdx(int wordsize) {
+    if (wordsize == 1) return 0;
+    if (wordsize == 2) return 1;
+    if (wordsize == 4) return 2;
+    return -1;
+  }
+
+  // Must match mapping in GetGpuKernelUnrollIdx
 #define GPU_KERNEL_UNROLL_DECL(LAUNCH_BOUND) \
   {GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND,  1),  \
    GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND,  2),  \
@@ -5004,19 +5081,21 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
    GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND,  6),  \
    GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND,  7),  \
    GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND,  8),  \
-   GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND,  9),  \
-   GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND, 10),  \
-   GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND, 11),  \
-   GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND, 12),  \
-   GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND, 13),  \
-   GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND, 14),  \
-   GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND, 15),  \
-   GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND, 16)}
+   GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND, 16),  \
+   GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND, 32)}
 
-  // Table of all GPU Reduction kernel functions (templated blocksize / unroll / dword size / temporal)
+  // Must match the unroll mapping in GPU_KERNEL_UNROLL_DECL
+  int GetGpuKernelUnrollIdx(int unroll) {
+    if (1 <= unroll && unroll <= 8) return unroll - 1;
+    if (unroll == 16)               return 8;
+    if (unroll == 32)               return 9;
+    return -1;
+  }
+
+  // Table of all GPU Reduction kernel functions (templated blocksize / unroll / dword size / temporal / kernel)
   typedef void (*GpuKernelFuncPtr)(SubExecParam*, int, int, int);
 #ifndef SINGLE_KERNEL
-  GpuKernelFuncPtr GpuKernelTable[4][MAX_UNROLL][3][4] =
+  GpuKernelFuncPtr GpuKernelsTable[4][10][3][4][2] =
   {
     GPU_KERNEL_UNROLL_DECL(256),
     GPU_KERNEL_UNROLL_DECL(512),
@@ -5029,128 +5108,82 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
   #undef GPU_KERNEL_DWORD_DECL
   #undef GPU_KERNEL_TEMPORAL_DECL
 
-#define GPU_COPY_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, DWORD)           \
-  {GpuCopyKernel<DWORD, LAUNCH_BOUND, UNROLL, TEMPORAL_NONE>,      \
-   GpuCopyKernel<DWORD, LAUNCH_BOUND, UNROLL, TEMPORAL_LOAD>,      \
-   GpuCopyKernel<DWORD, LAUNCH_BOUND, UNROLL, TEMPORAL_STORE>,     \
-   GpuCopyKernel<DWORD, LAUNCH_BOUND, UNROLL, TEMPORAL_BOTH>}
-
-#define GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, UNROLL)        \
-  {GPU_COPY_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, float),  \
-   GPU_COPY_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, float2), \
-   GPU_COPY_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, float4)}
-
-#define GPU_COPY_KERNEL_UNROLL_DECL(LAUNCH_BOUND) \
-  {GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  1),  \
-   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  2),  \
-   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  3),  \
-   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  4),  \
-   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  5),  \
-   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  6),  \
-   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  7),  \
-   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  8),  \
-   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  9),  \
-   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, 10),  \
-   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, 11),  \
-   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, 12),  \
-   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, 13),  \
-   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, 14),  \
-   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, 15),  \
-   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, 16)}
-
-  typedef void (*GpuCopyKernelFuncPtr)(SubExecParam*, int);
-#ifndef SINGLE_KERNEL
-  GpuCopyKernelFuncPtr GpuCopyKernelTable[4][MAX_UNROLL][3][4] =
-  {
-    GPU_COPY_KERNEL_UNROLL_DECL(256),
-    GPU_COPY_KERNEL_UNROLL_DECL(512),
-    GPU_COPY_KERNEL_UNROLL_DECL(768),
-    GPU_COPY_KERNEL_UNROLL_DECL(1024),
-  };
-#endif
-
-  #undef GPU_COPY_KERNEL_UNROLL_DECL
-  #undef GPU_COPY_KERNEL_DWORD_DECL
-  #undef GPU_COPY_KERNEL_TEMPORAL_DECL
+  int GetGpuKernelBlocksizeIdx(int blocksize) {
+    return (blocksize + 255) / 256 - 1;
+  }
 
   // Execute a single GPU Transfer (when using 1 stream per Transfer)
   static ErrResult ExecuteGpuTransfer(int           const  iteration,
+                                      int           const  exeTotalSubExecs,
+                                      SubExecParam*        exeSubExecParam,
                                       hipStream_t   const  stream,
                                       hipEvent_t    const  startEvent,
                                       hipEvent_t    const  stopEvent,
                                       int           const  xccDim,
                                       ConfigOptions const& cfg,
-                                      int           const  gfxKernelToUse,
+                                      int           const  gfxKernelIdx,
                                       TransferResources&   rss)
   {
+    // Determine which kernel to launch
+    int const blockSizeIdx = GetGpuKernelBlocksizeIdx(cfg.gfx.blockSize);
+    int const unrollIdx    = GetGpuKernelUnrollIdx(cfg.gfx.unrollFactor);
+    int const wordSizeIdx  = GetGpuKernelWordsizeIdx(cfg.gfx.wordSize);
+    int const temporalIdx  = GetGpuKernelTemporalIdx(cfg.gfx.temporalMode);
+
+#ifdef SINGLE_KERNEL
+    auto gpuKernel = GpuReduceKernel<float4, 1024, 1, 0>;
+#else
+    auto gpuKernel = GpuKernelsTable[blockSizeIdx][unrollIdx][wordSizeIdx][temporalIdx][gfxKernelIdx];
+#endif
+
+    // Compute kernel launch parameters
+    int  const numSubExecs = cfg.gfx.useMultiStream ? rss.subExecParamCpu.size() : exeTotalSubExecs;
+    int  const gridY = CalculateGridY(cfg.gfx.seType, cfg.gfx.blockSize, numSubExecs);
+    dim3 const gridSize(xccDim, gridY, 1);
+    dim3 const blockSize(cfg.gfx.blockSize);
+
     auto cpuStart = std::chrono::high_resolution_clock::now();
 
-    int numSubExecs = rss.subExecParamCpu.size();
-    int gridY = CalculateGridY(cfg.gfx.seType, cfg.gfx.blockSize, numSubExecs);
-    dim3 const gridSize(xccDim, gridY, 1);
-    dim3 const blockSize(cfg.gfx.blockSize, 1);
+    SubExecParam* params = cfg.gfx.useMultiStream ? rss.subExecParamGpuPtr : exeSubExecParam;
 
-    int const kernelTableBlockRow = (cfg.gfx.blockSize + 255) / 256 - 1;
-    int const unrollIdx = cfg.gfx.unrollFactor - 1;
-    int const wordSizeIdx = cfg.gfx.wordSize == 1 ? 0 :
-                            cfg.gfx.wordSize == 2 ? 1 :
-                                                    2;
-
-    if (gfxKernelToUse == GFX_KERNEL_REDUCE){
-#ifdef SINGLE_KERNEL
-      auto gpuKernel = GpuReduceKernel<float4, 1024, 1, 0>;
-#else
-      auto gpuKernel = GpuKernelTable[kernelTableBlockRow][unrollIdx][wordSizeIdx][cfg.gfx.temporalMode];
-#endif
 #if defined(__NVCC__)
-      if (startEvent != NULL)
-        ERR_CHECK(hipEventRecord(startEvent, stream));
-      gpuKernel<<<gridSize, blockSize, 0, stream>>>(rss.subExecParamGpuPtr, cfg.gfx.seType, cfg.gfx.waveOrder, cfg.general.numSubIterations);
-      if (stopEvent != NULL)
-        ERR_CHECK(hipEventRecord(stopEvent, stream));
+    if (cfg.gfx.useHipEvents)
+      ERR_CHECK(hipEventRecord(startEvent, stream));
+    gpuKernel<<<gridSize, blockSize, 0 , stream>>>(params, cfg.gfx.seType, cfg.gfx.waveOrder, cfg.general.numSubIterations);
+    if (cfg.gfx.useHipEvents)
+      ERR_CHECK(hipEventRecord(stopEvent, stream));
 #else
-      hipExtLaunchKernelGGL(gpuKernel, gridSize, blockSize, 0, stream, startEvent, stopEvent,
-                            0, rss.subExecParamGpuPtr, cfg.gfx.seType, cfg.gfx.waveOrder, cfg.general.numSubIterations);
+    hipExtLaunchKernelGGL(gpuKernel, gridSize, blockSize, 0, stream,
+                          cfg.gfx.useHipEvents ? startEvent : NULL,
+                          cfg.gfx.useHipEvents ? stopEvent  : NULL, 0,
+                          params, cfg.gfx.seType, cfg.gfx.waveOrder, cfg.general.numSubIterations);
 #endif
-    } else if (gfxKernelToUse == GFX_KERNEL_COPY) {
-#ifdef SINGLE_KERNEL
-      auto copyKernel = GpuCopyKernel<float4, 1024, 1, 0>;
-#else
-      auto copyKernel = GpuCopyKernelTable[kernelTableBlockRow][unrollIdx][wordSizeIdx][cfg.gfx.temporalMode];
-#endif
-#if defined(__NVCC__)
-      if (startEvent != NULL)
-        ERR_CHECK(hipEventRecord(startEvent, stream));
-      copyKernel<<<gridSize, blockSize, 0, stream>>>(rss.subExecParamGpuPtr, cfg.general.numSubIterations);
-      if (stopEvent != NULL)
-        ERR_CHECK(hipEventRecord(stopEvent, stream));
-#else
-      hipExtLaunchKernelGGL(copyKernel, gridSize, blockSize, 0, stream, startEvent, stopEvent,
-                            0, rss.subExecParamGpuPtr, cfg.general.numSubIterations);
-#endif
-    }
 
     ERR_CHECK(hipStreamSynchronize(stream));
 
-    auto cpuDelta = std::chrono::high_resolution_clock::now() - cpuStart;
-    double cpuDeltaMsec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() * 1000.0 / cfg.general.numSubIterations;
+    // Record this timing if this Transfer is being run in multistream mode
+    if (cfg.gfx.useMultiStream) {
+      if (iteration >= 0) {
+        auto cpuDelta = std::chrono::high_resolution_clock::now() - cpuStart;
+        double cpuDeltaMsec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() * 1000.0 / cfg.general.numSubIterations;
 
-    if (iteration >= 0) {
-      double deltaMsec = cpuDeltaMsec;
-      if (startEvent != NULL) {
-        float gpuDeltaMsec;
-        ERR_CHECK(hipEventElapsedTime(&gpuDeltaMsec, startEvent, stopEvent));
-        deltaMsec = gpuDeltaMsec / cfg.general.numSubIterations;
-      }
-      rss.totalDurationMsec += deltaMsec;
-      if (cfg.general.recordPerIteration) {
-        rss.perIterMsec.push_back(deltaMsec);
-        std::set<std::pair<int,int>> CUs;
-        for (int i = 0; i < numSubExecs; i++) {
-          CUs.insert(std::make_pair(rss.subExecParamGpuPtr[i].xccId,
-                                    GetId(rss.subExecParamGpuPtr[i].hwId)));
+        double deltaMsec = cpuDeltaMsec;
+        if (startEvent != NULL) {
+          float gpuDeltaMsec;
+          ERR_CHECK(hipEventElapsedTime(&gpuDeltaMsec, startEvent, stopEvent));
+          deltaMsec = gpuDeltaMsec / cfg.general.numSubIterations;
         }
-        rss.perIterCUs.push_back(CUs);
+
+        rss.totalDurationMsec += deltaMsec;
+        if (cfg.general.recordPerIteration) {
+          rss.perIterMsec.push_back(deltaMsec);
+          std::set<std::pair<int,int>> CUs;
+          for (int i = 0; i < numSubExecs; i++) {
+            CUs.insert(std::make_pair(rss.subExecParamGpuPtr[i].xccId,
+                                      GetId(rss.subExecParamGpuPtr[i].hwId)));
+          }
+          rss.perIterCUs.push_back(CUs);
+        }
       }
     }
     return ERR_NONE;
@@ -5167,89 +5200,42 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 
     int xccDim = exeInfo.useSubIndices ? exeInfo.numSubIndices : 1;
 
-    if (cfg.gfx.useMultiStream) {
-      // Launch each Transfer separately in its own stream
-      vector<std::future<ErrResult>> asyncTransfers;
-      for (int i = 0; i < exeInfo.streams.size(); i++) {
-        asyncTransfers.emplace_back(std::async(std::launch::async,
-                                               ExecuteGpuTransfer,
-                                               iteration,
-                                               exeInfo.streams[i],
-                                               cfg.gfx.useHipEvents ? exeInfo.startEvents[i] : NULL,
-                                               cfg.gfx.useHipEvents ? exeInfo.stopEvents[i] : NULL,
-                                               xccDim,
-                                               std::cref(cfg),
-                                               exeInfo.gfxKernelToUse,
-                                               std::ref(exeInfo.resources[i])));
-      }
-      for (auto& asyncTransfer : asyncTransfers)
-        ERR_CHECK(asyncTransfer.get());
-    } else {
-      // Combine all the Transfers into a single kernel launch
-      int numSubExecs = exeInfo.totalSubExecs;
-      int gridY = CalculateGridY(cfg.gfx.seType, cfg.gfx.blockSize, numSubExecs);
-      dim3 const gridSize(xccDim, gridY, 1);
-      dim3 const blockSize(cfg.gfx.blockSize, 1);
-      hipStream_t stream = exeInfo.streams[0];
-
-      int const kernelTableBlockRow = (cfg.gfx.blockSize + 255) / 256 - 1;
-      int const unrollIdx = cfg.gfx.unrollFactor - 1;
-      int const wordSizeIdx = cfg.gfx.wordSize == 1 ? 0 :
-                              cfg.gfx.wordSize == 2 ? 1 :
-                                                      2;
-      if (exeInfo.gfxKernelToUse == GFX_KERNEL_REDUCE) {
-#ifdef SINGLE_KERNEL
-        auto gpuKernel = GpuReduceKernel<float4, 1024, 1, 0>;
-#else
-        auto gpuKernel = GpuKernelTable[kernelTableBlockRow][unrollIdx][wordSizeIdx][cfg.gfx.temporalMode];
-#endif
-#if defined(__NVCC__)
-        if (cfg.gfx.useHipEvents)
-          ERR_CHECK(hipEventRecord(exeInfo.startEvents[0], stream));
-        gpuKernel<<<gridSize, blockSize, 0 , stream>>>(exeInfo.subExecParamGpu, cfg.gfx.seType, cfg.gfx.waveOrder, cfg.general.numSubIterations);
-        if (cfg.gfx.useHipEvents)
-          ERR_CHECK(hipEventRecord(exeInfo.stopEvents[0], stream));
-#else
-        hipExtLaunchKernelGGL(gpuKernel, gridSize, blockSize, 0, stream,
-                              cfg.gfx.useHipEvents ? exeInfo.startEvents[0] : NULL,
-                              cfg.gfx.useHipEvents ? exeInfo.stopEvents[0] : NULL, 0,
-                              exeInfo.subExecParamGpu, cfg.gfx.seType, cfg.gfx.waveOrder, cfg.general.numSubIterations);
-#endif
-      } else if (exeInfo.gfxKernelToUse == GFX_KERNEL_COPY) {
-#ifdef SINGLE_KERNEL
-        auto copyKernel = GpuCopyKernel<float4, 1024, 1, 0>;
-#else
-        auto copyKernel = GpuCopyKernelTable[kernelTableBlockRow][unrollIdx][wordSizeIdx][cfg.gfx.temporalMode];
-#endif
-#if defined(__NVCC__)
-        if (cfg.gfx.useHipEvents)
-          ERR_CHECK(hipEventRecord(exeInfo.startEvents[0], stream));
-        copyKernel<<<gridSize, blockSize, 0, stream>>>(exeInfo.subExecParamGpu, cfg.general.numSubIterations);
-        if (cfg.gfx.useHipEvents)
-          ERR_CHECK(hipEventRecord(exeInfo.stopEvents[0], stream));
-#else
-        hipExtLaunchKernelGGL(copyKernel, gridSize, blockSize, 0, stream,
-                              cfg.gfx.useHipEvents ? exeInfo.startEvents[0] : NULL,
-                              cfg.gfx.useHipEvents ? exeInfo.stopEvents[0] : NULL, 0,
-                              exeInfo.subExecParamGpu, cfg.general.numSubIterations);
-#endif
-      }
-      ERR_CHECK(hipStreamSynchronize(stream));
+    vector<std::future<ErrResult>> asyncTransfers;
+    for (int i = 0; i < exeInfo.streams.size(); i++) {
+      asyncTransfers.emplace_back(std::async(std::launch::async,
+                                             ExecuteGpuTransfer,
+                                             iteration,
+                                             exeInfo.totalSubExecs,
+                                             exeInfo.subExecParamGpu,
+                                             exeInfo.streams[i],
+                                             cfg.gfx.useHipEvents ? exeInfo.startEvents[i] : NULL,
+                                             cfg.gfx.useHipEvents ? exeInfo.stopEvents[i] : NULL,
+                                             xccDim,
+                                             std::cref(cfg),
+                                             exeInfo.gfxKernelToUse,
+                                             std::ref(exeInfo.resources[i])));
     }
+    for (auto& asyncTransfer : asyncTransfers)
+      ERR_CHECK(asyncTransfer.get());
+
     auto cpuDelta = std::chrono::high_resolution_clock::now() - cpuStart;
-    double cpuDeltaMsec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() * 1000.0
-      / cfg.general.numSubIterations;
 
     if (iteration >= 0) {
+      // Determine executor timing
+      // - Use HIP event timing if enabled and not using multi-stream
+      // - Otherwise, Use CPU timing
       if (cfg.gfx.useHipEvents && !cfg.gfx.useMultiStream) {
         float gpuDeltaMsec;
         ERR_CHECK(hipEventElapsedTime(&gpuDeltaMsec, exeInfo.startEvents[0], exeInfo.stopEvents[0]));
         gpuDeltaMsec /= cfg.general.numSubIterations;
         exeInfo.totalDurationMsec += gpuDeltaMsec;
       } else {
+        double cpuDeltaMsec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() * 1000.0
+          / cfg.general.numSubIterations;
         exeInfo.totalDurationMsec += cpuDeltaMsec;
       }
 
+      // If Transfers were combined into a single launch, figure out per-Transfer timing
       // Determine timing for each of the individual transfers that were part of this launch
       if (!cfg.gfx.useMultiStream) {
         for (int i = 0; i < exeInfo.resources.size(); i++) {
@@ -5657,6 +5643,11 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       if (exeDevice.exeRank == localRank) {
         localExecutors.push_back(exeDevice);
       }
+
+      // Select which GFX kernel to use for this executor
+      if (exeDevice.exeType == EXE_GPU_GFX) {
+        ERR_APPEND(SelectGfxKernel(cfg, transfers, exeInfo), errResults);
+      }
     }
 
     // Prepare reference src/dst arrays - only once for largest size
@@ -5859,15 +5850,6 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       if (err.errType == ERR_FATAL) return false;
     }
     return true;
-  }
-
-  int GetIntAttribute(IntAttribute attribute)
-  {
-    switch (attribute) {
-    case ATR_GFX_MAX_BLOCKSIZE: return MAX_BLOCKSIZE;
-    case ATR_GFX_MAX_UNROLL:    return MAX_UNROLL;
-    default:                    return -1;
-    }
   }
 
   std::string GetStrAttribute(StrAttribute attribute)

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -5042,6 +5042,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
    GpuCopyKernel  <DWORD, LAUNCH_BOUND, UNROLL, TEMPORAL>}
 
   // Must match mapping in GetGpuKernelTemporalIdx
+  constexpr int KERN_TEMPORALS = 4;
 #define GPU_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, DWORD)           \
   {GPU_KERNEL_KERNEL_DECL(LAUNCH_BOUND, UNROLL, DWORD, TEMPORAL_NONE),  \
    GPU_KERNEL_KERNEL_DECL(LAUNCH_BOUND, UNROLL, DWORD, TEMPORAL_LOAD),  \
@@ -5057,6 +5058,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
   }
 
   // Must match mapping in GetGpuKernelWordsizeIdx
+  constexpr int KERN_WORDSIZES = 3;
 #define GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND, UNROLL)        \
   {GPU_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, float),  \
    GPU_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, float2), \
@@ -5070,6 +5072,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
   }
 
   // Must match mapping in GetGpuKernelUnrollIdx
+  constexpr int KERN_UNROLLS = 10;
 #define GPU_KERNEL_UNROLL_DECL(LAUNCH_BOUND) \
   {GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND,  1),  \
    GPU_KERNEL_DWORD_DECL(LAUNCH_BOUND,  2),  \
@@ -5092,8 +5095,9 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 
   // Table of all GPU Reduction kernel functions (templated blocksize / unroll / dword size / temporal / kernel)
   typedef void (*GpuKernelFuncPtr)(SubExecParam*, int, int, int);
+  constexpr int KERN_BOUNDS = 4;
 #ifndef SINGLE_KERNEL
-  GpuKernelFuncPtr GpuKernelsTable[4][10][3][4][2] =
+  GpuKernelFuncPtr GpuKernelsTable[KERN_BOUNDS][KERN_UNROLLS][KERN_WORDSIZES][KERN_TEMPORALS][NUM_GFX_KERNELS] =
   {
     GPU_KERNEL_UNROLL_DECL(256),
     GPU_KERNEL_UNROLL_DECL(512),

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -153,6 +153,16 @@ namespace TransferBench
   inline bool IsGpuMemType(MemType m) { return (MEM_GPU <= m && m <= MEM_MANAGED);}
 
   /**
+   * Enumeration of supported GFX kernels
+   */
+  enum GfxKernelType
+  {
+    GFX_KERNEL_REDUCE = 0,                     ///< Default kernel that supports any multiple input/output buffers
+    GFX_KERNEL_COPY   = 1,                     ///< Simpler kernel that supports copies only
+    NUM_GFX_KERNELS   = 2                      ///< Number of GFX kernels currently supported
+  };
+
+  /**
    * A MemDevice indicates a memory type on a specific device
    */
   struct MemDevice
@@ -221,6 +231,7 @@ namespace TransferBench
     int                 blockOrder     = 0;     ///< Determines how threadblocks are ordered (0=sequential, 1=interleaved, 2=random)
     int                 blockSize      = 256;   ///< Size of each threadblock (must be multiple of 64)
     vector<uint32_t>    cuMask         = {};    ///< Bit-vector representing the CU mask
+    int                 gfxKernel      = -1;    ///< Kernel selector: -1=auto, 0=reduce, 1=copy-only
     vector<vector<int>> prefXccTable   = {};    ///< 2D table with preferred XCD to use for a specific [src][dst] GPU device
     int                 seType         = 0;     ///< SubExecutor granularity type (0=threadblock, 1=warp)
     int                 temporalMode   = 0;     ///< Non-temporal load/store mode 0=none, 1=load, 2=store, 3=both
@@ -665,9 +676,9 @@ namespace TransferBench
   #define hipStreamCreate                                    cudaStreamCreate
   #define hipStreamDestroy                                   cudaStreamDestroy
   #define hipStreamSynchronize                               cudaStreamSynchronize
-  #define hipMemGetAllocationGranularity                     cuMemGetAllocationGranularity
-  #define hipMemCreate                                       cuMemCreate
   // cu* driver API returns CUresult; cast to cudaError_t so callers can use a single error variable
+   #define hipMemGetAllocationGranularity(...)               ((cudaError_t)(cuMemGetAllocationGranularity(__VA_ARGS__))
+  #define hipMemCreate(...)                                  ((cudaError_t)(cuMemCreate(__VA_ARGS__))
   #define hipMemAddressReserve(...)                          ((cudaError_t)cuMemAddressReserve(__VA_ARGS__))
   #define hipMemMap(...)                                     ((cudaError_t)cuMemMap(__VA_ARGS__))
   #define hipMemSetAccess(...)                               ((cudaError_t)cuMemSetAccess(__VA_ARGS__))
@@ -1874,7 +1885,6 @@ namespace {
       System::Get().Broadcast(root, sizeof(data), &data);
 
       // data.alwaysValidate is permitted to be different across ranks
-
       if (data.blockBytes != cfg.data.blockBytes) ADD_ERROR("cfg.data.blockBytes");
       if (data.byteOffset != cfg.data.byteOffset) ADD_ERROR("cfg.data.byteOffset");
 
@@ -1915,14 +1925,14 @@ namespace {
     // Compare GFX Executor options
     {
       GfxOptions gfx = cfg.gfx;
-      // Same as above: null out vector members before sizeof-broadcast
-      // both fields are permitted to differ across ranks
+      // Null out vector members before sizeof broadcast
       decltype(gfx.cuMask)().swap(gfx.cuMask);
       decltype(gfx.prefXccTable)().swap(gfx.prefXccTable);
       System::Get().Broadcast(root, sizeof(gfx), &gfx);
       if (gfx.blockOrder     != cfg.gfx.blockOrder)     ADD_ERROR("cfg.gfx.blockOrder");
       if (gfx.blockSize      != cfg.gfx.blockSize)      ADD_ERROR("cfg.gfx.blockSize");
       // gfx.cuMask       is permitted to be different across ranks
+      if (gfx.gfxKernel      != cfg.gfx.gfxKernel)      ADD_ERROR("cfg.gfx.gfxKernel");
       // gfx.perfXccTable is permitted to be different across ranks
       if (gfx.seType         != cfg.gfx.seType)         ADD_ERROR("cfg.gfx.seType");
       if (gfx.temporalMode   != cfg.gfx.temporalMode)   ADD_ERROR("cfg.gfx.temporalMode");
@@ -2027,6 +2037,9 @@ namespace {
 
     if (!(cfg.gfx.wordSize == 1 || cfg.gfx.wordSize == 2 || cfg.gfx.wordSize == 4))
       errors.push_back({ERR_FATAL, "[gfx.wordSize] must be either 1, 2 or 4"});
+    if (cfg.gfx.gfxKernel < -1 || cfg.gfx.gfxKernel > NUM_GFX_KERNELS)
+      errors.push_back(
+        {ERR_FATAL, "[gfx.gfxKernel] must be -1 for auto, or less than %d", NUM_GFX_KERNELS});
 
     int numGpus = GetNumExecutors(EXE_GPU_GFX);
     int numXccs = GetNumExecutorSubIndices({EXE_GPU_GFX, 0});
@@ -2720,6 +2733,10 @@ namespace {
     vector<set<pair<int,int>>> perIterCUs;        ///< GFX-Executor only. XCC:CU used per iteration
   };
 
+
+
+
+
   // Internal resources allocated per Executor
   struct ExeInfo
   {
@@ -2737,6 +2754,7 @@ namespace {
     vector<hipEvent_t>         startEvents;       ///< HIP start timing event
     vector<hipEvent_t>         stopEvents;        ///< HIP stop timing event
     int                        wallClockRate;     ///< (GFX-only) Device wall clock rate
+    int                        gfxKernelToUse;    ///< (GFX-only) Which GFX kernel to use
   };
 
   // Structure to track PCIe topology
@@ -3845,6 +3863,48 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     return ERR_NONE;
   }
 
+  // Determine eligibility requirements for a particular GFX kernel
+  static bool CanUseGfxKernel(int const                gpuKernelIdx,
+                              ConfigOptions const&     cfg,
+                              vector<Transfer> const&  transfers,
+                              ExeInfo const&           exeInfo)
+  {
+    // GpuReducKernel always works
+    if (gpuKernelIdx == GFX_KERNEL_REDUCE) return true;
+
+    // CopyKernel only works if all Transfers are single SRC / single DST copies, with no warp subexecutors
+    if (gpuKernelIdx == GFX_KERNEL_COPY) {
+      if (cfg.gfx.seType != 0) return false;
+      if (exeInfo.resources.empty()) return false;
+      for (auto const& rss : exeInfo.resources) {
+        Transfer const& t = transfers[rss.transferIdx];
+        if (t.srcs.size() != 1 || t.dsts.size() != 1) return false;
+        if (cfg.gfx.useSingleTeam && t.numSubExecs > 1) return false;
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  static ErrResult SelectGfxKernel(ConfigOptions const& cfg, vector<Transfer> const& transfers, ExeInfo& exeInfo)
+  {
+    // Decide on which GFX kernel to use
+    // Auto-select - prefer copyKernel if eligible
+    if (cfg.gfx.gfxKernel == -1) {
+      exeInfo.gfxKernelToUse = CanUseGfxKernel(GFX_KERNEL_COPY, cfg, transfers, exeInfo) ? 1 : 0;
+    } else {
+      exeInfo.gfxKernelToUse = cfg.gfx.gfxKernel;
+    }
+
+    // Warn if using forcing copy kernel
+    if (exeInfo.gfxKernelToUse == GFX_KERNEL_COPY && !CanUseGfxKernel(GFX_KERNEL_COPY, cfg, transfers, exeInfo)) {
+      return {ERR_WARN,
+        "GFX copy kernel forced even though deemed incompatible for current set of Transfers / config"};
+    }
+    return ERR_NONE;
+  }
+
 // Preparation-related functions
 //========================================================================================
 
@@ -4115,6 +4175,11 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 
       // Prepare subexecutor parameters (on all ranks)
       ERR_CHECK(PrepareSubExecParams(cfg, t, rss));
+    }
+
+    // Select which GFX kernel to use for this executor
+    if (exeDevice.exeType == EXE_GPU_GFX) {
+      ERR_CHECK(SelectGfxKernel(cfg, transfers, exeInfo));
     }
 
     // Prepare additional requirements for GPU-based executors
@@ -4662,6 +4727,84 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
   }
 
+  // Simplified Kernel for GFX execution for copies only
+  template <typename PACKED_FLOAT, int LAUNCH_BOUND, int UNROLL, int TEMPORAL_MODE>
+  __global__ __launch_bounds__(LAUNCH_BOUND)
+    void GpuCopyKernel(SubExecParam* params, int numSubIterations)
+  {
+    // Capture GPU wall-clock timestamp
+    int64_t startCycle;
+    if (threadIdx.x == 0) startCycle = GetTimestamp();
+    SubExecParam& p = params[blockIdx.y];
+
+    // Filter by XCC
+#if !defined(__NVCC__)
+    int32_t xccId;
+    GetXccId(xccId);
+    if (p.preferredXccId != -1 && xccId != p.preferredXccId) return;
+#endif
+
+    // Cast src/dst buffers to the packed float type
+    size_t const numPackedFloat = p.N / (sizeof(PACKED_FLOAT)/sizeof(float));
+    PACKED_FLOAT const* __restrict packedSrcBuffer = reinterpret_cast<PACKED_FLOAT const*>(p.src[0]);
+    PACKED_FLOAT*       __restrict packedDstBuffer = reinterpret_cast<PACKED_FLOAT*      >(p.dst[0]);
+
+    int subIterations = 0;
+    while (1) {
+      // First loop: Each thread copies UNROLL number of PACKED_FLOATs
+      size_t const loop1Stride = UNROLL * blockDim.x;
+      size_t const loop1Limit  = numPackedFloat / loop1Stride * loop1Stride;
+      {
+        PACKED_FLOAT tmp[UNROLL];
+        for (size_t idx = threadIdx.x; idx < loop1Limit; idx += loop1Stride) {
+          #pragma unroll
+          for (int u = 0; u < UNROLL; u++)
+            Load<TEMPORAL_MODE>(&packedSrcBuffer[idx + u * blockDim.x], tmp[u]);
+
+          #pragma unroll
+          for (int u = 0; u < UNROLL; u++)
+            Store<TEMPORAL_MODE>(tmp[u], &packedDstBuffer[idx + u * blockDim.x]);
+        }
+      }
+
+      // Second loop: Each thread copies a PACKED_FLOAT
+      {
+        if (loop1Limit < numPackedFloat) {
+          PACKED_FLOAT tmp;
+          for (size_t idx = loop1Limit + threadIdx.x; idx < numPackedFloat; idx += blockDim.x) {
+            Load<TEMPORAL_MODE>(&packedSrcBuffer[idx], tmp);
+            Store<TEMPORAL_MODE>(tmp, &packedDstBuffer[idx]);
+          }
+        }
+      }
+
+      // Third loop; Deal with tailing floats
+      {
+        size_t const tailFloatStart = numPackedFloat * (sizeof(PACKED_FLOAT)/sizeof(float));
+        if (tailFloatStart < p.N) {
+          float tmp;
+          for (size_t idx = tailFloatStart + threadIdx.x; idx < p.N; idx += blockDim.x) {
+            Load<TEMPORAL_MODE>(&p.src[0][idx], tmp);
+            Store<TEMPORAL_MODE>(tmp, &p.dst[0][idx]);
+          }
+        }
+      }
+      // Allows for numSubiterations == 0 to run infinitely
+      if (++subIterations == numSubIterations) break;
+    }
+
+    // Wait for all threads to finish
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+      __threadfence_system();
+      p.stopCycle  = GetTimestamp();
+      p.startCycle = startCycle;
+      GetHwId(p.hwId);
+      GetXccId(p.xccId);
+    }
+  }
+
   // Kernel for GFX execution
   template <typename PACKED_FLOAT, int LAUNCH_BOUND, int UNROLL, int TEMPORAL_MODE>
   __global__ void __launch_bounds__(LAUNCH_BOUND)
@@ -4814,7 +4957,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
           }
         }
       }
-
+      // Allows for numSubiterations == 0 to run infinitely
       if (++subIterations == numSubIterations) break;
     }
 
@@ -4886,6 +5029,50 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
   #undef GPU_KERNEL_DWORD_DECL
   #undef GPU_KERNEL_TEMPORAL_DECL
 
+#define GPU_COPY_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, DWORD)           \
+  {GpuCopyKernel<DWORD, LAUNCH_BOUND, UNROLL, TEMPORAL_NONE>,      \
+   GpuCopyKernel<DWORD, LAUNCH_BOUND, UNROLL, TEMPORAL_LOAD>,      \
+   GpuCopyKernel<DWORD, LAUNCH_BOUND, UNROLL, TEMPORAL_STORE>,     \
+   GpuCopyKernel<DWORD, LAUNCH_BOUND, UNROLL, TEMPORAL_BOTH>}
+
+#define GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, UNROLL)        \
+  {GPU_COPY_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, float),  \
+   GPU_COPY_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, float2), \
+   GPU_COPY_KERNEL_TEMPORAL_DECL(LAUNCH_BOUND, UNROLL, float4)}
+
+#define GPU_COPY_KERNEL_UNROLL_DECL(LAUNCH_BOUND) \
+  {GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  1),  \
+   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  2),  \
+   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  3),  \
+   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  4),  \
+   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  5),  \
+   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  6),  \
+   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  7),  \
+   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  8),  \
+   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND,  9),  \
+   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, 10),  \
+   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, 11),  \
+   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, 12),  \
+   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, 13),  \
+   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, 14),  \
+   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, 15),  \
+   GPU_COPY_KERNEL_DWORD_DECL(LAUNCH_BOUND, 16)}
+
+  typedef void (*GpuCopyKernelFuncPtr)(SubExecParam*, int);
+#ifndef SINGLE_KERNEL
+  GpuCopyKernelFuncPtr GpuCopyKernelTable[4][MAX_UNROLL][3][4] =
+  {
+    GPU_COPY_KERNEL_UNROLL_DECL(256),
+    GPU_COPY_KERNEL_UNROLL_DECL(512),
+    GPU_COPY_KERNEL_UNROLL_DECL(768),
+    GPU_COPY_KERNEL_UNROLL_DECL(1024),
+  };
+#endif
+
+  #undef GPU_COPY_KERNEL_UNROLL_DECL
+  #undef GPU_COPY_KERNEL_DWORD_DECL
+  #undef GPU_COPY_KERNEL_TEMPORAL_DECL
+
   // Execute a single GPU Transfer (when using 1 stream per Transfer)
   static ErrResult ExecuteGpuTransfer(int           const  iteration,
                                       hipStream_t   const  stream,
@@ -4893,6 +5080,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
                                       hipEvent_t    const  stopEvent,
                                       int           const  xccDim,
                                       ConfigOptions const& cfg,
+                                      int           const  gfxKernelToUse,
                                       TransferResources&   rss)
   {
     auto cpuStart = std::chrono::high_resolution_clock::now();
@@ -4902,25 +5090,45 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     dim3 const gridSize(xccDim, gridY, 1);
     dim3 const blockSize(cfg.gfx.blockSize, 1);
 
-    int wordSizeIdx = cfg.gfx.wordSize == 1 ? 0 :
-                      cfg.gfx.wordSize == 2 ? 1 :
-                                              2;
-#ifdef SINGLE_KERNEL
-    auto gpuKernel = GpuReduceKernel<float4, 256, 1, 0>;
-#else
-    auto gpuKernel = GpuKernelTable[(cfg.gfx.blockSize+255)/256 - 1][cfg.gfx.unrollFactor - 1][wordSizeIdx][cfg.gfx.temporalMode];
-#endif
+    int const kernelTableBlockRow = (cfg.gfx.blockSize + 255) / 256 - 1;
+    int const unrollIdx = cfg.gfx.unrollFactor - 1;
+    int const wordSizeIdx = cfg.gfx.wordSize == 1 ? 0 :
+                            cfg.gfx.wordSize == 2 ? 1 :
+                                                    2;
 
-#if defined(__NVCC__)
-    if (startEvent != NULL)
-      ERR_CHECK(hipEventRecord(startEvent, stream));
-    gpuKernel<<<gridSize, blockSize, 0, stream>>>(rss.subExecParamGpuPtr, cfg.gfx.seType, cfg.gfx.waveOrder, cfg.general.numSubIterations);
-    if (stopEvent != NULL)
-      ERR_CHECK(hipEventRecord(stopEvent, stream));
+    if (gfxKernelToUse == GFX_KERNEL_REDUCE){
+#ifdef SINGLE_KERNEL
+      auto gpuKernel = GpuReduceKernel<float4, 1024, 1, 0>;
 #else
-    hipExtLaunchKernelGGL(gpuKernel, gridSize, blockSize, 0, stream, startEvent, stopEvent,
-                          0, rss.subExecParamGpuPtr, cfg.gfx.seType, cfg.gfx.waveOrder, cfg.general.numSubIterations);
+      auto gpuKernel = GpuKernelTable[kernelTableBlockRow][unrollIdx][wordSizeIdx][cfg.gfx.temporalMode];
 #endif
+#if defined(__NVCC__)
+      if (startEvent != NULL)
+        ERR_CHECK(hipEventRecord(startEvent, stream));
+      gpuKernel<<<gridSize, blockSize, 0, stream>>>(rss.subExecParamGpuPtr, cfg.gfx.seType, cfg.gfx.waveOrder, cfg.general.numSubIterations);
+      if (stopEvent != NULL)
+        ERR_CHECK(hipEventRecord(stopEvent, stream));
+#else
+      hipExtLaunchKernelGGL(gpuKernel, gridSize, blockSize, 0, stream, startEvent, stopEvent,
+                            0, rss.subExecParamGpuPtr, cfg.gfx.seType, cfg.gfx.waveOrder, cfg.general.numSubIterations);
+#endif
+    } else if (gfxKernelToUse == GFX_KERNEL_COPY) {
+#ifdef SINGLE_KERNEL
+      auto copyKernel = GpuCopyKernel<float4, 1024, 1, 0>;
+#else
+      auto copyKernel = GpuCopyKernelTable[kernelTableBlockRow][unrollIdx][wordSizeIdx][cfg.gfx.temporalMode];
+#endif
+#if defined(__NVCC__)
+      if (startEvent != NULL)
+        ERR_CHECK(hipEventRecord(startEvent, stream));
+      copyKernel<<<gridSize, blockSize, 0, stream>>>(rss.subExecParamGpuPtr, cfg.general.numSubIterations);
+      if (stopEvent != NULL)
+        ERR_CHECK(hipEventRecord(stopEvent, stream));
+#else
+      hipExtLaunchKernelGGL(copyKernel, gridSize, blockSize, 0, stream, startEvent, stopEvent,
+                            0, rss.subExecParamGpuPtr, cfg.general.numSubIterations);
+#endif
+    }
 
     ERR_CHECK(hipStreamSynchronize(stream));
 
@@ -4971,6 +5179,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
                                                cfg.gfx.useHipEvents ? exeInfo.stopEvents[i] : NULL,
                                                xccDim,
                                                std::cref(cfg),
+                                               exeInfo.gfxKernelToUse,
                                                std::ref(exeInfo.resources[i])));
       }
       for (auto& asyncTransfer : asyncTransfers)
@@ -4983,27 +5192,48 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       dim3 const blockSize(cfg.gfx.blockSize, 1);
       hipStream_t stream = exeInfo.streams[0];
 
-      int wordSizeIdx = cfg.gfx.wordSize == 1 ? 0 :
-                        cfg.gfx.wordSize == 2 ? 1 :
-                                                2;
+      int const kernelTableBlockRow = (cfg.gfx.blockSize + 255) / 256 - 1;
+      int const unrollIdx = cfg.gfx.unrollFactor - 1;
+      int const wordSizeIdx = cfg.gfx.wordSize == 1 ? 0 :
+                              cfg.gfx.wordSize == 2 ? 1 :
+                                                      2;
+      if (exeInfo.gfxKernelToUse == GFX_KERNEL_REDUCE) {
 #ifdef SINGLE_KERNEL
-      auto gpuKernel = GpuReduceKernel<float4, 256, 1, 0>;
+        auto gpuKernel = GpuReduceKernel<float4, 1024, 1, 0>;
 #else
-      auto gpuKernel = GpuKernelTable[(cfg.gfx.blockSize+255)/256 - 1][cfg.gfx.unrollFactor - 1][wordSizeIdx][cfg.gfx.temporalMode];
+        auto gpuKernel = GpuKernelTable[kernelTableBlockRow][unrollIdx][wordSizeIdx][cfg.gfx.temporalMode];
 #endif
-
 #if defined(__NVCC__)
-      if (cfg.gfx.useHipEvents)
-        ERR_CHECK(hipEventRecord(exeInfo.startEvents[0], stream));
-      gpuKernel<<<gridSize, blockSize, 0 , stream>>>(exeInfo.subExecParamGpu, cfg.gfx.seType, cfg.gfx.waveOrder, cfg.general.numSubIterations);
-      if (cfg.gfx.useHipEvents)
-        ERR_CHECK(hipEventRecord(exeInfo.stopEvents[0], stream));
+        if (cfg.gfx.useHipEvents)
+          ERR_CHECK(hipEventRecord(exeInfo.startEvents[0], stream));
+        gpuKernel<<<gridSize, blockSize, 0 , stream>>>(exeInfo.subExecParamGpu, cfg.gfx.seType, cfg.gfx.waveOrder, cfg.general.numSubIterations);
+        if (cfg.gfx.useHipEvents)
+          ERR_CHECK(hipEventRecord(exeInfo.stopEvents[0], stream));
 #else
-      hipExtLaunchKernelGGL(gpuKernel, gridSize, blockSize, 0, stream,
-                            cfg.gfx.useHipEvents ? exeInfo.startEvents[0] : NULL,
-                            cfg.gfx.useHipEvents ? exeInfo.stopEvents[0] : NULL, 0,
-                            exeInfo.subExecParamGpu, cfg.gfx.seType, cfg.gfx.waveOrder, cfg.general.numSubIterations);
+        hipExtLaunchKernelGGL(gpuKernel, gridSize, blockSize, 0, stream,
+                              cfg.gfx.useHipEvents ? exeInfo.startEvents[0] : NULL,
+                              cfg.gfx.useHipEvents ? exeInfo.stopEvents[0] : NULL, 0,
+                              exeInfo.subExecParamGpu, cfg.gfx.seType, cfg.gfx.waveOrder, cfg.general.numSubIterations);
 #endif
+      } else if (exeInfo.gfxKernelToUse == GFX_KERNEL_COPY) {
+#ifdef SINGLE_KERNEL
+        auto copyKernel = GpuCopyKernel<float4, 1024, 1, 0>;
+#else
+        auto copyKernel = GpuCopyKernelTable[kernelTableBlockRow][unrollIdx][wordSizeIdx][cfg.gfx.temporalMode];
+#endif
+#if defined(__NVCC__)
+        if (cfg.gfx.useHipEvents)
+          ERR_CHECK(hipEventRecord(exeInfo.startEvents[0], stream));
+        copyKernel<<<gridSize, blockSize, 0, stream>>>(exeInfo.subExecParamGpu, cfg.general.numSubIterations);
+        if (cfg.gfx.useHipEvents)
+          ERR_CHECK(hipEventRecord(exeInfo.stopEvents[0], stream));
+#else
+        hipExtLaunchKernelGGL(copyKernel, gridSize, blockSize, 0, stream,
+                              cfg.gfx.useHipEvents ? exeInfo.startEvents[0] : NULL,
+                              cfg.gfx.useHipEvents ? exeInfo.stopEvents[0] : NULL, 0,
+                              exeInfo.subExecParamGpu, cfg.general.numSubIterations);
+#endif
+      }
       ERR_CHECK(hipStreamSynchronize(stream));
     }
     auto cpuDelta = std::chrono::high_resolution_clock::now() - cpuStart;

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -2640,8 +2640,8 @@ namespace {
     int                        teamIdx;           ///< Size of team this sub executor is part of
 
     // Outputs
-    long long                  startCycle;        ///< Start timestamp for in-kernel timing (GPU-GFX executor)
-    long long                  stopCycle;         ///< Stop  timestamp for in-kernel timing (GPU-GFX executor)
+    int64_t                    startCycle;        ///< Start timestamp for in-kernel timing (GPU-GFX executor)
+    int64_t                    stopCycle;         ///< Stop  timestamp for in-kernel timing (GPU-GFX executor)
     uint32_t                   hwId;              ///< Hardware ID
     uint32_t                   xccId;             ///< XCC ID
   };
@@ -3855,7 +3855,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       if (exeInfo.resources.empty()) return false;
       for (auto const& rss : exeInfo.resources) {
         Transfer const& t = transfers[rss.transferIdx];
-        if (t.srcs.size() != 1 || t.dsts.size() != 1) return false;
+        if (t.srcs.size() > 1 || t.dsts.size() > 1) return false;
         if (cfg.gfx.useSingleTeam && t.numSubExecs > 1) return false;
       }
       return true;
@@ -4851,7 +4851,6 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
 
     if (shouldRecordTiming) {
-      __threadfence_system();
       p.stopCycle  = GetTimestamp();
       p.startCycle = startCycle;
       GetHwId(p.hwId);
@@ -5030,7 +5029,6 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
 
     if (shouldRecordTiming) {
-      __threadfence_system();
       p.stopCycle  = GetTimestamp();
       p.startCycle = startCycle;
       GetHwId(p.hwId);
@@ -5240,8 +5238,8 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       if (!cfg.gfx.useMultiStream) {
         for (int i = 0; i < exeInfo.resources.size(); i++) {
           TransferResources& rss = exeInfo.resources[i];
-          long long minStartCycle = std::numeric_limits<long long>::max();
-          long long maxStopCycle  = std::numeric_limits<long long>::min();
+          int64_t minStartCycle = std::numeric_limits<int64_t>::max();
+          int64_t maxStopCycle  = std::numeric_limits<int64_t>::min();
           std::set<std::pair<int, int>> CUs;
 
           for (auto subExecIdx : rss.subExecIdx) {
@@ -5252,6 +5250,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
                                         GetId(exeInfo.subExecParamGpu[subExecIdx].hwId)));
             }
           }
+
           double deltaMsec = (maxStopCycle - minStartCycle) / (double)(exeInfo.wallClockRate);
           deltaMsec /= cfg.general.numSubIterations;
           rss.totalDurationMsec += deltaMsec;


### PR DESCRIPTION
## Motivation
Adding a new GFX copy kernel that only supports single src single dst copies to investigate performance, as it may have less register pressure than the GFX reduction kernel. 

## Technical Details
The new copy kernel can be enabled by setting GFX_KERNEL=1.  GFX_KERNEL=0 will force the GpuReduceKernel which remain default behavior.  Setting GFX_KERNEL=-1 will switch to auto-mode, where GpuCopyKernel will be used if the Transfers are compatible single-source/single-destination copies.  

The gfxsweep preset was also updated to allow for KERNELS option to sweep over GFX kernels, as well as adjusted to allow for different timing methods (TIMING_MODE: -1=auto, 0 = Aggregate CPU wall-clock, 1 = HipEvent executor time, 2 = GPU wallclock time).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
