### PR TITLE
Adding SHOW_PERCENTILES to show extra per-iteration statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Documentation for TransferBench is available at
 - Adding information on how to run multi-rank with TransferBench, when run with no args
 - Added new "nica2a" preset (NIC all-to-all over GPUs via NIC executors, multi-node)
 - Added new GFX_KERNEL to allow experimenting with copy-only GFX kernel.  Currently this is opt-in only
+- Added `SHOW_PERCENTILES` (e.g. `50,75,90,95,99`) to show empirical percentiles of per-iteration duration
 
 ### Modified
 - DMA-BUF support enablement in CMake changed to ENABLE_DMA_BUF to be more similar to other compile-time options

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -38,6 +38,7 @@ THE SOFTWARE.
 #include <cstdio>
 #include <cstring>
 #include <iostream>
+#include <set>
 #include <numa.h>
 #include <random>
 #include <time.h>
@@ -109,6 +110,7 @@ public:
   int maxNumVarSubExec;              // Maximum # of subexecutors to use for variable subExec Transfers (0 to use device limit)
   int outputToCsv;                   // Output in CSV format
   int samplingFactor;                // Affects how many different values of N are generated (when N set to 0)
+  std::vector<int> showPercentiles;  // Iteration-duration percentiles to print
 
   // NIC options
   int ibGidIndex;                    // GID Index for RoCE NICs
@@ -167,6 +169,7 @@ public:
     samplingFactor    = GetEnvVar("SAMPLING_FACTOR"     , 1);
     showBorders       = GetEnvVar("SHOW_BORDERS"        , 1);
     showIterations    = GetEnvVar("SHOW_ITERATIONS"     , 0);
+    showPercentiles   = GetEnvVarArray("SHOW_PERCENTILES", {});
     useHipEvents      = GetEnvVar("USE_HIP_EVENTS"      , 1);
     useHsaDma         = GetEnvVar("USE_HSA_DMA"         , 0);
     useInteractive    = GetEnvVar("USE_INTERACTIVE"     , 0);
@@ -276,6 +279,16 @@ public:
 #endif
     }
 
+    // Check that percentiles are valid
+    std::sort(showPercentiles.begin(), showPercentiles.end());
+    showPercentiles.erase(std::unique(showPercentiles.begin(), showPercentiles.end()), showPercentiles.end());
+    for (int v : showPercentiles) {
+      if (v < 1 || v > 99) {
+        printf("[ERROR] SHOW_PERCENTILES: value %d out of range (allowed 1..99)\n", v);
+        exit(1);
+      }
+    }
+
     // Parse preferred XCC table (if provided)
     char const* prefXccRaw = getenv("XCC_PREF_TABLE");
     if (prefXccRaw) {
@@ -362,6 +375,7 @@ public:
     printf(" SAMPLING_FACTOR     - Add this many samples (when possible) between powers of 2 when auto-generating data sizes\n");
     printf(" SHOW_BORDERS        - Show ASCII box-drawing characters in tables\n");
     printf(" SHOW_ITERATIONS     - Show per-iteration timing info\n");
+    printf(" SHOW_PERCENTILES    - Comma-separated percentiles iteration duration\n");
     printf(" USE_HIP_EVENTS      - Use HIP events for GFX executor timing\n");
     printf(" USE_HSA_DMA         - Use hsa_amd_async_copy instead of hipMemcpy for non-targeted DMA execution\n");
     printf(" USE_INTERACTIVE     - Pause for user-input before starting transfer loop\n");
@@ -500,6 +514,8 @@ public:
     Print("SHOW_BORDERS", showBorders, "%s ASCII box-drawing characaters in tables", showBorders ? "Showing" : "Hiding");
     Print("SHOW_ITERATIONS", showIterations,
           "%s per-iteration timing", showIterations ? "Showing" : "Hiding");
+    Print("SHOW_PERCENTILES", showPercentiles.empty() ? 0 : 1, "%s",
+          showPercentiles.empty() ? "Disabled" : GetStr(showPercentiles).c_str());
     Print("USE_HIP_EVENTS", useHipEvents,
           "Using %s for GFX/DMA Executor timing", useHipEvents ? "HIP events" : "CPU wall time");
     Print("USE_HSA_DMA", useHsaDma,
@@ -677,7 +693,7 @@ public:
     cfg.general.numIterations      = numIterations;
     cfg.general.numSubIterations   = numSubIterations;
     cfg.general.numWarmups         = numWarmups;
-    cfg.general.recordPerIteration = showIterations;
+    cfg.general.recordPerIteration = ((showIterations != 0) || !showPercentiles.empty()) ? 1 : 0;
     cfg.general.useInteractive     = useInteractive;
 
     cfg.data.alwaysValidate        = alwaysValidate;

--- a/src/client/Utilities.hpp
+++ b/src/client/Utilities.hpp
@@ -21,13 +21,29 @@ THE SOFTWARE.
 */
 
 #pragma once
+#include <algorithm>
+#include <cmath>
 #include <unordered_map>
 #include <unordered_set>
 #include <type_traits>
+#include "EnvVars.hpp"
 #include "TransferBench.hpp"
 
 namespace TransferBench::Utils
 {
+  // Linear interpolation on sorted samples (same ordering as common empirical quantiles with (n-1) indexing).
+  inline double PercentileDurationMsecFromSorted(std::vector<double> const& sortedAsc, int pct)
+  {
+    size_t const n = sortedAsc.size();
+    if (n == 0)
+      return 0.0;
+    double const pos = (static_cast<double>(pct) / 100.0) * static_cast<double>(n - 1);
+    size_t const lo = static_cast<size_t>(std::floor(pos));
+    size_t const hi = static_cast<size_t>(std::ceil(pos));
+    double const frac = pos - std::floor(pos);
+    return sortedAsc[lo] * (1.0 - frac) + sortedAsc[hi] * frac;
+  }
+
   // Helper class to help format tabular data / output to CSV
   class TableHelper
   {
@@ -538,10 +554,13 @@ namespace TransferBench::Utils
     for (auto const& exeInfoPair : results.exeResults) {
       ExeResult const& exeResult = exeInfoPair.second;
       numRows += 1 + exeResult.transferIdx.size();
+      if (!ev.showPercentiles.empty()) {
+        numRows += static_cast<int>(ev.showPercentiles.size()) * static_cast<int>(exeResult.transferIdx.size());
+      }
       if (ev.showIterations) {
         numRows += (numTimedIterations + 1) * exeResult.transferIdx.size();
-
-        // Check that per-iteration information exists
+      }
+      if (ev.showIterations || !ev.showPercentiles.empty()) {
         for (int idx : exeResult.transferIdx) {
           TransferResult const& r = results.tfrResults[idx];
           if (r.perIterMsec.size() != numTimedIterations) {
@@ -670,6 +689,24 @@ namespace TransferBench::Utils
           rowIdx++;
           table.DrawRowBorder(rowIdx);
         }
+
+        // Show percentiles
+        if (!ev.showPercentiles.empty()) {
+          std::vector<double> sortedDur = r.perIterMsec;
+          std::sort(sortedDur.begin(), sortedDur.end());
+          for (int pct : ev.showPercentiles) {
+            double dur = PercentileDurationMsecFromSorted(sortedDur, pct);
+            double bwGbs = dur > 0.0 ? (t.numBytes / 1.0E9) / dur * 1000.0 : 0.0;
+            table.Set(rowIdx, 0, "p%d ", pct);
+            table.Set(rowIdx, 1, "%8.3f GB/s ", bwGbs);
+            table.Set(rowIdx, 2, "%8.3f ms ", dur);
+            table.Set(rowIdx, 3, " ");
+            table.Set(rowIdx, 4, " ");
+            table.SetCellAlignment(rowIdx, 4, TableHelper::ALIGN_LEFT);
+            rowIdx++;
+          }
+        }
+
       }
     }
     table.DrawRowBorder(rowIdx);


### PR DESCRIPTION
## Motivation
Add ability to get additional statistics about per-iteration duration through the new env var SHOW_PERCENTILES which takes in comma-separated percentages.  For example SHOW_PERCENTILES=50,90,99 reports the duration 50%/90%/99% of Transfers are faster than.

## Technical Details
This is purely a client-side change.  When SHOW_PERCENTILES is enabled, per-iteration timing is recorded, and then the results are sorted to compute the statistics:

## Example output

Test 1:
```
-------------------┬--------------┬------------┬-------------------┬--------------------
  Executor: CPU 00 │  12.058 GB/s │  89.050 ms │  1073741824 bytes │  12.091 GB/s (sum)
-------------------┼--------------┼------------┼-------------------┼--------------------
     Transfer 0    │  12.091 GB/s │  88.802 ms │  1073741824 bytes │ C0 -> C0:1 -> C1
               p50 │  12.090 GB/s │  88.814 ms │                   │
               p90 │  11.720 GB/s │  91.617 ms │                   │
               p99 │  11.702 GB/s │  91.757 ms │                   │
-------------------┼--------------┼------------┼-------------------┼--------------------
   Aggregate (CPU) │  12.014 GB/s │  89.374 ms │  1073741824 bytes │ Overhead 0.325 ms
-------------------┴--------------┴------------┴-------------------┴--------------------

```
