### PR TITLE
[ci] Run build pipeline on candidate without publishing artifacts/packages

### DIFF
--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -75,6 +75,7 @@ jobs:
           done
 
       - name: Upload artifacts (always, for inspection)
+        if: github.ref_name != 'candidate' && github.base_ref != 'candidate'
         uses: actions/upload-artifact@v4
         with:
           name: ubuntu-22.04-packages
@@ -184,6 +185,7 @@ jobs:
           done
 
       - name: Upload artifacts (always, for inspection)
+        if: github.ref_name != 'candidate' && github.base_ref != 'candidate'
         uses: actions/upload-artifact@v4
         with:
           name: manylinux_2_28-packages

--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -2,9 +2,9 @@ name: Build Relocatable Packages
 
 on:
   push:
-    branches: [develop, mainline, 'release/**', candidate]
+    branches: [candidate, develop, mainline, 'release/**']
   pull_request:
-    branches: [develop, mainline]
+    branches: [candidate, develop, mainline]
   schedule:
     # Daily at 13:00 UTC (5:00 AM PST)
     - cron: '0 13 * * *'
@@ -84,14 +84,14 @@ jobs:
           if-no-files-found: error
 
       - name: Configure AWS credentials (OIDC)
-        if: github.repository == 'ROCm/TransferBench' && vars.AWS_S3_BUCKET != ''
+        if: github.repository == 'ROCm/TransferBench' && vars.AWS_S3_BUCKET != '' && github.ref_name != 'candidate' && github.base_ref != 'candidate'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Upload to S3
-        if: github.repository == 'ROCm/TransferBench' && vars.AWS_S3_BUCKET != ''
+        if: github.repository == 'ROCm/TransferBench' && vars.AWS_S3_BUCKET != '' && github.ref_name != 'candidate' && github.base_ref != 'candidate'
         env:
           AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
         run: |
@@ -193,20 +193,20 @@ jobs:
           if-no-files-found: error
 
       - name: Install AWS CLI
-        if: github.repository == 'ROCm/TransferBench' && vars.AWS_S3_BUCKET != ''
+        if: github.repository == 'ROCm/TransferBench' && vars.AWS_S3_BUCKET != '' && github.ref_name != 'candidate' && github.base_ref != 'candidate'
         run: |
           curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscli.zip
           (cd /tmp && unzip -q awscli.zip && ./aws/install)
 
       - name: Configure AWS credentials (OIDC)
-        if: github.repository == 'ROCm/TransferBench' && vars.AWS_S3_BUCKET != ''
+        if: github.repository == 'ROCm/TransferBench' && vars.AWS_S3_BUCKET != '' && github.ref_name != 'candidate' && github.base_ref != 'candidate'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Upload to S3
-        if: github.repository == 'ROCm/TransferBench' && vars.AWS_S3_BUCKET != ''
+        if: github.repository == 'ROCm/TransferBench' && vars.AWS_S3_BUCKET != '' && github.ref_name != 'candidate' && github.base_ref != 'candidate'
         env:
           AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
         run: |

--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -74,7 +74,7 @@ jobs:
             dpkg-deb -c "${deb}" | head -50
           done
 
-      - name: Upload artifacts (always, for inspection)
+      - name: Upload artifacts
         if: github.ref_name != 'candidate' && github.base_ref != 'candidate'
         uses: actions/upload-artifact@v4
         with:
@@ -184,7 +184,7 @@ jobs:
             rpm -qlp "${rpm}" | head -50
           done
 
-      - name: Upload artifacts (always, for inspection)
+      - name: Upload artifacts
         if: github.ref_name != 'candidate' && github.base_ref != 'candidate'
         uses: actions/upload-artifact@v4
         with:
@@ -297,6 +297,7 @@ jobs:
           cat report/build-report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload report
+        if: github.ref_name != 'candidate' && github.base_ref != 'candidate'
         uses: actions/upload-artifact@v4
         with:
           name: build-report

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,11 +3,12 @@ name: "CodeQL Security Scanning"
 on:
   push:
     branches:
+      - candidate
       - develop
       - mainline
-      - candidate
   pull_request:
     branches:
+      - candidate
       - develop
       - mainline
   schedule:


### PR DESCRIPTION
## Motivation

Add `candidate` to PR triggers so pushes and PRs run the full build pipeline. Gate all artifact and S3 upload steps so no artifacts/packages are published until `candidate` is promoted to `develop`.

## Technical Details

- Add `candidate` to `pull_request` branch triggers so PRs against it run the full build pipeline
- Gate all artifact and S3 upload steps. Builds still run for every push/PR to `candidate`; artifacts and packages are never published.
- PRs from `candidate` to `develop` will trigger build + artifact/package upload.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
