### PR TITLE
Enable no-src GPU SDMA transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Documentation for TransferBench is available at
 [https://rocm.docs.amd.com/projects/TransferBench](https://rocm.docs.amd.com/projects/TransferBench).
 
+## v1.69.00
+### Fixed
+- Fix for non-zero byte offsets used with DMA executor
+
 ## v1.68.00
 ### Fixed
 - Improper draining of writes that could artificially inflate transfer timing

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -259,7 +259,7 @@ void DisplayVersion()
 #ifndef TB_GIT_COMMIT
 #define TB_GIT_COMMIT "unknown"
 #endif
-  Print("TransferBench v%s.%s (%s:%s)%s%s\n", VERSION, CLIENT_VERSION, TB_GIT_BRANCH, TB_GIT_COMMIT, support.c_str(), multiNodeMode.c_str());
+  Print("TransferBench v%s.%sC (%s:%s)%s%s\n", VERSION, CLIENT_VERSION, TB_GIT_BRANCH, TB_GIT_COMMIT, support.c_str(), multiNodeMode.c_str());
   Print("=============================================================================================================\n");
 }
 

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -2327,12 +2327,20 @@ namespace {
         }
         break;
       case EXE_GPU_DMA:
-        if (t.srcs.size() != 1) {
+        if (t.srcs.size() > 1) {
           errors.push_back({ERR_FATAL,
-                            "Transfer %d: DMA executor must have exactly 1 source", i});
+                            "Transfer %d: DMA executor must have 0 or 1 sources", i});
           hasFatalError = true;
           break;
         }
+#if defined(__NVCC__)
+        if (t.srcs.empty()) {
+          errors.push_back({ERR_FATAL,
+                            "Transfer %d: DMA memset (0 sources) not supported on NVIDIA hardware", i});
+          hasFatalError = true;
+          break;
+        }
+#endif
         if (t.dsts.size() < 1) {
           errors.push_back({ERR_FATAL,
                             "Transfer %d: DMA executor must have at least 1 destination", i});
@@ -2355,6 +2363,12 @@ namespace {
           hasFatalError = true;
           break;
 #else
+          if (t.srcs.empty()) {
+            errors.push_back({ERR_FATAL,
+                              "Transfer %d: DMA memset (0 sources) does not support engine selection", i});
+            hasFatalError = true;
+            break;
+          }
           useSubIndexCount[t.exeDevice]++;
           int numSubIndices = GetNumExecutorSubIndices(t.exeDevice);
           if (t.exeSubIndex >= numSubIndices) {
@@ -2375,7 +2389,6 @@ namespace {
               hasFatalError = true;
               break;
             }
-
           }
 
           int numDsts = (int)t.dsts.size();
@@ -2414,22 +2427,24 @@ namespace {
 #endif
         }
 
-        if (!IsGpuMemType(t.srcs[0].memType) && !IsGpuMemType(t.dsts[0].memType)) {
-          errors.push_back({ERR_WARN,
-              "Transfer %d: No GPU memory for source or destination.  Copy might not execute on DMA %d",
-              i, t.exeDevice.exeIndex});
-        } else {
-          // Currently HIP will use src agent if source memory is GPU, otherwise dst agent
-          if (IsGpuMemType(t.srcs[0].memType)) {
-            if (t.srcs[0].memIndex != t.exeDevice.exeIndex) {
-              errors.push_back({ERR_WARN,
-                  "Transfer %d: DMA executor may automatically switch to using the source memory device (%d) not (%d)",
-                  i, t.srcs[0].memIndex, t.exeDevice.exeIndex});
-            }
-          } else if (t.dsts[0].memIndex != t.exeDevice.exeIndex) {
+        if (!t.srcs.empty()) {
+          if (!IsGpuMemType(t.srcs[0].memType) && !IsGpuMemType(t.dsts[0].memType)) {
             errors.push_back({ERR_WARN,
-                "Transfer %d: DMA executor may automatically switch to using the destination memory device (%d) not (%d)",
-                i, t.dsts[0].memIndex, t.exeDevice.exeIndex});
+                "Transfer %d: No GPU memory for source or destination.  Copy might not execute on DMA %d",
+                i, t.exeDevice.exeIndex});
+          } else {
+            // Currently HIP will use src agent if source memory is GPU, otherwise dst agent
+            if (IsGpuMemType(t.srcs[0].memType)) {
+              if (t.srcs[0].memIndex != t.exeDevice.exeIndex) {
+                errors.push_back({ERR_WARN,
+                    "Transfer %d: DMA executor may automatically switch to using the source memory device (%d) not (%d)",
+                    i, t.srcs[0].memIndex, t.exeDevice.exeIndex});
+              }
+            } else if (t.dsts[0].memIndex != t.exeDevice.exeIndex) {
+              errors.push_back({ERR_WARN,
+                  "Transfer %d: DMA executor may automatically switch to using the destination memory device (%d) not (%d)",
+                  i, t.dsts[0].memIndex, t.exeDevice.exeIndex});
+            }
           }
         }
         break;
@@ -4311,8 +4326,10 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
           rss.dstAgent[dstIdx] = info.agentOwner;
         }
 
-        ERR_CHECK(hsa_amd_pointer_info(rss.srcMem[0], &info, NULL, NULL, NULL));
-        rss.srcAgent = info.agentOwner;
+        if (!rss.srcMem.empty()) {
+          ERR_CHECK(hsa_amd_pointer_info(rss.srcMem[0], &info, NULL, NULL, NULL));
+          rss.srcAgent = info.agentOwner;
+        }
 
         // Create HSA completion signal
         ERR_CHECK(hsa_signal_create(1, 0, NULL, &rss.signal));
@@ -5508,8 +5525,21 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     ERR_CHECK(hipSetDevice(exeIndex));
     int subIterations = 0;
     size_t const initOffset = cfg.data.byteOffset / sizeof(float);
-    float* const src = resources.srcMem[0] + initOffset;
-    if (!useSubIndices && !cfg.dma.useHsaCopy) {
+    if (resources.srcMem.empty()) {
+      // DMA memset: fill each destination via LINEAR_FILL on SDMA DACC BE.
+      // count is in uint32_t units; value matches MEMSET_VAL byte pattern (0x4B4B4B4B).
+#if !defined(__NVCC__)
+      uint32_t fillVal;
+      float const f = MEMSET_VAL;
+      memcpy(&fillVal, &f, sizeof(fillVal));
+      size_t const count = resources.numBytes / sizeof(uint32_t);
+      do {
+        for (int dstIdx = 0; dstIdx < numDsts; dstIdx++)
+          ERR_CHECK(hsa_amd_memory_fill(resources.dstMem[dstIdx], fillVal, count));
+      } while (++subIterations != cfg.general.numSubIterations);
+#endif
+    } else if (!useSubIndices && !cfg.dma.useHsaCopy) {
+      float* const src = resources.srcMem[0] + initOffset;
       if (cfg.dma.useHipEvents)
         ERR_CHECK(hipEventRecord(startEvent, stream));
 
@@ -5541,6 +5571,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 #if defined(__NVCC__)
       return {ERR_FATAL, "HSA copy not supported on NVIDIA hardware"};
 #else
+      float* const src = resources.srcMem[0] + initOffset;
       // Use HSA async copy
       do {
         hsa_signal_store_screlease(resources.signal, numDsts);

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -5602,7 +5602,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 
     if (iteration >= 0) {
       double deltaMsec = cpuDeltaMsec;
-      if (!useSubIndices && !cfg.dma.useHsaCopy && cfg.dma.useHipEvents) {
+      if (!resources.srcMem.empty() && !useSubIndices && !cfg.dma.useHsaCopy && cfg.dma.useHipEvents) {
         float gpuDeltaMsec;
         ERR_CHECK(hipEventElapsedTime(&gpuDeltaMsec, startEvent, stopEvent));
         deltaMsec = gpuDeltaMsec / cfg.general.numSubIterations;

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -92,7 +92,7 @@ namespace TransferBench
   using std::set;
   using std::vector;
 
-  constexpr char VERSION[] = "1.68";
+  constexpr char VERSION[] = "1.69";
 
   /**
    * Enumeration of supported Executor types
@@ -5507,6 +5507,8 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     int numDsts = (int)resources.dstMem.size();
     ERR_CHECK(hipSetDevice(exeIndex));
     int subIterations = 0;
+    size_t const initOffset = cfg.data.byteOffset / sizeof(float);
+    float* const src = resources.srcMem[0] + initOffset;
     if (!useSubIndices && !cfg.dma.useHsaCopy) {
       if (cfg.dma.useHipEvents)
         ERR_CHECK(hipEventRecord(startEvent, stream));
@@ -5520,12 +5522,13 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       do {
         // Queue for each output location
         for (int dstIdx = 0; dstIdx < numDsts; dstIdx++) {
+          float* const dst = resources.dstMem[dstIdx] + initOffset;
 #if defined(CUMEM_ENABLED)
-          ERR_CHECK(cuMemcpyAsync((CUdeviceptr)resources.dstMem[dstIdx],
-                                  (CUdeviceptr)resources.srcMem[0],
+          ERR_CHECK(cuMemcpyAsync((CUdeviceptr)dst,
+                                  (CUdeviceptr)src,
                                   resources.numBytes, stream));
 #else
-          ERR_CHECK(hipMemcpyAsync(resources.dstMem[dstIdx], resources.srcMem[0], resources.numBytes,
+          ERR_CHECK(hipMemcpyAsync(dst, src, resources.numBytes,
                                    memcpyKind, stream));
 #endif
         }
@@ -5542,14 +5545,15 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       do {
         hsa_signal_store_screlease(resources.signal, numDsts);
         for (int dstIdx = 0; dstIdx < numDsts; dstIdx++) {
+          float* const dst = resources.dstMem[dstIdx] + initOffset;
           if (!useSubIndices) {
-            ERR_CHECK(hsa_amd_memory_async_copy(resources.dstMem[dstIdx], resources.dstAgent[dstIdx],
-                                                resources.srcMem[0], resources.srcAgent,
+            ERR_CHECK(hsa_amd_memory_async_copy(dst, resources.dstAgent[dstIdx],
+                                                src, resources.srcAgent,
                                                 resources.numBytes, 0, NULL,
                                                 resources.signal));
           } else {
-            HSA_CALL(hsa_amd_memory_async_copy_on_engine(resources.dstMem[dstIdx], resources.dstAgent[dstIdx],
-                                                         resources.srcMem[0], resources.srcAgent,
+            HSA_CALL(hsa_amd_memory_async_copy_on_engine(dst, resources.dstAgent[dstIdx],
+                                                         src, resources.srcAgent,
                                                          resources.numBytes, 0, NULL,
                                                          resources.signal,
                                                          resources.sdmaEngineId, true));


### PR DESCRIPTION
## Motivation

Extends EXE_GPU_DMA to accept zero-source transfers, enabling SDMA-driven memset without introducing a new executor type.

## Technical Details

Fill value:
```
uint32_t fillVal = bit_cast<uint32_t>(MEMSET_VAL);  // 0x4B4B4B4B
count = numBytes / sizeof(uint32_t);  // count is in uint32_t units
```
`0x4B4B4B4B` matches both memset(MEMSET_CHAR) (used by dstReference[0]) and MemsetVal<float>() used by the GFX 0-src kernel, so existing correctness validation passes without changes.

Validation:
- `srcs.size() != 1 → srcs.size() > 1`; 0 sources now valid on AMD
- 0-src + `exeSubIndex != -1` results in fatal error
- Copy-agent-selection warnings wrapped in `if (!t.srcs.empty())`

Resource setup:
- `hsa_amd_pointer_info` on `srcMem[0]` guarded by `!rss.srcMem.empty()`

Constraints:
- AMD only. NVIDIA builds get a fatal error for 0-src DMA transfers.
- No engine selection as `hsa_amd_memory_fill` has no engine parameter/mask, so combining 0 sources with an engine subindex (e.g., `n d0.2 g1`) is rejected at validation.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
