### PR TITLE
removing secondary reordering

### DIFF
--- a/src/client/Presets/PodAllToAll.hpp
+++ b/src/client/Presets/PodAllToAll.hpp
@@ -154,15 +154,16 @@ int PodAllToAllPreset(EnvVars&          ev,
       return ERR_FATAL;
     }
     int groupSize = n / numGroups;
-    std::vector<MemDevice> devices(n);
     std::vector<int> indices(n);
     for (int k = 0; k < n; k++) indices[k] = k;
     Utils::StrideGenerate(indices, groupStride);
-    int idx = 0;
-    for (int rank : ranks) {
-      for (int devIdx = 0; devIdx < numGpus; devIdx++) {
-        devices[indices[idx++]] = {memType, devIdx, rank};
-      }
+
+    std::vector<MemDevice> devices(n);
+    for (int i = 0; i < n; i++) {
+      int const globalIdx = indices[i];
+      int const rankIdx   = globalIdx / numGpus;
+      int const devIdx    = globalIdx % numGpus;
+      devices[i] = {memType, devIdx, ranks[rankIdx]};
     }
 
     // Build transfers for every group, then run once per pod so all groups share the same


### PR DESCRIPTION
## Motivation

Quick fix for missed grouping change

## Technical Details

Grouping should be based directly on `StrideGenerate` output, previous vestige of a second layer of reordering is in `poda2a` and caused wrong grouping results.
## Test Plan

Example: 
With 3 nodes, each with 4 devices, NUM_GROUPS=4, GROUP_STRIDE=4 should result in
[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] => [0, 4, 8, 1, 5, 9, 2, 6, 10, 3, 7, 11] => [0, 4, 8], [1, 5, 9], [2, 6, 10], [3, 7, 11]

## Test Result
```
A2A group 0: R0:G0, R1:G0, R2:G0
A2A group 1: R0:G1, R1:G1, R2:G1
A2A group 2: R0:G2, R1:G2, R2:G2
A2A group 3: R0:G3, R1:G3, R2:G3
```

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
