### PR TITLE
Fixes for cuMem compilation and invalid device ordinal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ MPI_PATH  ?= /usr/local/openmpi
 # DISABLE_DMA_BUF: Disable DMA-BUF support for GPU Direct RDMA (default: 1)
 # DISABLE_AMD_SMI: Disable AMD-SMI pod membership checking support (default: 0)
 # DISABLE_NVML: Disable NVML pod membership detection for CUDA builds (default: 0)
+# DISABLE_POD_COMM: Disable pod communication support (default: 0)
+# DISABLE_CUMEM: Disable CUDA driver API (default: 0). On CUDA, POD_COMM_ENABLED requires CUMEM_ENABLED.
 
 HIPCC ?= $(ROCM_PATH)/bin/amdclang++
 NVCC ?= $(CUDA_PATH)/bin/nvcc
@@ -177,6 +179,18 @@ ifeq ($(filter clean,$(MAKECMDGOALS)),)
     endif
   endif
 
+  # TransferBenchCuda: CUDA driver API (libcuda). Independent of POD, but POD on CUDA requires CUMEM.
+  DISABLE_CUMEM ?= 0
+  ifeq ($(MAKECMDGOALS),TransferBenchCuda)
+    ifneq ($(DISABLE_CUMEM),1)
+      $(info - Building with CUMEM_ENABLED (CUDA driver API, -lcuda))
+      COMMON_FLAGS += -DCUMEM_ENABLED
+      LDFLAGS += -lcuda
+    else
+      $(info - CUDA driver API disabled (DISABLE_CUMEM=1); POD comm unavailable on CUDA)
+    endif
+  endif
+
   POD_ENABLED = 0
   AMD_SMI_ENABLED = 0
   # Compile with pod support if
@@ -208,9 +222,12 @@ ifeq ($(filter clean,$(MAKECMDGOALS)),)
 
       ifeq ($(CUDA_VERSION_OK),yes)
         $(info - Detected CUDA version $(CUDA_MAJOR).$(CUDA_MINOR) which has MNNVL support)
-        COMMON_FLAGS += -DPOD_COMM_ENABLED
-        LDFLAGS += -lcuda
-        POD_ENABLED = 1
+        ifeq ($(DISABLE_CUMEM),1)
+          $(info - Pod communication skipped on CUDA: requires CUMEM_ENABLED (DISABLE_CUMEM=1))
+        else
+          COMMON_FLAGS += -DPOD_COMM_ENABLED
+          POD_ENABLED = 1
+        endif
       else
         $(info - Detected CUDA version $(CUDA_MAJOR).$(CUDA_MINOR) which does not have MNNVL support)
         $(info - Pod support will require CUDA version of at least $(CUDA_MIN_MAJOR).$(CUDA_MIN_MINOR))

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -5453,8 +5453,9 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
         Transfer const& t = transfers[resource->transferIdx];
         for (int srcIdx = 0; srcIdx < resource->srcMem.size(); srcIdx++) {
           if (t.srcs[srcIdx].memRank == localRank) {
-            if (IsGpuMemType(t.srcs[srcIdx].memType))
+            if (IsGpuMemType(t.srcs[srcIdx].memType)) {
               ERR_APPEND(hipSetDevice(t.srcs[srcIdx].memIndex), errResults);
+            }
             ERR_APPEND(hipMemcpy(resource->srcMem[srcIdx] + initOffset, srcReference[srcIdx].data(), resource->numBytes,
                                  hipMemcpyDefault), errResults);
           }

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1460,8 +1460,6 @@ namespace {
     // If memHandle is provided, allocate sharable memory
     if (memHandle != NULL) {
 #ifdef POD_COMM_ENABLED
-      ERR_CHECK(hipSetDevice(deviceIdx));
-      // Prepare HIP memory allocation properties structure
       hipMemAllocationProp prop = {};
       ERR_CHECK(GetMemAllocationProp(memDevice, prop));
 
@@ -4276,13 +4274,11 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       // Deallocate source memory
       for (int iSrc = 0; iSrc < t.srcs.size(); ++iSrc) {
         if (t.srcs[iSrc].memRank == localRank) {
-          ERR_CHECK(hipSetDevice(t.srcs[iSrc].memIndex));
           ERR_CHECK(DeallocateMemory(t.srcs[iSrc].memType, rss.srcMem[iSrc],
                                      rss.srcActualBytes[iSrc],
                                      &rss.srcMemHandle[iSrc]));
         } else if (exeDevice.exeRank == localRank && rss.srcMemHandle[iSrc] != 0) {
 #ifdef POD_COMM_ENABLED
-          ERR_CHECK(hipSetDevice(exeDevice.exeIndex));
           ERR_CHECK(hipMemUnmap((gpu_device_ptr)rss.srcMem[iSrc], rss.srcActualBytes[iSrc]));
           ERR_CHECK(hipMemRelease(rss.srcMemHandle[iSrc]));
           ERR_CHECK(hipMemAddressFree((gpu_device_ptr)rss.srcMem[iSrc], rss.srcActualBytes[iSrc]));
@@ -4293,13 +4289,11 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       // Deallocate destination memory
       for (int iDst = 0; iDst < t.dsts.size(); ++iDst) {
         if (t.dsts[iDst].memRank == localRank) {
-          ERR_CHECK(hipSetDevice(t.dsts[iDst].memIndex));
           ERR_CHECK(DeallocateMemory(t.dsts[iDst].memType, rss.dstMem[iDst],
                                      rss.dstActualBytes[iDst],
                                      &rss.dstMemHandle[iDst]));
         } else if (exeDevice.exeRank == localRank && rss.dstMemHandle[iDst] != 0) {
 #ifdef POD_COMM_ENABLED
-          ERR_CHECK(hipSetDevice(exeDevice.exeIndex));
           ERR_CHECK(hipMemUnmap((gpu_device_ptr)rss.dstMem[iDst], rss.dstActualBytes[iDst]));
           ERR_CHECK(hipMemRelease(rss.dstMemHandle[iDst]));
           ERR_CHECK(hipMemAddressFree((gpu_device_ptr)rss.dstMem[iDst], rss.dstActualBytes[iDst]));
@@ -5312,7 +5306,11 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       this->errMsg  = "";
     } else {
       this->errType = ERR_FATAL;
+#if defined(__NVCC__)
+      this->errMsg  = std::string("CUDA Runtime Error: ") + hipGetErrorString(err);
+#else
       this->errMsg  = std::string("HIP Error: ") + hipGetErrorString(err);
+#endif
     }
   }
 
@@ -5455,7 +5453,8 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
         Transfer const& t = transfers[resource->transferIdx];
         for (int srcIdx = 0; srcIdx < resource->srcMem.size(); srcIdx++) {
           if (t.srcs[srcIdx].memRank == localRank) {
-            ERR_APPEND(hipSetDevice(t.srcs[srcIdx].memIndex), errResults);
+            if (IsGpuMemType(t.srcs[srcIdx].memType))
+              ERR_APPEND(hipSetDevice(t.srcs[srcIdx].memIndex), errResults);
             ERR_APPEND(hipMemcpy(resource->srcMem[srcIdx] + initOffset, srcReference[srcIdx].data(), resource->numBytes,
                                  hipMemcpyDefault), errResults);
           }

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -5080,7 +5080,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       do {
         // Queue for each output location
         for (int dstIdx = 0; dstIdx < numDsts; dstIdx++) {
-#if defined(__NVCC__)
+#if defined(CUMEM_ENABLED)
           ERR_CHECK(cuMemcpyAsync((CUdeviceptr)resources.dstMem[dstIdx],
                                   (CUdeviceptr)resources.srcMem[0],
                                   resources.numBytes, stream));
@@ -5314,7 +5314,20 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
   }
 
-#if defined(__NVCC__)
+#if !defined(__NVCC__)
+  ErrResult::ErrResult(hsa_status_t err)
+  {
+    if (err == HSA_STATUS_SUCCESS) {
+      this->errType = ERR_NONE;
+      this->errMsg  = "";
+    } else {
+      const char *errString = NULL;
+      hsa_status_string(err, &errString);
+      this->errType = ERR_FATAL;
+      this->errMsg  = std::string("HSA Error: ") + errString;
+    }
+  }
+#elif defined(CUMEM_ENABLED)
   ErrResult::ErrResult(CUresult err)
   {
     if (err == CUDA_SUCCESS) {
@@ -5327,19 +5340,6 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       this->errType = ERR_FATAL;
       this->errMsg  = std::string("CUDA Driver Error: ") + errName
                       + " (" + errString + ")";
-    }
-  }
-#else
-  ErrResult::ErrResult(hsa_status_t err)
-  {
-    if (err == HSA_STATUS_SUCCESS) {
-      this->errType = ERR_NONE;
-      this->errMsg  = "";
-    } else {
-      const char *errString = NULL;
-      hsa_status_string(err, &errString);
-      this->errType = ERR_FATAL;
-      this->errMsg  = std::string("HSA Error: ") + errString;
     }
   }
 #endif
@@ -6136,7 +6136,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 
 #ifdef AMD_SMI_ENABLED
     amdsmi_shut_down();
-#elif defined(__NVCC__) && defined(POD_COMM_ENABLED)
+#elif defined(NVML_ENABLED)
     nvmlShutdown();
 #endif
   }


### PR DESCRIPTION
## Motivation
cuMem symbols and definitions are currently guarded by pod communication enablement. It's not a long term solution as these two are not always coupled and usage might diverge in future. The separation of these two also fixes existing linking error with `cuMemcpyAsync` or `CUResult` in absence of `POD_COMM_ENABLED`.

## Technical Details

- Introduced a separate `CUMEM_ENABLED` macro for build process as well as header. `POD_COMM_ENABLED` will have to depend on cuMem enablement as well. 
- Minor adjustment for error reporting for cuda runtime calls
- Eliminated unnecessary `hipSetDevice`: Previously in #241 multiple `hipSetDevice` are added throughout cuMem allocation and release to make sure context is always initialized. Not all of them were needed, and unconditional invocation also caused error for non GPU executors.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Tested all combination of Makefile flags and made sure compilation/linking succeeded.
Previously on CI machines with more CPU NUMA nodes than GPU devices, certain sweeping presets such as p2p would fail, which is fixed now.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
