### PR TITLE
revert clock check

### DIFF
--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -4333,20 +4333,6 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 #else
       ERR_CHECK(hipDeviceGetAttribute(&exeInfo.wallClockRate, hipDeviceAttributeWallClockRate,
                                       exeDevice.exeIndex));
-      // Check that GPU wallclock rate is non-zero
-      if (exeInfo.wallClockRate == 0) {
-        if (getenv("TB_WALLCLOCK_RATE")) {
-          exeInfo.wallClockRate = atoi(getenv("TB_WALLCLOCK_RATE"));
-          return {ERR_WARN,
-            "GPU %d wallclock rate query returned 0 unexpectedly.  Setting to %d instead as specified by TB_WALLCLOCK_RATE",
-            exeDevice.exeIndex, exeInfo.wallClockRate};
-        } else {
-          exeInfo.wallClockRate = 100000;
-          return {ERR_WARN,
-            "GPU %d wallclock rate query returned 0 unexpectedly.  Setting to %d instead.  Use TB_WALLCLOCK_RATE to customize",
-            exeDevice.exeIndex, exeInfo.wallClockRate};
-        }
-      }
 #endif
       int transferOffset = 0;
       if (cfg.gfx.useMultiStream || cfg.gfx.blockOrder == 0) {
@@ -4419,6 +4405,21 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 #else
       return {ERR_FATAL, "RDMA executor is not supported"};
 #endif
+    }
+
+    // Check that GPU wallclock rate is non-zero
+    if (exeDevice.exeType == EXE_GPU_GFX && exeInfo.wallClockRate == 0) {
+      if (getenv("TB_WALLCLOCK_RATE")) {
+        exeInfo.wallClockRate = atoi(getenv("TB_WALLCLOCK_RATE"));
+        return {ERR_WARN,
+          "GPU %d wallclock rate query returned 0 unexpectedly.  Setting to %d instead as specified by TB_WALLCLOCK_RATE",
+          exeDevice.exeIndex, exeInfo.wallClockRate};
+      } else {
+        exeInfo.wallClockRate = 100000;
+        return {ERR_WARN,
+          "GPU %d wallclock rate query returned 0 unexpectedly.  Setting to %d instead.  Use TB_WALLCLOCK_RATE to customize",
+          exeDevice.exeIndex, exeInfo.wallClockRate};
+      }
     }
 
     return ERR_NONE;


### PR DESCRIPTION
## Motivation

Previous modifications would cause GFX transfers return early when clockrate is 0. Reverting this change for now

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
