### PR TITLE
Skip set_mempolicy for phantom NUMA nodes

### DIFF
--- a/src/client/Topology.hpp
+++ b/src/client/Topology.hpp
@@ -86,7 +86,13 @@ void DisplaySingleRankTopology(bool outputToCsv)
   } else {
     printf("\nDetected Topology:\n");
     printf("==================\n");
-    printf("  %d configured CPU NUMA node(s) [%d total]\n", numCpus, numa_max_node() + 1);
+    int numCpusTotal = numa_max_node() + 1;
+    int numPhantom   = numCpusTotal - numCpus;
+    if (numPhantom > 0)
+      printf("  %d configured CPU NUMA node(s) [%d total; detected %d phantom NUMA node(s) with no memory/CPU]\n",
+             numCpus, numCpusTotal, numPhantom);
+    else
+      printf("  %d configured CPU NUMA node(s) [%d total]\n", numCpus, numCpusTotal);
     printf("  %d GPU device(s)\n", numGpus);
     printf("  %d Supported NIC device(s)\n", numNics);
   }

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1548,7 +1548,10 @@ namespace {
     if (IsCpuMemType(memType)) {
 
       // Set NUMA policy prior to call to hipHostMalloc
-      numa_set_preferred(deviceIdx);
+      // Skip memory-less NUMA nodes to avoid set_mempolicy EINVAL
+      if (deviceIdx < 0 || numa_bitmask_isbitset(numa_get_mems_allowed(), deviceIdx)) {
+        numa_set_preferred(deviceIdx);
+      }
 
       // Allocate host-pinned memory (should respect NUMA mem policy)
       int flags = 0;

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -7219,11 +7219,6 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     int numCpus = numa_bitmask_weight(numa_get_mems_allowed());
     topo.numExecutors[EXE_CPU] = numCpus;
 
-    if (numCpus < numCpusConfigured)
-      printf("[INFO] Detected %d phantom NUMA node(s) with no memory/CPU; "
-             "limiting CPU executors to %d node(s) with memory\n",
-             numCpusConfigured - numCpus, numCpus);
-
     std::string cpuName = GetCpuName();
 
     for (int exeIndex = 0; exeIndex < numCpus; exeIndex++) {

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -7212,9 +7212,17 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     // Collect Pod membership
     CollectPodMembership(topo.ppodId, topo.vpodId);
 
-    // CPU Executor
-    int numCpus = numa_num_configured_nodes();
+    // CPU Executor — limit to NUMA nodes that have real memory backing.
+    // Phantom nodes (e.g. MNNVL fabric nodes) are present in numa_num_configured_nodes()
+    // but have no memory, causing set_mempolicy EINVAL when probed.
+    int numCpusConfigured = numa_num_configured_nodes();
+    int numCpus = numa_bitmask_weight(numa_get_mems_allowed());
     topo.numExecutors[EXE_CPU] = numCpus;
+
+    if (numCpus < numCpusConfigured)
+      printf("[INFO] Detected %d phantom NUMA node(s) with no memory/CPU; "
+             "limiting CPU executors to %d node(s) with memory\n",
+             numCpusConfigured - numCpus, numCpus);
 
     std::string cpuName = GetCpuName();
 
@@ -7224,7 +7232,9 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
 
     for (int cpuCore = 0; cpuCore < numa_num_configured_cpus(); cpuCore++) {
-      topo.numSubExecutors[{EXE_CPU, numa_node_of_cpu(cpuCore)}]++;
+      int node = numa_node_of_cpu(cpuCore);
+      if (numa_bitmask_isbitset(numa_get_mems_allowed(), node))
+        topo.numSubExecutors[{EXE_CPU, node}]++;
     }
 
     if (verbose) {
@@ -7753,11 +7763,11 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       ErrResult err;
       int32_t* tempBuffer;
 
-      // Index CPU agents
+      // Index CPU agents — only probe NUMA nodes with real memory backing
       cpuAgents.clear();
-      int numCpus = numa_num_configured_nodes();
-      for (int i = 0; i < numCpus; i++) {
-        AllocateMemory({MEM_CPU, i}, 1024, (void**)&tempBuffer);
+      for (int node = 0; node <= numa_max_node(); node++) {
+        if (!numa_bitmask_isbitset(numa_get_mems_allowed(), node)) continue;
+        AllocateMemory({MEM_CPU, node}, 1024, (void**)&tempBuffer);
         hsa_amd_pointer_info(tempBuffer, &info, NULL, NULL, NULL);
         cpuAgents.push_back(info.agentOwner);
         DeallocateMemory(MEM_CPU, tempBuffer, 1024);

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -7215,7 +7215,6 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     // CPU Executor — limit to NUMA nodes that have real memory backing.
     // Phantom nodes (e.g. MNNVL fabric nodes) are present in numa_num_configured_nodes()
     // but have no memory, causing set_mempolicy EINVAL when probed.
-    int numCpusConfigured = numa_num_configured_nodes();
     int numCpus = numa_bitmask_weight(numa_get_mems_allowed());
     topo.numExecutors[EXE_CPU] = numCpus;
 

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1548,10 +1548,7 @@ namespace {
     if (IsCpuMemType(memType)) {
 
       // Set NUMA policy prior to call to hipHostMalloc
-      // Skip memory-less NUMA nodes to avoid set_mempolicy EINVAL
-      if (deviceIdx < 0 || numa_bitmask_isbitset(numa_get_mems_allowed(), deviceIdx)) {
-        numa_set_preferred(deviceIdx);
-      }
+      numa_set_preferred(deviceIdx);
 
       // Allocate host-pinned memory (should respect NUMA mem policy)
       int flags = 0;


### PR DESCRIPTION
## Motivation

Fix set_mempolicy EINVAL for memory-less NUMA nodes during topology init

## Technical Details

CollectTopology() probes each NUMA node by allocating a small buffer, which calls `numa_set_preferred(i)` for all `numa_num_configured_nodes()`. If some nodes have no memory backing, `set_mempolicy(MPOL_PREFERRED)` returns **EINVAL** for them.

Guard the call with `numa_get_mems_allowed()` so only nodes with real memory get a preferred policy set.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
