### PR TITLE
Fix memory allocation bug to use the correct hipDevice

### DIFF
--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1499,9 +1499,9 @@ namespace {
       // Set NUMA policy prior to call to hipHostMalloc
       numa_set_preferred(deviceIdx);
     } else if (IsGpuMemType(memType)) {
-      // Switch to the appropriate GPU — use memDevice.memIndex directly since
-      // the MEM_CPU_CLOSEST NUMA remapping above only applies to CPU types
-      ERR_CHECK(hipSetDevice(memDevice.memIndex));
+      // Switch to the appropriate GPU
+      // IMP: if the remapping above changes, remember to modify this!
+      ERR_CHECK(hipSetDevice(deviceIdx));
     }
 
     // If memHandle is provided, allocate sharable memory
@@ -7788,7 +7788,6 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       gpuAgents.clear();
       char *tempBuffer;
       for (int i = 0; i < numGpus; i++) {
-        if (hipSetDevice(i) != hipSuccess) continue;
         AllocateMemory({MEM_GPU, i}, 1024, (void**)&tempBuffer);
         hsa_amd_pointer_info(tempBuffer, &info, NULL, NULL, NULL);
         gpuAgents.push_back(info.agentOwner);

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1499,8 +1499,9 @@ namespace {
       // Set NUMA policy prior to call to hipHostMalloc
       numa_set_preferred(deviceIdx);
     } else if (IsGpuMemType(memType)) {
-      // Switch to the appropriate GPU
-      ERR_CHECK(hipSetDevice(deviceIdx));
+      // Switch to the appropriate GPU — use memDevice.memIndex directly since
+      // the MEM_CPU_CLOSEST NUMA remapping above only applies to CPU types
+      ERR_CHECK(hipSetDevice(memDevice.memIndex));
     }
 
     // If memHandle is provided, allocate sharable memory
@@ -1542,12 +1543,12 @@ namespace {
         ERR_CHECK(CheckPages((char*)*memPtr, roundedUpBytes, deviceIdx));
         numa_set_preferred(-1);
       } else if (IsGpuMemType(memType)) {
-        ERR_CHECK(hipSetDevice(memDevice.memIndex));
         ERR_CHECK(hipMemset(*memPtr, 0, numBytes));
         ERR_CHECK(hipDeviceSynchronize());
       }
       return ERR_NONE;
 #else
+      if (IsCpuMemType(memType)) numa_set_preferred(-1);
       return {ERR_FATAL, "Unable to allocate sharable memory if not compiled with pod communication support"};
 #endif
     } else {
@@ -7787,6 +7788,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       gpuAgents.clear();
       char *tempBuffer;
       for (int i = 0; i < numGpus; i++) {
+        if (hipSetDevice(i) != hipSuccess) continue;
         AllocateMemory({MEM_GPU, i}, 1024, (void**)&tempBuffer);
         hsa_amd_pointer_info(tempBuffer, &info, NULL, NULL, NULL);
         gpuAgents.push_back(info.agentOwner);

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -1495,6 +1495,14 @@ namespace {
       deviceIdx = GetClosestCpuNumaToGpu(memDevice.memIndex);
     }
 
+    if (IsCpuMemType(memType)) {
+      // Set NUMA policy prior to call to hipHostMalloc
+      numa_set_preferred(deviceIdx);
+    } else if (IsGpuMemType(memType)) {
+      // Switch to the appropriate GPU
+      ERR_CHECK(hipSetDevice(deviceIdx));
+    }
+
     // If memHandle is provided, allocate sharable memory
     if (memHandle != NULL) {
 #ifdef POD_COMM_ENABLED
@@ -1532,6 +1540,7 @@ namespace {
         memset(*memPtr, 0, roundedUpBytes);
         // Check that the allocated pages are actually on the correct NUMA node
         ERR_CHECK(CheckPages((char*)*memPtr, roundedUpBytes, deviceIdx));
+        numa_set_preferred(-1);
       } else if (IsGpuMemType(memType)) {
         ERR_CHECK(hipSetDevice(memDevice.memIndex));
         ERR_CHECK(hipMemset(*memPtr, 0, numBytes));
@@ -1546,9 +1555,6 @@ namespace {
     }
 
     if (IsCpuMemType(memType)) {
-
-      // Set NUMA policy prior to call to hipHostMalloc
-      numa_set_preferred(deviceIdx);
 
       // Allocate host-pinned memory (should respect NUMA mem policy)
       int flags = 0;
@@ -1590,8 +1596,6 @@ namespace {
       // Reset to default numa mem policy
       numa_set_preferred(-1);
     } else if (IsGpuMemType(memType)) {
-      // Switch to the appropriate GPU
-      ERR_CHECK(hipSetDevice(memDevice.memIndex));
 
       if (memType == MEM_GPU) {
         // Allocate GPU memory on appropriate device


### PR DESCRIPTION
## Motivation

Not using hipSetDevice before allocating memory can use an unintended deviceIdx when executing fabric-handle-based transfers

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
