### PR TITLE
[ROCM-24669] pkg: drop hsa-rocr dep, warn at install time instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,7 +360,7 @@ if(BUILD_RELOCATABLE_PACKAGE)
   # DEB
   set(CPACK_DEBIAN_PACKAGE_NAME       "${CPACK_PACKAGE_NAME}")
   set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS    "numactl, libnuma1, hsa-rocr")
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS    "numactl, libnuma1")
   set(CPACK_DEBIAN_PACKAGE_MAINTAINER "${CPACK_PACKAGE_CONTACT}")
   if(NOT "${_tb_pkg_release}" STREQUAL "")
     set(CPACK_DEBIAN_PACKAGE_RELEASE "${_tb_pkg_release}")
@@ -373,7 +373,7 @@ if(BUILD_RELOCATABLE_PACKAGE)
   # RPM
   set(CPACK_RPM_PACKAGE_NAME    "${CPACK_PACKAGE_NAME}")
   set(CPACK_RPM_PACKAGE_LICENSE "MIT")
-  set(CPACK_RPM_PACKAGE_REQUIRES "numactl, hsa-rocr")
+  set(CPACK_RPM_PACKAGE_REQUIRES "numactl")
   set(CPACK_RPM_PACKAGE_VENDOR  "${CPACK_PACKAGE_VENDOR}")
   if(NOT "${_tb_pkg_release}" STREQUAL "")
     set(CPACK_RPM_PACKAGE_RELEASE "${_tb_pkg_release}")
@@ -393,6 +393,17 @@ if(BUILD_RELOCATABLE_PACKAGE)
         "/opt" "/opt/rocm"
         "${_rpm_exclude_prefix}"
         "${_rpm_exclude_prefix}/bin")
+
+  # Advisory install-time check for libhsa-runtime64.so.1. The package declares
+  # no hard ROCm dep so it can install on TheRock-tarball systems where no ROCm
+  # component is tracked by apt/dpkg; the postinst warns (never fails) when the
+  # HSA runtime is not discoverable, so a missing runtime surfaces at install
+  # time instead of as a dynamic-linker error on first invocation.
+  set(_tb_postinst_src "${CMAKE_CURRENT_SOURCE_DIR}/packaging/postinst-check-hsa.sh")
+  set(_tb_postinst_deb "${CMAKE_BINARY_DIR}/packaging/postinst")
+  configure_file("${_tb_postinst_src}" "${_tb_postinst_deb}" COPYONLY)
+  set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${_tb_postinst_deb}")
+  set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${_tb_postinst_src}")
 
   # TGZ — embed release tag so successive runs do not collide on the same key.
   # CMake 3.13+ honors CPACK_ARCHIVE_FILE_NAME for archive generators, but
@@ -414,7 +425,7 @@ else()
   rocm_setup_version(VERSION ${VERSION_STRING})
 
   # Package specific CPACK vars
-  rocm_package_add_dependencies(DEPENDS "numactl" "hsa-rocr")
+  rocm_package_add_dependencies(DEPENDS "numactl")
 
   set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md")
   set(CPACK_RPM_PACKAGE_LICENSE "MIT")

--- a/packaging/postinst-check-hsa.sh
+++ b/packaging/postinst-check-hsa.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Advisory check used as both the DEB postinst and the RPM %post scriptlet.
+# TransferBench links against libhsa-runtime64.so.1; without it the binary
+# fails at first run with a dynamic-linker error. The relocatable package
+# declares no hard dep on hsa-rocr (or any ROCm component) because it is
+# expected to install on TheRock-tarball systems where no ROCm package is
+# tracked by apt/dpkg. Warn here so the user diagnoses a missing runtime
+# at install time, not at TransferBench launch.
+#
+# Always exits 0 — this is advisory, never fatal.
+
+set -e
+
+found=0
+
+if command -v ldconfig >/dev/null 2>&1; then
+    if ldconfig -p 2>/dev/null | grep -q 'libhsa-runtime64\.so\.1'; then
+        found=1
+    fi
+fi
+
+if [ "$found" -eq 0 ]; then
+    for d in /opt/rocm/lib /opt/rocm/lib64 /opt/rocm-*/lib /opt/rocm/extras-*/lib /opt/rocm/core-*/lib; do
+        if [ -e "$d/libhsa-runtime64.so.1" ]; then
+            found=1
+            break
+        fi
+    done
+fi
+
+if [ "$found" -eq 0 ]; then
+    cat >&2 <<'EOF'
+====================================================================
+TransferBench: WARNING
+
+libhsa-runtime64.so.1 was not found on the dynamic loader path or
+under any of /opt/rocm/lib, /opt/rocm-*/lib, or /opt/rocm/extras-*/lib.
+
+TransferBench requires the ROCm HSA runtime at run time. Install a
+ROCm 7.x stack (system packages or TheRock SDK) before invoking
+TransferBench, or set LD_LIBRARY_PATH to a directory containing
+libhsa-runtime64.so.1.
+
+Without it, TransferBench will fail at startup with:
+    error while loading shared libraries: libhsa-runtime64.so.1
+====================================================================
+EOF
+fi
+
+exit 0


### PR DESCRIPTION
Fixes ROCM-24669 — `amdrocm7-transferbench` DEB/RPM declares a hard dependency on `hsa-rocr`, which ROCm 7.13 no longer ships. Install fails on TheRock 7.13 with `Package hsa-rocr is not configured yet`.

## Summary
- Drop the hard `hsa-rocr` dep from `CPACK_DEBIAN_PACKAGE_DEPENDS`, `CPACK_RPM_PACKAGE_REQUIRES`, and the legacy `rocm_package_add_dependencies` call. The dep was wrong for the relocatable artifact in general — it ships against the TheRock SDK and is meant to install on systems where ROCm came from a tarball and is not tracked by apt/dpkg at all.
- Add `packaging/postinst-check-hsa.sh` and wire it as both the DEB postinst (via `CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA`) and the RPM `%post` (via `CPACK_RPM_POST_INSTALL_SCRIPT_FILE`). It probes `ldconfig` and the standard `/opt/rocm{,-*,/extras-*,/core-*}/lib` prefixes for `libhsa-runtime64.so.1` and prints a stderr warning when none have it. Always exits 0 — install never fails on its account; the warning surfaces a missing runtime at install time instead of as a confusing dynamic-linker error on first invocation.
- `numactl` / `libnuma1` stay in the dep list since those are real OS packages that exist independent of any ROCm install.

## Behavior matrix
| Scenario | Before | After |
|---|---|---|
| TheRock tarball under `/opt/rocm/*` | install **fails** (`hsa-rocr` not in dpkg) | install succeeds, no warning |
| System apt ROCm with `hsa-rocr` installed | install succeeds | install succeeds, no warning |
| Bare system, no ROCm anywhere | install fails | install **succeeds** with WARNING block to stderr; runtime linker error on first run if user never installs ROCm |

## Test plan
- [ ] CI relocatable build passes on Ubuntu 22.04 (DEB) and manylinux_2_28 (RPM).
- [ ] Inspect the produced DEB: `dpkg-deb -I amdrocm7-transferbench_*.deb` shows `Depends: numactl, libnuma1` (no `hsa-rocr`) and lists a `postinst` in the control archive.
- [ ] Inspect the produced RPM: `rpm -qp --requires amdrocm7-transferbench-*.rpm` shows only `numactl` (no `hsa-rocr`); `rpm -qp --scripts` shows the `%post` body.
- [ ] Install the DEB on the original ROCm 7.13 / TheRock repro box from the ticket and confirm `dpkg -i` configures cleanly and `TransferBench` launches.
- [ ] Install the DEB on a bare Ubuntu container with no ROCm and confirm the install succeeds with the warning visible on stderr.

[ROCM-24669]: https://amd-hub.atlassian.net/browse/ROCM-24669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ