### PR TITLE
option to use hipExtLaunch, add empty batch support

### DIFF
--- a/src/client/Presets/EmptyKernel.hpp
+++ b/src/client/Presets/EmptyKernel.hpp
@@ -64,6 +64,7 @@ static void inline EmptyKernelRunBatch(int         const batchSize,
 // Event timing for one batch: CUDA uses explicit record/stop around <<<>>>; HIP uses
 // hipExtLaunchKernelGGL with start on the first launch and stop on the last
 static void inline EmptyKernelRunBatchEvtOnly(int         const batchSize,
+                                              int         const useExtLaunch,
                                               int         const gridX,
                                               int         const blockX,
                                               hipStream_t const stream,
@@ -75,10 +76,22 @@ static void inline EmptyKernelRunBatchEvtOnly(int         const batchSize,
   EmptyKernelRunBatch(batchSize, gridX, blockX, stream);
   HIP_CALL(hipEventRecord(stopEvent, stream));
 #else
-  for (int i = 0; i < batchSize; i++) {
-    hipExtLaunchKernelGGL(EmptyKernelDeviceKernel, gridX, blockX, 0, stream,
-                          (i ==           0) ? startEvent : NULL,
-                          (i == batchSize-1) ?  stopEvent : NULL, 0);
+  if (batchSize == 0)
+  {
+     HIP_CALL(hipEventRecord(startEvent, stream));
+     HIP_CALL(hipEventRecord(stopEvent, stream));
+  } else {
+    if (useExtLaunch) {
+      for (int i = 0; i < batchSize; i++) {
+        hipExtLaunchKernelGGL(EmptyKernelDeviceKernel, gridX, blockX, 0, stream,
+                              (i ==           0) ? startEvent : NULL,
+                              (i == batchSize-1) ?  stopEvent : NULL, 0);
+      }
+    } else {
+      HIP_CALL(hipEventRecord(startEvent, stream));
+      EmptyKernelRunBatch(batchSize, gridX, blockX, stream);
+      HIP_CALL(hipEventRecord(stopEvent, stream));
+    }
   }
 #endif
 }
@@ -99,11 +112,19 @@ int EmptyKernelPreset(EnvVars&          ev,
   int const myRank   = GetRank();
 
   int numDetectedGpus = TransferBench::GetNumExecutors(EXE_GPU_GFX);
-  int numGpuDevices   = EnvVars::GetEnvVar("NUM_GPU_DEVICES", numDetectedGpus);
-  int numIterations   = EnvVars::GetEnvVar("NUM_ITERATIONS", 5);
   int numSubExec      = TransferBench::GetNumSubExecutors({EXE_GPU_GFX, 0});
 
-  std::vector<int> batchSizes = EnvVars::GetEnvVarArray("BATCHSIZES", {1, 16, 256});
+#if defined(__NVCC__)
+  int defaultExtLaunch = 0;
+#else
+  int defaultExtLaunch = 1;
+#endif
+
+  // Collect env vars
+  int numGpuDevices   = EnvVars::GetEnvVar("NUM_GPU_DEVICES", numDetectedGpus);
+  int numIterations   = EnvVars::GetEnvVar("NUM_ITERATIONS",                5);
+  int useExtLaunch    = EnvVars::GetEnvVar("USE_EXT_LAUNCH", defaultExtLaunch);
+  std::vector<int> batchSizes = EnvVars::GetEnvVarArray("BATCHSIZES", {0, 1, 16, 256});
   std::vector<int> gridSizes  = EnvVars::GetEnvVarArray("GRIDSIZES",  {numSubExec});
   std::vector<int> blockSizes = EnvVars::GetEnvVarArray("BLOCKSIZES", {256});
 
@@ -122,9 +143,11 @@ int EmptyKernelPreset(EnvVars&          ev,
     ev.Print("NUM_WARMUPS",     ev.numWarmups,     "Untimed warmup iterations");
     ev.Print("OUTPUT_TO_CSV",   ev.outputToCsv,    "CSV formatting for result table");
     ev.Print("SHOW_ITERATIONS", ev.showIterations, "Show per-iteration EVT/CPU columns before MIN/AVG/MAX");
+    ev.Print("USE_EXT_LAUNCH",  useExtLaunch,      "Use hipExtLaunchKernelGGL to combine hipEvents with kernel launch");
     Utils::Print("\n");
   }
 
+  // Check that input parameters are uniform across all ranks
   IS_UNIFORM(batchSizes,        "BATCHSIZES");
   IS_UNIFORM(gridSizes,         "GRIDSIZES");
   IS_UNIFORM(blockSizes,        "BLOCKSIZES");
@@ -132,14 +155,15 @@ int EmptyKernelPreset(EnvVars&          ev,
   IS_UNIFORM(numIterations,     "NUM_ITERATIONS");
   IS_UNIFORM(ev.numWarmups,     "NUM_WARMUPS");
   IS_UNIFORM(ev.showIterations, "SHOW_ITERATIONS");
+  IS_UNIFORM(useExtLaunch,      "USE_EXT_LAUNCH");
 
   if (batchSizes.empty()) {
     Utils::Print("[ERROR] BATCHSIZES may not be empty\n");
     return ERR_FATAL;
   }
   for (int b : batchSizes) {
-    if (b < 1) {
-      Utils::Print("[ERROR] BATCHSIZES entries must be >= 1 (got %d)\n", b);
+    if (b < 0) {
+      Utils::Print("[ERROR] BATCHSIZES entries must be >= 0 (got %d)\n", b);
       return ERR_FATAL;
     }
   }
@@ -179,6 +203,13 @@ int EmptyKernelPreset(EnvVars&          ev,
     Utils::Print("[ERROR] NUM_WARMUPS must be non-negative (got %d)\n", ev.numWarmups);
     return ERR_FATAL;
   }
+
+#if defined(__NVCC__)
+  if (useExtLaunch) {
+    Utils::Print("[ERROR] USE_EXT_LAUNCH is not supported on NVIDIA hardware\n");
+    return ERR_FATAL;
+  }
+#endif
 
   char const sep = ev.outputToCsv ? ',' : ' ';
 
@@ -227,17 +258,17 @@ int EmptyKernelPreset(EnvVars&          ev,
           HIP_CALL(hipSetDevice(gpu));
           for (int iteration = -ev.numWarmups; iteration < numIterations; iteration++) {
 
-            EmptyKernelRunBatchEvtOnly(batchSize, gridSize, blockSize, stream[gpu], startEvent[gpu], stopEvent[gpu]);
+            EmptyKernelRunBatchEvtOnly(batchSize, useExtLaunch, gridSize, blockSize, stream[gpu], startEvent[gpu], stopEvent[gpu]);
             HIP_CALL(hipStreamSynchronize(stream[gpu]));
             float elapsedMsec = 0.0f;
             HIP_CALL(hipEventElapsedTime(&elapsedMsec, startEvent[gpu], stopEvent[gpu]));
-            double const evtUsec = static_cast<double>(elapsedMsec) * 1000.0 / batchSize;
+            double const evtUsec = static_cast<double>(elapsedMsec) * 1000.0 / (batchSize == 0 ? 1 : batchSize);
 
             auto const t0 = std::chrono::steady_clock::now();
             EmptyKernelRunBatch(batchSize, gridSize, blockSize, stream[gpu]);
             HIP_CALL(hipStreamSynchronize(stream[gpu]));
             auto const t1 = std::chrono::steady_clock::now();
-            double const cpuUsec = std::chrono::duration<double, std::micro>(t1 - t0).count() / batchSize;
+            double const cpuUsec = std::chrono::duration<double, std::micro>(t1 - t0).count() / (batchSize == 0 ? 1 : batchSize);
 
             if (iteration >= 0) {
               results[gpu][iteration]               = evtUsec;


### PR DESCRIPTION
## Motivation
Add USE_EXT_LAUNCH to quantify the difference in launch latency when using the traditional kernel sandwiched between two hipEvents, vs the use of hipExtLaunch which allows for the hipEvents to be passed in alongside the kernel AQL packet.

Also add the ability to run with batch size of zero, to understand the base-line timing impact of not even launching any kernel at all.
