### PR TITLE
Adding missing flush to gfxsweep preset

### DIFF
--- a/src/client/Presets/GfxSweep.hpp
+++ b/src/client/Presets/GfxSweep.hpp
@@ -159,7 +159,7 @@ int GfxSweepPreset(EnvVars&          ev,
               Utils::Print("  %1d  %c  %1d  %c  %1d  %c %4d %c %2d  %c  %1d  ",
                            waveOrder, sep, wordSize, sep,  temporalMode, sep,
                            blockSize, sep, unroll, sep, kernelIdx, sep);
-
+              fflush(stdout);
               for (auto s = 0; s < numSesList.size(); s++) {
                 int numSubExec = numSesList[s];
                 for (Transfer& t : transfers) t.numSubExecs = numSubExec;


### PR DESCRIPTION
Minor modification to make sure run configuration information is flushed to stdout.