### PR TITLE
Small fixes for candidate v1.67 release

### DIFF
--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -38,6 +38,7 @@ THE SOFTWARE.
 #include <cstdio>
 #include <cstring>
 #include <iostream>
+#include <optional>
 #include <set>
 #include <numa.h>
 #include <random>
@@ -352,6 +353,7 @@ public:
     printf(" GFX_SINGLE_TEAM     - Have subexecutors work together on full array instead of working on disjoint subarrays\n");
     printf(" GFX_WAVE_ORDER      - Stride pattern for GFX kernel (0=UWC,1=UCW,2=WUC,3=WCU,4=CUW,5=CWU)\n");
     printf(" GFX_WORD_SIZE       - GFX kernel packed data size (4=DWORDx4, 2=DWORDx2, 1=DWORDx1)\n");
+    printf(" GPU_MAX_HW_QUEUES   - Max hardware queues per GPU device (default = 4)\n");
     printf(" HIDE_ENV            - Hide environment variable value listing\n");
 #if NIC_EXEC_ENABLED
     printf(" IB_GID_INDEX        - Required for RoCE NICs (default=-1/auto)\n");
@@ -478,6 +480,9 @@ public:
     Print("GFX_WORD_SIZE", gfxWordSize,
           "Using GFX word size of %d (DWORDx%d)", gfxWordSize, gfxWordSize);
 
+    Print("GPU_MAX_HW_QUEUES", gpuMaxHwQueues,
+          "Max %d hardware queues per GPU device", gpuMaxHwQueues);
+
 #if NIC_EXEC_ENABLED
     Print("IP_ADDRESS_FAMILY", ipAddressFamily,
           "IP address family is set to IPv%d", ipAddressFamily);
@@ -562,68 +567,59 @@ public:
     return defaultValue;
   }
 
-  static std::vector<int> GetEnvVarArray(std::string const& varname, std::vector<int> const& defaultValue)
+  // Returns comma-split tokens for varname, or an empty optional if unset/empty (use default).
+  static std::optional<std::vector<std::string>> GetEnvTokens(std::string const& varname)
   {
     char const* raw = getenv(varname.c_str());
-    if (raw) {
-      std::vector<int> values;
-      std::string copy(raw);
-      char* token = copy.empty() ? NULL : strtok(&copy[0], ",");
-      while (token) {
-        int val;
-        if (sscanf(token, "%d", &val) == 1) {
-          values.push_back(val);
-        } else {
-          printf("[ERROR] Unrecognized token [%s]\n", token);
-          exit(1);
-        }
-        token = strtok(NULL, ",");
+    if (!raw || raw[0] == '\0') return std::nullopt;
+    std::vector<std::string> tokens;
+    std::string copy(raw);
+    char* token = strtok(&copy[0], ",");
+    while (token) { tokens.push_back(token); token = strtok(NULL, ","); }
+    return tokens;
+  }
+
+  static std::vector<int> GetEnvVarArray(std::string const& varname, std::vector<int> const& defaultValue)
+  {
+    auto tokens = GetEnvTokens(varname);
+    if (!tokens) return defaultValue;
+    std::vector<int> values;
+    for (auto const& tok : *tokens) {
+      int val;
+      if (sscanf(tok.c_str(), "%d", &val) == 1) {
+        values.push_back(val);
+      } else {
+        printf("[ERROR] Unrecognized token [%s]\n", tok.c_str());
+        exit(1);
       }
-      return values;
     }
-    return defaultValue;
+    return values;
   }
 
   static std::vector<std::string> GetEnvVarStrArray(std::string const& varname, std::vector<std::string> const& defaultValue)
   {
-    char const* raw = getenv(varname.c_str());
-    if (raw) {
-      std::vector<std::string> values;
-      std::string copy(raw);
-      char* token = copy.empty() ? NULL : strtok(&copy[0], ",");
-      while (token) {
-        values.push_back(token);
-        token = strtok(NULL, ",");
-      }
-      return values;
-    }
-    return defaultValue;
+    auto tokens = GetEnvTokens(varname);
+    if (!tokens) return defaultValue;
+    return *tokens;
   }
 
   static std::vector<int> GetEnvVarRangeArray(std::string const& varname, std::vector<int> const& defaultValue)
   {
-    char const* raw = getenv(varname.c_str());
-    if (raw) {
-      std::string copy(raw);
-      std::set<int> values;
-      char* token = copy.empty() ? NULL : strtok(&copy[0], ",");
-      while (token) {
-        int start, end;
-        if (sscanf(token, "%d-%d", &start, &end) == 2) {
-          for (int i = start; i <= end; i++) values.insert(i);
-        } else if (sscanf(token, "%d", &start) == 1) {
-          values.insert(start);
-        } else {
-          printf("[ERROR] Unrecognized token [%s]\n", token);
-          exit(1);
-        }
-        token = strtok(NULL, ",");
+    auto tokens = GetEnvTokens(varname);
+    if (!tokens) return defaultValue;
+    std::set<int> values;
+    for (auto const& tok : *tokens) {
+      int start, end;
+      if (sscanf(tok.c_str(), "%d-%d", &start, &end) == 2) {
+        for (int i = start; i <= end; i++) values.insert(i);
+      } else if (sscanf(tok.c_str(), "%d", &start) == 1) {
+        values.insert(start);
+      } else {
+        printf("[ERROR] Unrecognized token [%s]\n", tok.c_str());
+        exit(1);
       }
-      std::vector<int> result;
-      for (auto v : values) result.push_back(v);
-      return result;
     }
-    return defaultValue;
+    return std::vector<int>(values.begin(), values.end());
   }
 
   static std::string GetEnvVar(std::string const& varname, std::string const& defaultValue)
@@ -673,8 +669,10 @@ public:
         }
       }
     }
-    if (inRun)
+    if (inRun) {
       curr.second = (cuMask.size() * 32) / numXccs - 1;
+      runs.push_back(curr);
+    }
 
     std::string result = "CUs used: (" + std::to_string(used) + ") ";
     for (int i = 0; i < runs.size(); i++)

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -631,7 +631,7 @@ public:
 
   std::string GetStr(std::vector<int> const& varnameList) const {
     std::string result = "";
-    for (auto i = 0; i < varnameList.size(); i++) {
+    for (size_t i = 0; i < varnameList.size(); i++) {
       if (i) result += ",";
       result += std::to_string(varnameList[i]);
     }
@@ -640,7 +640,7 @@ public:
 
   std::string GetStr(std::vector<std::string> const& varnameList) const {
     std::string result = "";
-    for (auto i = 0; i < varnameList.size(); i++) {
+    for (size_t i = 0; i < varnameList.size(); i++) {
       if (i) result += ",";
       result += varnameList[i];
     }

--- a/src/client/Presets/NicAllToAll.hpp
+++ b/src/client/Presets/NicAllToAll.hpp
@@ -270,6 +270,8 @@ int NicAllToAllPreset(EnvVars&                    ev,
   for (size_t i = 0; i < results.tfrResults.size(); i++) {
     int nicIdx  = results.tfrResults[i].exeDevice.exeIndex;
     int rankIdx = results.tfrResults[i].exeDevice.exeRank;
+    // Guard against remapped NIC indices from RunTransfers executor resolution
+    if (rankIdx < 0 || rankIdx >= numRanks || nicIdx < 0 || nicIdx >= numNicsPerRank) continue;
     bwByRankNic[rankIdx][nicIdx] += results.tfrResults[i].avgBandwidthGbPerSec;
   }
 

--- a/src/client/Presets/NicAllToAll.hpp
+++ b/src/client/Presets/NicAllToAll.hpp
@@ -271,7 +271,11 @@ int NicAllToAllPreset(EnvVars&                    ev,
     int nicIdx  = results.tfrResults[i].exeDevice.exeIndex;
     int rankIdx = results.tfrResults[i].exeDevice.exeRank;
     // Guard against remapped NIC indices from RunTransfers executor resolution
-    if (rankIdx < 0 || rankIdx >= numRanks || nicIdx < 0 || nicIdx >= numNicsPerRank) continue;
+    if (rankIdx < 0 || rankIdx >= numRanks || nicIdx < 0 || nicIdx >= numNicsPerRank) {
+      Utils::Print("[WARN] Skipping result %zu: executor (rank=%d, nic=%d) outside expected range [0,%d)[0,%d)\n",
+                   i, rankIdx, nicIdx, numRanks, numNicsPerRank);
+      continue;
+    }
     bwByRankNic[rankIdx][nicIdx] += results.tfrResults[i].avgBandwidthGbPerSec;
   }
 

--- a/src/client/Presets/NicAllToAll.hpp
+++ b/src/client/Presets/NicAllToAll.hpp
@@ -272,7 +272,7 @@ int NicAllToAllPreset(EnvVars&                    ev,
     int rankIdx = results.tfrResults[i].exeDevice.exeRank;
     // Guard against remapped NIC indices from RunTransfers executor resolution
     if (rankIdx < 0 || rankIdx >= numRanks || nicIdx < 0 || nicIdx >= numNicsPerRank) {
-      Utils::Print("[WARN] Skipping result %zu: executor (rank=%d, nic=%d) outside expected range [0,%d)[0,%d)\n",
+      Utils::Print("[WARN] Skipping result %zu: executor (rank=%d, nic=%d) outside expected range rank:[0,%d), nic:[0,%d)\n",
                    i, rankIdx, nicIdx, numRanks, numNicsPerRank);
       continue;
     }

--- a/src/client/Presets/NicAllToAll.hpp
+++ b/src/client/Presets/NicAllToAll.hpp
@@ -34,14 +34,14 @@ int NicAllToAllPreset(EnvVars&                    ev,
     Utils::Print("[ERROR] NIC all-to-all preset can only be run across ranks that are homogenous\n");
     Utils::Print("[ERROR] Run ./TransferBench without any args to display topology information\n");
     Utils::Print("[ERROR] TB_NIC_FILTER may also be used to limit NIC visibility to scale-out NICs\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   int numRanks = TransferBench::GetNumRanks();
   int numNicsPerRank = TransferBench::GetNumExecutors(EXE_NIC);
   if (numNicsPerRank == 0) {
     Utils::Print("[ERROR] No NIC detected. This preset requires NIC executors.\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   int useCpuMem = EnvVars::GetEnvVar("USE_CPU_MEM", 0);
@@ -49,7 +49,7 @@ int NicAllToAllPreset(EnvVars&                    ev,
   int numMemDevices = TransferBench::GetNumExecutors(useCpuMem ? EXE_CPU : EXE_GPU_GFX);
   if (numMemDevices == 0) {
     Utils::Print("[ERROR] No %s executors detected for NIC all-to-all.\n", useCpuMem ? "CPU" : "GPU GFX");
-    return 1;
+    return ERR_FATAL;
   }
 
   int numQueuePairs = EnvVars::GetEnvVar("NUM_QUEUE_PAIRS", 1);
@@ -72,11 +72,11 @@ int NicAllToAllPreset(EnvVars&                    ev,
 
   if (numQueuePairs < 1) {
     Utils::Print("[ERROR] NUM_QUEUE_PAIRS must be >= 1 (got %d)\n", numQueuePairs);
-    return 1;
+    return ERR_FATAL;
   }
   if (groupSize < 1) {
     Utils::Print("[ERROR] GROUP_SIZE must be >= 1 (got %d)\n", groupSize);
-    return 1;
+    return ERR_FATAL;
   }
 
   bool scopeInter = false;
@@ -87,7 +87,7 @@ int NicAllToAllPreset(EnvVars&                    ev,
         scopeInter = true;
       else if (strcmp(scopeStr, "intra") && strcmp(scopeStr, "INTRA")) {
         Utils::Print("[ERROR] NIC_A2A_SCOPE must be \"intra\" or \"inter\"\n");
-        return 1;
+        return ERR_FATAL;
       }
     }
   }
@@ -97,14 +97,14 @@ int NicAllToAllPreset(EnvVars&                    ev,
 
   if (numNicPlanes < 1) {
     Utils::Print("[ERROR] NUM_NIC_PLANES must be >= 1\n");
-    return 1;
+    return ERR_FATAL;
   }
 
   // Same divisibility check as PodAllToAll (total devices = ranks × memory devices per rank).
   if (M % groupSize) {
     Utils::Print("[ERROR] Group size %d cannot evenly divide %d total devices from %d ranks.\n",
                  groupSize, M, numRanks);
-    return 1;
+    return ERR_FATAL;
   }
 
   // Within each stride orbit, partition by natural rank-major device index: orbit lists devLin = r, r+d, r+2d, ...
@@ -115,7 +115,7 @@ int NicAllToAllPreset(EnvVars&                    ev,
     Utils::Print("[ERROR] With STRIDE=%d there are %d disjoint cycles; use a GROUP_SIZE that divides each cycle's device count,\n",
                  stride, dCycles);
     Utils::Print("[ERROR] or use STRIDE=1 so the cycle size equals total devices (%d).\n", M);
-    return 1;
+    return ERR_FATAL;
   }
 
   std::vector<int> deviceSubgroup(M);
@@ -155,12 +155,12 @@ int NicAllToAllPreset(EnvVars&                    ev,
       if (memIdx < 0) {
         Utils::Print("[ERROR] Failed to identify closest %s for Rank %d NIC %d\n",
                      useCpuMem ? "CPU NUMA node" : "GPU", rank, nic);
-        return 1;
+        return ERR_FATAL;
       }
       if (memIdx >= numMemDevices) {
         Utils::Print("[ERROR] Closest %s index %d for Rank %d NIC %d is out of range [0,%d)\n",
                      useCpuMem ? "CPU" : "GPU", memIdx, rank, nic, numMemDevices);
-        return 1;
+        return ERR_FATAL;
       }
       nicToMem[rank][nic] = memIdx;
     }
@@ -237,7 +237,7 @@ int NicAllToAllPreset(EnvVars&                    ev,
   if (!TransferBench::RunTransfers(cfg, transfers, results)) {
     for (auto const& err : results.errResults)
       Utils::Print("%s\n", err.errMsg.c_str());
-    return 1;
+    return ERR_FATAL;
   } else if (showDetails) {
     Utils::PrintResults(ev, 1, transfers, results);
     Utils::Print("\n");

--- a/src/client/Presets/PodAllToAll.hpp
+++ b/src/client/Presets/PodAllToAll.hpp
@@ -43,6 +43,11 @@ int PodAllToAllPreset(EnvVars&          ev,
   int numRanks = TransferBench::GetNumRanks();
   int numDetectedGpus = TransferBench::GetNumExecutors(EXE_GPU_GFX);
 
+  // When pod detection fails (e.g. amd-smi unavailable), the map is empty
+  if (Utils::GetRankPerPodMap().empty()) {
+    Utils::Print("[ERROR] No pods detected. Set TB_FORCE_SINGLE_POD=1 to treat all ranks as a single pod.\n");
+    return ERR_FATAL;
+  }
   // Restrict to single-pod runs; multi-pod support is not yet implemented
   if (Utils::GetRankPerPodMap().size() != 1) {
     Utils::Print("[ERROR] PodAllToAll preset currently requires all ranks to be in a single pod. Set TB_FORCE_SINGLE_POD=1 to treat all ranks as a single pod.\n");
@@ -129,7 +134,7 @@ int PodAllToAllPreset(EnvVars&          ev,
     return ERR_FATAL;
   }
 
-  // Validate per-pod: pods may have different rank counts so global check is insufficient
+  // Validate group size divides the single pod's total device count
   for (auto const& [pod, ranks] : Utils::GetRankPerPodMap()) {
     int podDevices = (int)ranks.size() * numGpus;
     if (podDevices % groupSize) {
@@ -149,10 +154,6 @@ int PodAllToAllPreset(EnvVars&          ev,
   ExeType exeType = useDmaExec ? EXE_GPU_DMA : EXE_GPU_GFX;
 
   Utils::RankPerPodMap& rankToPod = Utils::GetRankPerPodMap();
-  if (rankToPod.empty()) {
-    Utils::Print("[ERROR] No pods detected. Set TB_FORCE_SINGLE_POD=1 to treat all ranks as a single pod.\n");
-    return ERR_FATAL;
-  }
   for (auto const& [pod, ranks] : rankToPod) {
     int n = ranks.size() * numGpus;
     int numGroups = n / groupSize;

--- a/src/client/Presets/PodAllToAll.hpp
+++ b/src/client/Presets/PodAllToAll.hpp
@@ -118,9 +118,14 @@ int PodAllToAllPreset(EnvVars&          ev,
     return ERR_FATAL;
   }
 
-  if (numRanks * numDetectedGpus % groupSize) {
-    Utils::Print("[ERROR] Group size %d cannot evenly divide %d total devices from %d ranks.\n", groupSize, numRanks * numDetectedGpus, numRanks);
-    return ERR_FATAL;
+  // Validate per-pod: pods may have different rank counts so global check is insufficient
+  for (auto const& [pod, ranks] : Utils::GetRankPerPodMap()) {
+    int podDevices = (int)ranks.size() * numGpus;
+    if (podDevices % groupSize) {
+      Utils::Print("[ERROR] Group size %d cannot evenly divide %d devices in pod %d (%zu ranks).\n",
+                   groupSize, podDevices, pod, ranks.size());
+      return ERR_FATAL;
+    }
   }
 
   Utils::Print("GPU-%s IntraPod All-To-All benchmark:\n", useDmaExec ? "DMA" : "GFX");

--- a/src/client/Presets/PodAllToAll.hpp
+++ b/src/client/Presets/PodAllToAll.hpp
@@ -167,6 +167,7 @@ int PodAllToAllPreset(EnvVars&          ev,
           TransferBench::Transfer transfer;
           transfer.numBytes = numBytesPerTransfer;
           for (int x = 0; x < numSrcs; x++) transfer.srcs.push_back(devices[i]);
+          // First dst is the remote peer (devices[j]); extra dsts are local (devices[i]) to stress-test src bandwidth
           if (numDsts) transfer.dsts.push_back(devices[j]);
           for (int x = 1; x < numDsts; x++) transfer.dsts.push_back(devices[i]);
           transfer.exeDevice = {exeType,

--- a/src/client/Presets/PodAllToAll.hpp
+++ b/src/client/Presets/PodAllToAll.hpp
@@ -109,7 +109,7 @@ int PodAllToAllPreset(EnvVars&          ev,
     }
   }
   // Validate env vars
-  if (numGpus < 0 || numGpus > numDetectedGpus) {
+  if (numGpus <= 0 || numGpus > numDetectedGpus) {
     Utils::Print("[ERROR] Cannot use %d GPUs.  Detected %d GPUs\n", numGpus, numDetectedGpus);
     return ERR_FATAL;
   }
@@ -181,6 +181,7 @@ int PodAllToAllPreset(EnvVars&          ev,
           transfers.push_back(transfer);
         }
 
+        // NIC transfers are supplementary bandwidth; excluded from groupReIndex and bandwidth table
         if (numQueuePairs > 0) {
           TransferBench::Transfer transfer;
           transfer.numBytes = numBytesPerTransfer;

--- a/src/client/Presets/PodAllToAll.hpp
+++ b/src/client/Presets/PodAllToAll.hpp
@@ -53,7 +53,7 @@ int PodAllToAllPreset(EnvVars&          ev,
   int useDmaExec    = EnvVars::GetEnvVar("USE_DMA_EXEC"   , 0);
   int useRemoteRead = EnvVars::GetEnvVar("USE_REMOTE_READ", 0);
   int stride        = EnvVars::GetEnvVar("STRIDE"         , 1);
-  int groupSize     = EnvVars::GetEnvVar("GROUP_SIZE"     , numRanks * numDetectedGpus);
+  int groupSize     = EnvVars::GetEnvVar("GROUP_SIZE"     , numRanks * numGpus);
 
   // Check that all ranks have at least the number of GPUs requested
   // Warn if NIC configuration is slightly different from one another
@@ -127,8 +127,8 @@ int PodAllToAllPreset(EnvVars&          ev,
   for (auto const& [pod, ranks] : Utils::GetRankPerPodMap()) {
     int podDevices = (int)ranks.size() * numGpus;
     if (podDevices % groupSize) {
-      Utils::Print("[ERROR] Group size %d cannot evenly divide %d devices in pod %ld (%zu ranks).\n",
-                   groupSize, podDevices, (long)pod, ranks.size());
+      Utils::Print("[ERROR] Group size %d cannot evenly divide %d devices in pod %lld (%zu ranks).\n",
+                   groupSize, podDevices, (long long)pod, ranks.size());
       return ERR_FATAL;
     }
   }

--- a/src/client/Presets/PodAllToAll.hpp
+++ b/src/client/Presets/PodAllToAll.hpp
@@ -43,6 +43,12 @@ int PodAllToAllPreset(EnvVars&          ev,
   int numRanks = TransferBench::GetNumRanks();
   int numDetectedGpus = TransferBench::GetNumExecutors(EXE_GPU_GFX);
 
+  // Restrict to single-pod runs; multi-pod support is not yet implemented
+  if (Utils::GetRankPerPodMap().size() != 1) {
+    Utils::Print("[ERROR] PodAllToAll preset currently requires all ranks to be in a single pod. Set TB_FORCE_SINGLE_POD=1 to treat all ranks as a single pod.\n");
+    return ERR_FATAL;
+  }
+
   // Collect env vars for this preset
   int a2aLocal      = EnvVars::GetEnvVar("A2A_LOCAL"      , 0);
   int memTypeIdx    = EnvVars::GetEnvVar("MEM_TYPE"       , 0);

--- a/src/client/Presets/PodAllToAll.hpp
+++ b/src/client/Presets/PodAllToAll.hpp
@@ -118,12 +118,17 @@ int PodAllToAllPreset(EnvVars&          ev,
     return ERR_FATAL;
   }
 
+  if (groupSize < 1) {
+    Utils::Print("[ERROR] GROUP_SIZE must be >= 1 (got %d)\n", groupSize);
+    return ERR_FATAL;
+  }
+
   // Validate per-pod: pods may have different rank counts so global check is insufficient
   for (auto const& [pod, ranks] : Utils::GetRankPerPodMap()) {
     int podDevices = (int)ranks.size() * numGpus;
     if (podDevices % groupSize) {
-      Utils::Print("[ERROR] Group size %d cannot evenly divide %d devices in pod %d (%zu ranks).\n",
-                   groupSize, podDevices, pod, ranks.size());
+      Utils::Print("[ERROR] Group size %d cannot evenly divide %d devices in pod %ld (%zu ranks).\n",
+                   groupSize, podDevices, (long)pod, ranks.size());
       return ERR_FATAL;
     }
   }

--- a/src/client/Presets/Rings.hpp
+++ b/src/client/Presets/Rings.hpp
@@ -111,6 +111,7 @@ int RingsPreset(EnvVars&          ev,
   Utils::StrideGenerate(indices, stride);
 
   // Establish memory devices for all GPUs
+  // Assumes ranks are numbered 0..numRanks-1 and each has exactly numGpus devices
   std::vector<MemDevice> memDevices(totalGpus);
   for (int i = 0; i < totalGpus; i++) {
     memDevices[i] = {memType, indices[i] % numGpus, indices[i] / numGpus};

--- a/src/client/Presets/Rings.hpp
+++ b/src/client/Presets/Rings.hpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#include <limits>
 #include <numeric>
 
 int RingsPreset(EnvVars&          ev,

--- a/src/client/Presets/WallClock.hpp
+++ b/src/client/Presets/WallClock.hpp
@@ -96,6 +96,11 @@ int WallClockPreset(EnvVars&          ev,
     Utils::Print("[ERROR] wallclock preset requires at least one GPU\n");
     return ERR_FATAL;
   }
+  // Timed/auto mode (numIterations <= 0) never runs timed iterations, so results would be undefined
+  if (ev.numIterations <= 0) {
+    Utils::Print("[ERROR] wallclock preset requires NUM_ITERATIONS > 0 (timed mode is not supported)\n");
+    return ERR_FATAL;
+  }
 
   // Collect local results
   int numXccs = GetNumExecutorSubIndices({EXE_GPU_GFX, 0});
@@ -134,7 +139,7 @@ int WallClockPreset(EnvVars&          ev,
 
     for (int i = -ev.numWarmups; i < ev.numIterations; i++)
     {
-      HIP_CALL(hipMemset(readyFlag, 0, sizeof(int)));
+      HIP_CALL(hipMemset(readyFlag, 0, sizeof(*readyFlag)));
       HIP_CALL(hipDeviceSynchronize());
       GetXccTimestamps<<<dim3(numXccs,2,1), 1>>>(timestamps, readyFlag);
       HIP_CALL(hipDeviceSynchronize());

--- a/src/client/Presets/WallClock.hpp
+++ b/src/client/Presets/WallClock.hpp
@@ -32,7 +32,7 @@ __global__ void GetXccTimestamps(uint64_t* timestamps, volatile int* readyFlag)
     int xccId;
     GetXccId(xccId);
 
-    // All threadblocks wait for ready signal
+    // All threadblocks wait for ready signal (no timeout — assumes signaling block is live)
     while (*readyFlag == 0);
 
     // Collect timestamp and save to memory; guard against unexpected XCC IDs

--- a/src/client/Presets/WallClock.hpp
+++ b/src/client/Presets/WallClock.hpp
@@ -35,9 +35,9 @@ __global__ void GetXccTimestamps(uint64_t* timestamps, volatile int* readyFlag)
     // All threadblocks wait for ready signal
     while (*readyFlag == 0);
 
-    // Collect timestamp and save to memory
+    // Collect timestamp and save to memory; guard against unexpected XCC IDs
     auto w = GetTimestamp();
-    timestamps[xccId] = w;
+    if (xccId >= 0 && xccId < (int)gridDim.x) timestamps[xccId] = w;
   } else if (blockIdx.x == 0) {
 
     // Sleep for some number of cycles to ensure that other threadblocks are active
@@ -103,7 +103,16 @@ int WallClockPreset(EnvVars&          ev,
   }
 
   // Collect local results
+  // Query XCC count per device; all must match since results are sized from GPU 0
   int numXccs = GetNumExecutorSubIndices({EXE_GPU_GFX, 0});
+  for (int deviceId = 1; deviceId < numGpuDevices; deviceId++) {
+    int devXccs = GetNumExecutorSubIndices({EXE_GPU_GFX, deviceId});
+    if (devXccs != numXccs) {
+      Utils::Print("[ERROR] GPU device %d has %d XCCs but GPU 0 has %d; heterogeneous XCC counts are not supported\n",
+                   deviceId, devXccs, numXccs);
+      return ERR_FATAL;
+    }
+  }
 
   // Compute wall clock rate (based on GPU 0)
   int wallClockKhz;

--- a/src/client/Presets/WallClock.hpp
+++ b/src/client/Presets/WallClock.hpp
@@ -107,6 +107,10 @@ int WallClockPreset(EnvVars&          ev,
   // Collect local results
   // Query XCC count per device; all must match since results are sized from GPU 0
   int numXccs = GetNumExecutorSubIndices({EXE_GPU_GFX, 0});
+  if (numXccs <= 0) {
+    Utils::Print("[ERROR] wallclock preset requires at least one XCC (GPU 0 reports 0); topology data may be missing\n");
+    return ERR_FATAL;
+  }
   for (int deviceId = 1; deviceId < numGpuDevices; deviceId++) {
     int devXccs = GetNumExecutorSubIndices({EXE_GPU_GFX, deviceId});
     if (devXccs != numXccs) {
@@ -150,6 +154,7 @@ int WallClockPreset(EnvVars&          ev,
 
     for (int i = -ev.numWarmups; i < ev.numIterations; i++)
     {
+      memset(timestamps, 0, numXccs * sizeof(uint64_t));
       HIP_CALL(hipMemset(readyFlag, 0, sizeof(*readyFlag)));
       HIP_CALL(hipDeviceSynchronize());
       GetXccTimestamps<<<dim3(numXccs,2,1), 1>>>(timestamps, readyFlag);

--- a/src/client/Presets/WallClock.hpp
+++ b/src/client/Presets/WallClock.hpp
@@ -20,6 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#include <limits>
+
 __global__ void GetXccTimestamps(uint64_t* timestamps, volatile int* readyFlag)
 {
   // Only first thread does any work
@@ -92,13 +94,13 @@ int WallClockPreset(EnvVars&          ev,
   IS_UNIFORM(ev.numWarmups,     "NUM_WARMUPS");
   IS_UNIFORM(ev.showIterations, "SHOW_ITERATIONS");
 
-  if (numGpuDevices <= 0) {
-    Utils::Print("[ERROR] wallclock preset requires at least one GPU\n");
+  if (numGpuDevices <= 0 || numGpuDevices > numDetectedGpus) {
+    Utils::Print("[ERROR] wallclock preset requires 1 <= NUM_GPU_DEVICES <= %d (got %d)\n", numDetectedGpus, numGpuDevices);
     return ERR_FATAL;
   }
-  // Timed/auto mode (numIterations <= 0) never runs timed iterations, so results would be undefined
+  // Seconds-based (numIterations < 0) and infinite (numIterations == 0) modes are not supported
   if (ev.numIterations <= 0) {
-    Utils::Print("[ERROR] wallclock preset requires NUM_ITERATIONS > 0 (timed mode is not supported)\n");
+    Utils::Print("[ERROR] wallclock preset requires NUM_ITERATIONS > 0 (seconds-based and infinite modes are not supported)\n");
     return ERR_FATAL;
   }
 

--- a/src/client/Utilities.hpp
+++ b/src/client/Utilities.hpp
@@ -23,8 +23,12 @@ THE SOFTWARE.
 #pragma once
 #include <algorithm>
 #include <cmath>
+#include <iomanip>
+#include <set>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <type_traits>
 #include "EnvVars.hpp"
 #include "TransferBench.hpp"

--- a/src/client/Utilities.hpp
+++ b/src/client/Utilities.hpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 #include <algorithm>
 #include <cmath>
 #include <iomanip>
+#include <map>
 #include <set>
 #include <tuple>
 #include <unordered_map>


### PR DESCRIPTION
## Motivation

Tighten preset input validation, fix correctness bugs, and improve code robustness across several presets and shared utilities.

## Technical Details

Preset validation fixes:
- PodAllToAll:
  - restrict to single-pod runs; multi-pod support is not yet implemented (rejects when GetRankPerPodMap().size() != 1, with a dedicated message for the no-pods-detected case)
  - validate GROUP_SIZE divisibility against the single pod's total device count
  - fix GROUP_SIZE default to use numGpus (user-specified) instead of numDetectedGpus to avoid false validation failures when NUM_GPU_DEVICES is set below the detected count
  - guard GROUP_SIZE < 1 before modulo to prevent UB
  - guard numGpus <= 0 (was only catching < 0)
- WallClock:
  - guard numXccs <= 0 before kernel launch to prevent invalid gridDim.x=0 dispatch when topology data is missing
  - zero-initialize timestamps buffer before each kernel launch to prevent stale values from unexpected XCC IDs corrupting delta calculations
  - reject NUM_ITERATIONS <= 0 (seconds-based and infinite modes are unsupported)
  - extend NUM_GPU_DEVICES validation to also reject values exceeding detected GPU count
  - use sizeof(*readyFlag) for type safety
- NicAllToAll:
  - guard bwByRankNic indexing against remapped NIC executor indices from RunTransfers
  - emit a warning instead of silently skipping on out-of-range results

Code quality:
- EnvVars:
  - extract shared GetEnvTokens helper to eliminate duplicated getenv/strtok logic across three array-parsing functions
  - treat unset/empty env vars consistently as "use default"
  - fix GetCuMaskDesc dropping the last contiguous CU run
  - use size_t loop index in GetStr to fix signed/unsigned comparison
- Add missing explicit STL includes that were previously resolved only through transient HIP/compiler headers

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
