### PR TITLE
Adding TB_WALLCLOCK_RATE into hbmtest

### DIFF
--- a/src/client/Presets/HbmBandwidth.hpp
+++ b/src/client/Presets/HbmBandwidth.hpp
@@ -400,6 +400,18 @@ int HbmBandwidthPreset(EnvVars&          ev,
       wallClockRate = 1000000;
 #else
       HIP_CALL(hipDeviceGetAttribute(&wallClockRate, hipDeviceAttributeWallClockRate, gpuIdx));
+      // Check that GPU wallclock rate is non-zero
+      if (wallClockRate == 0) {
+        if (getenv("TB_WALLCLOCK_RATE")) {
+          wallClockRate = atoi(getenv("TB_WALLCLOCK_RATE"));
+          Utils::Print("GPU d wallclock rate query returned 0 unexpectedly.  Setting to %d instead as specified by TB_WALLCLOCK_RATE",
+                       gpuIdx, wallClockRate);
+        } else {
+          wallClockRate = 100000;
+          Utils::Print("GPU %d wallclock rate query returned 0 unexpectedly.  Setting to %d instead.  Use TB_WALLCLOCK_RATE to customize",
+                       gpuIdx, wallClockRate);
+        }
+      }
 #endif
       if (Utils::AllocateMemory({MEM_CPU_CLOSEST, gpuIdx, myRank}, sizeof(int64_t), (void**)&minStartCycle) ||
           Utils::AllocateMemory({MEM_CPU_CLOSEST, gpuIdx, myRank}, sizeof(int64_t), (void**)&maxStopCycle)) {

--- a/src/client/Presets/HbmBandwidth.hpp
+++ b/src/client/Presets/HbmBandwidth.hpp
@@ -404,7 +404,7 @@ int HbmBandwidthPreset(EnvVars&          ev,
       if (wallClockRate == 0) {
         if (getenv("TB_WALLCLOCK_RATE")) {
           wallClockRate = atoi(getenv("TB_WALLCLOCK_RATE"));
-          Utils::Print("GPU d wallclock rate query returned 0 unexpectedly.  Setting to %d instead as specified by TB_WALLCLOCK_RATE",
+          Utils::Print("GPU %d wallclock rate query returned 0 unexpectedly.  Setting to %d instead as specified by TB_WALLCLOCK_RATE",
                        gpuIdx, wallClockRate);
         } else {
           wallClockRate = 100000;


### PR DESCRIPTION
## Motivation
Adding default value for wallclock rate for hbmtest preset, as well as the same TB_WALLCLOCK_RATE behavior to override.