### PR TITLE
Add NIC_TRAFFIC_CLASS_FIFO env var for ctrl-path DSCP (like NCCL_IB_FIFO_TC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Documentation for TransferBench is available at
 ## v1.67.00
 ### Added
 - Added NIC_TRAFFIC_CLASS to set the DSCP/traffic class byte in the RoCE GRH for QPs (equivalent to NCCL_IB_TC)
-- Added NIC_TRAFFIC_CLASS_FIFO to set a DSCP/traffic class to steer the control traffic into another priority queue (equivalent NCCL_IB_FIFO_TC)
+- Added NIC_TRAFFIC_CLASS_FIFO to set a DSCP/traffic class to steer the control traffic into another priority queue (equivalent to NCCL_IB_FIFO_TC)
 - Added NIC_SERVICE_LEVEL to set the IB service level (sl) for QPs (equivalent to NCCL_IB_SL)
 - Initial support for pod communication.  Requires compatible hardware / ROCm version and subject to further testing
   - This potentially enables GFX/DMA executors to access SRC/DST memory locations on GPUs within the same pod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ Documentation for TransferBench is available at
 
 ## v1.67.00
 ### Added
-- Added NIC_TRAFFIC_CLASS to set the DSCP/traffic class byte in the RoCE GRH for QPs (RoCE only)
-- Added NIC_SERVICE_LEVEL to set the IB service level (sl) for QPs (IB and RoCE)
+- Added NIC_TRAFFIC_CLASS to set the DSCP/traffic class byte in the RoCE GRH for QPs (equivalent to NCCL_IB_TC)
+- Added NIC_TRAFFIC_CLASS_FIFO to set a DSCP/traffic class to steer the control traffic into another priority queue (equivalent NCCL_IB_FIFO_TC)
+- Added NIC_SERVICE_LEVEL to set the IB service level (sl) for QPs (equivalent to NCCL_IB_SL)
 - Initial support for pod communication.  Requires compatible hardware / ROCm version and subject to further testing
   - This potentially enables GFX/DMA executors to access SRC/DST memory locations on GPUs within the same pod
   - Pod membership requires amd-smi however can be skipped by setting TB_FORCE_SINGLE_POD=1

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -120,6 +120,7 @@ public:
   int nicChunkBytes;                 // Number of bytes to send per chunk for RDMA operations
   int nicCqPollBatch;                // Number of CQ entries to poll per ibv_poll_cq call
   int nicRelaxedOrder;               // Use relaxed ordering for RDMA
+  int nicFifoTrafficClass;           // DSCP/traffic class byte for control (FIFO) QPs
   int nicServiceLevel;               // IB service level (sl) for InfiniBand QPs
   int nicTrafficClass;               // DSCP/traffic class byte for RoCE GRH
   int roceVersion;                   // RoCE version number
@@ -186,11 +187,16 @@ public:
     ipAddressFamily   = GetEnvVar("IP_ADDRESS_FAMILY"   , 4);
     nicChunkBytes     = GetEnvVar("NIC_CHUNK_BYTES"     , 1073741824);
     nicCqPollBatch    = GetEnvVar("NIC_CQ_POLL_BATCH"   , 4);
-    nicRelaxedOrder   = GetEnvVar("NIC_RELAX_ORDER"     , 1);
-    nicServiceLevel   = GetEnvVar("NIC_SERVICE_LEVEL"   , 0);
-    nicTrafficClass   = GetEnvVar("NIC_TRAFFIC_CLASS"   , 0);
+    nicFifoTrafficClass = GetEnvVar("NIC_TRAFFIC_CLASS_FIFO", 0);
+    nicRelaxedOrder     = GetEnvVar("NIC_RELAX_ORDER"    , 1);
+    nicServiceLevel     = GetEnvVar("NIC_SERVICE_LEVEL"  , 0);
+    nicTrafficClass     = GetEnvVar("NIC_TRAFFIC_CLASS"  , 0);
 
     // Check that NIC service level and traffic class are in valid ranges
+    if (nicFifoTrafficClass < 0 || nicFifoTrafficClass > 255) {
+      printf("[ERROR] NIC_TRAFFIC_CLASS_FIFO must be in range 0..255 (got %d)\n", nicFifoTrafficClass);
+      exit(1);
+    }
     if (nicServiceLevel < 0 || nicServiceLevel > 15) {
       printf("[ERROR] NIC_SERVICE_LEVEL must be in range 0..15 (got %d)\n", nicServiceLevel);
       exit(1);
@@ -379,6 +385,7 @@ public:
 #if NIC_EXEC_ENABLED
     printf(" NIC_CHUNK_BYTES     - Number of bytes to send at a time using NIC (default = 1GB)\n");
     printf(" NIC_CQ_POLL_BATCH   - Number of CQ entries to poll per ibv_poll_cq call (default = 4)\n");
+    printf(" NIC_TRAFFIC_CLASS_FIFO - DSCP/traffic class byte for control (FIFO) QP GRH (default=0)\n");
     printf(" NIC_RELAX_ORDER     - Set to non-zero to use relaxed ordering\n");
     printf(" NIC_SERVICE_LEVEL   - IB service level (sl) for InfiniBand QPs (default=0)\n");
     printf(" NIC_TRAFFIC_CLASS   - DSCP/traffic class byte for RoCE GRH (default=0)\n");
@@ -520,6 +527,8 @@ public:
           "Polling %d CQ entries per ibv_poll_cq call", nicCqPollBatch);
     Print("NIC_RELAX_ORDER", nicRelaxedOrder,
           "Using %s ordering for NIC RDMA", nicRelaxedOrder ? "relaxed" : "strict");
+    Print("NIC_TRAFFIC_CLASS_FIFO", nicFifoTrafficClass,
+          "RoCE FIFO/ctrl traffic class (DSCP) set to %d", nicFifoTrafficClass);
     Print("NIC_SERVICE_LEVEL", nicServiceLevel,
           "IB service level (sl) set to %d", nicServiceLevel);
     Print("NIC_TRAFFIC_CLASS", nicTrafficClass,
@@ -744,6 +753,7 @@ public:
     cfg.nic.ibGidIndex             = ibGidIndex;
     cfg.nic.ibPort                 = ibPort;
     cfg.nic.ipAddressFamily        = ipAddressFamily;
+    cfg.nic.fifoTrafficClass       = nicFifoTrafficClass;
     cfg.nic.useRelaxedOrder        = nicRelaxedOrder;
     cfg.nic.serviceLevel           = nicServiceLevel;
     cfg.nic.trafficClass           = nicTrafficClass;

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -197,6 +197,10 @@ public:
       printf("[ERROR] NIC_TRAFFIC_CLASS_FIFO must be in range 0..255 (got %d)\n", nicFifoTrafficClass);
       exit(1);
     }
+    if (nicFifoTrafficClass != 0 && numIterations <= 0) {
+      printf("[ERROR] NIC_TRAFFIC_CLASS_FIFO requires NUM_ITERATIONS > 0 (timed/infinite mode is not supported)\n");
+      exit(1);
+    }
     if (nicServiceLevel < 0 || nicServiceLevel > 15) {
       printf("[ERROR] NIC_SERVICE_LEVEL must be in range 0..15 (got %d)\n", nicServiceLevel);
       exit(1);

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3562,13 +3562,14 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       rss.sendWorkRequests.resize(rss.qpCount);
     }
 
-    // Create control (FIFO) QPs when fifoTrafficClass is non-zero.
-    // Compute numPrepost here so dst ctrl QPs are created with enough max_recv_wr capacity.
-    int ctrlNumPrepost = (cfg.general.numWarmups +
-                         std::max(1, std::abs(cfg.general.numIterations))) *
-                         std::max(1, cfg.general.numSubIterations);
-
-    if (cfg.nic.fifoTrafficClass != 0) {
+    // Create control (FIFO) QPs when fifoTrafficClass is non-zero and this is an RDMA_WRITE
+    // transfer (srcIsExeNic == true).  RDMA_READ transfers never use ctrl QPs so skip them.
+    // Compute ctrlNumPrepost in 64-bit to avoid signed overflow for large iteration counts,
+    // then clamp to INT_MAX before casting (NIC_TRAFFIC_CLASS_FIFO already rejects numIterations<=0).
+    int64_t ctrlNumPrepost64 = (int64_t)(cfg.general.numWarmups + cfg.general.numIterations) *
+                                std::max(1, cfg.general.numSubIterations);
+    int ctrlNumPrepost = (int)std::min(ctrlNumPrepost64, (int64_t)INT_MAX);
+    if (cfg.nic.fifoTrafficClass != 0 && rss.srcIsExeNic) {
       if (GetRank() == srcMemRank) {
         IBV_PTR_CALL(rss.srcCtrlCompQueue, ibv_create_cq,
                      rss.srcContext, rss.qpCount, NULL, NULL, 0);
@@ -3717,8 +3718,9 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       }
     }
 
-    // Exchange ctrl QP numbers and connect them with fifoTrafficClass
-    if (cfg.nic.fifoTrafficClass != 0) {
+    // Exchange ctrl QP numbers and connect them with fifoTrafficClass.
+    // Guard on srcIsExeNic to match the ctrl QP creation block above.
+    if (cfg.nic.fifoTrafficClass != 0 && rss.srcIsExeNic) {
       ConnInfo srcCtrlInfo = {}, dstCtrlInfo = {};
       for (int i = 0; i < rss.qpCount; i++) {
         if (GetRank() == srcMemRank) {

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -4790,6 +4790,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     if (cfg.nic.fifoTrafficClass != 0 && rss.srcIsExeNic) {
       ibv_send_wr* badSendWr;
       for (int qpIdx = 0; qpIdx < rss.qpCount; qpIdx++) {
+        rss.ctrlSendWr.wr_id = qpIdx;
         int err = ibv_post_send(rss.srcCtrlQueuePairs[qpIdx], &rss.ctrlSendWr, &badSendWr);
         if (err)
           return {ERR_FATAL, "Transfer %d: ibv_post_send on ctrl QP %d failed (%s)",
@@ -4797,10 +4798,13 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       }
       for (int qpIdx = 0; qpIdx < rss.qpCount; qpIdx++) {
         ibv_wc wc;
-        while (ibv_poll_cq(rss.srcCtrlCompQueue, 1, &wc) == 0) {}
+        int nc;
+        while ((nc = ibv_poll_cq(rss.srcCtrlCompQueue, 1, &wc)) == 0) {}
+        if (nc < 0)
+          return {ERR_FATAL, "Transfer %d: ctrl CQ poll error", rss.transferIdx};
         if (wc.status != IBV_WC_SUCCESS)
-          return {ERR_FATAL, "Transfer %d: ctrl send CQ error on QP %d [status %d]",
-                  rss.transferIdx, qpIdx, wc.status};
+          return {ERR_FATAL, "Transfer %d: ctrl send CQ error on QP %llu [status %d]",
+                  rss.transferIdx, wc.wr_id, wc.status};
       }
     }
 

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3592,6 +3592,11 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
         rss.srcNicIndex, srcMemRank, rss.dstNicIndex, dstMemRank, rss.srcPortAttr.link_layer, rss.dstPortAttr.link_layer};
     }
 
+    // Shared result type for broadcasting QP transition success/failure across MPI ranks
+    struct QpTransitionResult { ErrType errType; bool rtrFailed; };
+    static_assert(std::is_trivially_copyable<QpTransitionResult>::value,
+                  "QpTransitionResult must be trivially copyable for MPI broadcast");
+
     ConnInfo dstConnInfo = {};
     ConnInfo srcConnInfo = {};
     for (int i = 0; i < rss.qpCount; i++) {
@@ -3621,8 +3626,6 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       // Then move them to read-to-send (RTS)
       // Broadcast each rank's result so all ranks fail together rather than
       // hanging on the next iteration's Broadcast when qpCount > 1.
-      struct QpTransitionResult { ErrType errType; bool rtrFailed; };
-      static_assert(std::is_trivially_copyable<QpTransitionResult>::value, "QpTransitionResult must be trivially copyable for MPI broadcast");
       QpTransitionResult srcQpResult = {ERR_NONE, false};
       if (GetRank() == srcMemRank) {
         ErrResult err = TransitionQpToRtr(rss.srcQueuePairs[i], dstConnInfo, port, srcIsRoCE, rss.srcPortAttr.active_mtu, cfg.nic.trafficClass, cfg.nic.serviceLevel);

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3831,7 +3831,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       rss.dstQueuePairs.clear();
     }
 
-    // Destroy ctrl queue pairs and completion queues (only exist when fifoTrafficClass != trafficClass)
+    // Destroy ctrl queue pairs and completion queues (only exist when fifoTrafficClass != 0)
     if (isSrcRank && !rss.srcCtrlQueuePairs.empty()) {
       for (auto qp : rss.srcCtrlQueuePairs) IBV_CALL(ibv_destroy_qp, qp);
       rss.srcCtrlQueuePairs.clear();

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -270,6 +270,7 @@ namespace TransferBench
     int         queueSize       = 100;          ///< Completion queue size
     int         roceVersion     = 2;            ///< RoCE version (used for auto GID detection)
     int         useRelaxedOrder = 1;            ///< Use relaxed ordering
+    uint8_t     fifoTrafficClass = 0;           ///< DSCP/traffic class byte for control (FIFO) QPs
     uint8_t     serviceLevel    = 0;            ///< IB service level (sl) for InfiniBand QPs
     uint8_t     trafficClass    = 0;            ///< DSCP/traffic class byte for RoCE GRH
     int         useNuma         = 0;            ///< Switch to closest numa thread for execution
@@ -2001,9 +2002,10 @@ namespace {
       if (nic.maxRecvWorkReq  != cfg.nic.maxRecvWorkReq)  ADD_ERROR("cfg.nic.maxRecvWorkReq");
       if (nic.maxSendWorkReq  != cfg.nic.maxSendWorkReq)  ADD_ERROR("cfg.nic.maxSendWorkReq");
       // nic.queueSize   is permitted to be different across ranks
-      if (nic.roceVersion     != cfg.nic.roceVersion)     ADD_ERROR("cfg.nic.roceVersion");
-      if (nic.serviceLevel    != cfg.nic.serviceLevel)    ADD_ERROR("cfg.nic.serviceLevel");
-      if (nic.trafficClass    != cfg.nic.trafficClass)    ADD_ERROR("cfg.nic.trafficClass");
+      if (nic.roceVersion        != cfg.nic.roceVersion)        ADD_ERROR("cfg.nic.roceVersion");
+      if (nic.fifoTrafficClass   != cfg.nic.fifoTrafficClass)   ADD_ERROR("cfg.nic.fifoTrafficClass");
+      if (nic.serviceLevel       != cfg.nic.serviceLevel)       ADD_ERROR("cfg.nic.serviceLevel");
+      if (nic.trafficClass       != cfg.nic.trafficClass)       ADD_ERROR("cfg.nic.trafficClass");
       if (nic.useRelaxedOrder != cfg.nic.useRelaxedOrder) ADD_ERROR("cfg.nic.useRelaxedOrder");
       if (nic.useNuma         != cfg.nic.useNuma)         ADD_ERROR("cfg.nic.useNuma");
     }
@@ -2749,6 +2751,12 @@ namespace {
     ibv_gid                    dstGid;            ///< GID handle for DST NIC
     vector<ibv_qp*>            srcQueuePairs;     ///< Queue pairs for SRC NIC
     vector<ibv_qp*>            dstQueuePairs;     ///< Queue pairs for DST NIC
+    ibv_cq*                    srcCtrlCompQueue;  ///< Completion queue for SRC ctrl QPs (FIFO TC)
+    ibv_cq*                    dstCtrlCompQueue;  ///< Completion queue for DST ctrl QPs (FIFO TC)
+    vector<ibv_qp*>            srcCtrlQueuePairs; ///< Control QPs on SRC NIC (FIFO TC)
+    vector<ibv_qp*>            dstCtrlQueuePairs; ///< Control QPs on DST NIC (FIFO TC)
+    ibv_send_wr                ctrlSendWr;        ///< Send WR for ctrl signal (zero-byte inline, reused per iteration)
+    ibv_recv_wr                ctrlRecvWr;        ///< Recv WR for ctrl signal (reused per iteration)
     ibv_mr*                    srcMemRegion;      ///< Memory region for SRC
     ibv_mr*                    dstMemRegion;      ///< Memory region for DST
     int                        srcDmabufFd;       ///< DMA-BUF file descriptor for SRC (if using dmabuf)
@@ -3554,6 +3562,28 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       rss.sendWorkRequests.resize(rss.qpCount);
     }
 
+    // Create control (FIFO) QPs when fifoTrafficClass differs from trafficClass
+    if (cfg.nic.fifoTrafficClass != cfg.nic.trafficClass) {
+      if (GetRank() == srcMemRank) {
+        IBV_PTR_CALL(rss.srcCtrlCompQueue, ibv_create_cq,
+                     rss.srcContext, cfg.nic.queueSize, NULL, NULL, 0);
+        rss.srcCtrlQueuePairs.resize(rss.qpCount);
+        for (int i = 0; i < rss.qpCount; i++) {
+          ERR_CHECK(CreateQueuePair(cfg, rss.srcProtect, rss.srcCtrlCompQueue, rss.srcCtrlQueuePairs[i]));
+          ERR_CHECK(InitQueuePair(rss.srcCtrlQueuePairs[i], port, rdmaAccessFlags));
+        }
+      }
+      if (GetRank() == dstMemRank) {
+        IBV_PTR_CALL(rss.dstCtrlCompQueue, ibv_create_cq,
+                     rss.dstContext, cfg.nic.queueSize, NULL, NULL, 0);
+        rss.dstCtrlQueuePairs.resize(rss.qpCount);
+        for (int i = 0; i < rss.qpCount; i++) {
+          ERR_CHECK(CreateQueuePair(cfg, rss.dstProtect, rss.dstCtrlCompQueue, rss.dstCtrlQueuePairs[i]));
+          ERR_CHECK(InitQueuePair(rss.dstCtrlQueuePairs[i], port, rdmaAccessFlags));
+        }
+      }
+    }
+
     // Broadcast SRC/DST port link_layer so that all ranks know it so that they can be compared
     System::Get().Broadcast(srcMemRank, sizeof(rss.srcPortAttr.link_layer), &rss.srcPortAttr.link_layer);
     System::Get().Broadcast(dstMemRank, sizeof(rss.dstPortAttr.link_layer), &rss.dstPortAttr.link_layer);
@@ -3675,6 +3705,70 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
         }
       }
     }
+
+    // Exchange ctrl QP numbers and connect them with fifoTrafficClass
+    if (cfg.nic.fifoTrafficClass != cfg.nic.trafficClass) {
+      ConnInfo srcCtrlInfo = {}, dstCtrlInfo = {};
+      for (int i = 0; i < rss.qpCount; i++) {
+        if (GetRank() == srcMemRank) {
+          srcCtrlInfo.lid    = rss.srcPortAttr.lid;
+          srcCtrlInfo.gid    = rss.srcGid;
+          srcCtrlInfo.gidIdx = srcGidIndex;
+          srcCtrlInfo.qpn    = rss.srcCtrlQueuePairs[i]->qp_num;
+          srcCtrlInfo.rkey   = 0;
+          srcCtrlInfo.vaddr  = 0;
+        }
+        System::Get().Broadcast(srcMemRank, sizeof(srcCtrlInfo), &srcCtrlInfo);
+
+        if (GetRank() == dstMemRank) {
+          dstCtrlInfo.lid    = rss.dstPortAttr.lid;
+          dstCtrlInfo.gid    = rss.dstGid;
+          dstCtrlInfo.gidIdx = dstGidIndex;
+          dstCtrlInfo.qpn    = rss.dstCtrlQueuePairs[i]->qp_num;
+          dstCtrlInfo.rkey   = 0;
+          dstCtrlInfo.vaddr  = 0;
+        }
+        System::Get().Broadcast(dstMemRank, sizeof(dstCtrlInfo), &dstCtrlInfo);
+
+        QpTransitionResult srcCtrlResult = {ERR_NONE, false};
+        if (GetRank() == srcMemRank) {
+          ErrResult err = TransitionQpToRtr(rss.srcCtrlQueuePairs[i], dstCtrlInfo, port, srcIsRoCE,
+                                            rss.srcPortAttr.active_mtu, cfg.nic.fifoTrafficClass, cfg.nic.serviceLevel);
+          srcCtrlResult.rtrFailed = (err.errType != ERR_NONE);
+          if (err.errType == ERR_NONE) err = TransitionQpToRts(rss.srcCtrlQueuePairs[i]);
+          srcCtrlResult.errType = err.errType;
+        }
+        System::Get().Broadcast(srcMemRank, sizeof(srcCtrlResult), &srcCtrlResult);
+        if (srcCtrlResult.errType != ERR_NONE)
+          return {ERR_FATAL, "SRC rank %d failed to transition ctrl QP %d to %s",
+                  srcMemRank, i, srcCtrlResult.rtrFailed ? "RTR" : "RTS"};
+
+        QpTransitionResult dstCtrlResult = {ERR_NONE, false};
+        if (GetRank() == dstMemRank) {
+          ErrResult err = TransitionQpToRtr(rss.dstCtrlQueuePairs[i], srcCtrlInfo, port, dstIsRoCE,
+                                            rss.dstPortAttr.active_mtu, cfg.nic.fifoTrafficClass, cfg.nic.serviceLevel);
+          dstCtrlResult.rtrFailed = (err.errType != ERR_NONE);
+          if (err.errType == ERR_NONE) err = TransitionQpToRts(rss.dstCtrlQueuePairs[i]);
+          dstCtrlResult.errType = err.errType;
+        }
+        System::Get().Broadcast(dstMemRank, sizeof(dstCtrlResult), &dstCtrlResult);
+        if (dstCtrlResult.errType != ERR_NONE)
+          return {ERR_FATAL, "DST rank %d failed to transition ctrl QP %d to %s",
+                  dstMemRank, i, dstCtrlResult.rtrFailed ? "RTR" : "RTS"};
+      }
+
+      // Pre-build reusable ctrl send/recv WRs (zero-byte inline, posted once per iteration)
+      rss.ctrlSendWr            = {};
+      rss.ctrlSendWr.sg_list    = nullptr;
+      rss.ctrlSendWr.num_sge    = 0;
+      rss.ctrlSendWr.opcode     = IBV_WR_SEND;
+      rss.ctrlSendWr.send_flags = IBV_SEND_SIGNALED | IBV_SEND_INLINE;
+
+      rss.ctrlRecvWr            = {};
+      rss.ctrlRecvWr.sg_list    = nullptr;
+      rss.ctrlRecvWr.num_sge    = 0;
+    }
+
     return ERR_NONE;
   }
 
@@ -3709,6 +3803,18 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       for (auto dstQueuePair : rss.dstQueuePairs)
         IBV_CALL(ibv_destroy_qp, dstQueuePair);
       rss.dstQueuePairs.clear();
+    }
+
+    // Destroy ctrl queue pairs and completion queues (only exist when fifoTrafficClass != trafficClass)
+    if (isSrcRank && !rss.srcCtrlQueuePairs.empty()) {
+      for (auto qp : rss.srcCtrlQueuePairs) IBV_CALL(ibv_destroy_qp, qp);
+      rss.srcCtrlQueuePairs.clear();
+      IBV_CALL(ibv_destroy_cq, rss.srcCtrlCompQueue);
+    }
+    if (isDstRank && !rss.dstCtrlQueuePairs.empty()) {
+      for (auto qp : rss.dstCtrlQueuePairs) IBV_CALL(ibv_destroy_qp, qp);
+      rss.dstCtrlQueuePairs.clear();
+      IBV_CALL(ibv_destroy_cq, rss.dstCtrlCompQueue);
     }
 
     // Destroy completion queues
@@ -4653,7 +4759,56 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
                                       int           const  exeIndex,
                                       TransferResources&   rss)
   {
-    // Loop over each of the queue pairs and post work request
+    // Ping-pong control path: receiver arms recv, both sync, sender fires zero-byte signal
+    // on ctrl QPs (stamped with fifoTrafficClass), then data transfer proceeds as normal.
+    if (cfg.nic.fifoTrafficClass != cfg.nic.trafficClass) {
+      // [1] Receiver arms one recv WR per ctrl QP before the barrier
+      if (!rss.srcIsExeNic) {
+        ibv_recv_wr* badRecvWr;
+        for (int qpIdx = 0; qpIdx < rss.qpCount; qpIdx++) {
+          ibv_recv_wr wr = rss.ctrlRecvWr;   // copy: wr.next must be null
+          int err = ibv_post_recv(rss.dstCtrlQueuePairs[qpIdx], &wr, &badRecvWr);
+          if (err)
+            return {ERR_FATAL, "Transfer %d: ibv_post_recv on ctrl QP %d failed (%s)",
+                    rss.transferIdx, qpIdx, strerror(err)};
+        }
+      }
+
+      // [2] Barrier — guarantees receiver has armed recv before sender fires
+      System::Get().Barrier();
+
+      // [3] Sender fires one zero-byte inline IBV_WR_SEND per ctrl QP
+      if (rss.srcIsExeNic) {
+        ibv_send_wr* badSendWr;
+        for (int qpIdx = 0; qpIdx < rss.qpCount; qpIdx++) {
+          int err = ibv_post_send(rss.srcCtrlQueuePairs[qpIdx], &rss.ctrlSendWr, &badSendWr);
+          if (err)
+            return {ERR_FATAL, "Transfer %d: ibv_post_send on ctrl QP %d failed (%s)",
+                    rss.transferIdx, qpIdx, strerror(err)};
+        }
+        // [4] Sender polls ctrl CQ for send completions
+        for (int qpIdx = 0; qpIdx < rss.qpCount; qpIdx++) {
+          ibv_wc wc;
+          while (ibv_poll_cq(rss.srcCtrlCompQueue, 1, &wc) == 0) {}
+          if (wc.status != IBV_WC_SUCCESS)
+            return {ERR_FATAL, "Transfer %d: ctrl send CQ error on QP %d [status %d]",
+                    rss.transferIdx, qpIdx, wc.status};
+        }
+      }
+
+      // [5] Receiver polls ctrl CQ — confirms signal arrived
+      if (!rss.srcIsExeNic) {
+        for (int qpIdx = 0; qpIdx < rss.qpCount; qpIdx++) {
+          ibv_wc wc;
+          while (ibv_poll_cq(rss.dstCtrlCompQueue, 1, &wc) == 0) {}
+          if (wc.status != IBV_WC_SUCCESS)
+            return {ERR_FATAL, "Transfer %d: ctrl recv CQ error on QP %d [status %d]",
+                    rss.transferIdx, qpIdx, wc.status};
+        }
+      }
+    }
+
+    // [6] Data path — unchanged: post all RDMA send WRs (stamped with trafficClass)
     ibv_send_wr* badWorkReq;
     for (int qpIndex = 0; qpIndex < rss.qpCount; qpIndex++) {
       size_t numChunks = rss.sendWorkRequests[qpIndex].size();

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3571,7 +3571,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     if (cfg.nic.fifoTrafficClass != 0) {
       if (GetRank() == srcMemRank) {
         IBV_PTR_CALL(rss.srcCtrlCompQueue, ibv_create_cq,
-                     rss.srcContext, cfg.nic.queueSize, NULL, NULL, 0);
+                     rss.srcContext, rss.qpCount, NULL, NULL, 0);
         rss.srcCtrlQueuePairs.resize(rss.qpCount);
         for (int i = 0; i < rss.qpCount; i++) {
           // SRC ctrl QP only posts sends, so use default max_recv_wr
@@ -3581,7 +3581,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       }
       if (GetRank() == dstMemRank) {
         IBV_PTR_CALL(rss.dstCtrlCompQueue, ibv_create_cq,
-                     rss.dstContext, cfg.nic.queueSize, NULL, NULL, 0);
+                     rss.dstContext, ctrlNumPrepost * rss.qpCount, NULL, NULL, 0);
         rss.dstCtrlQueuePairs.resize(rss.qpCount);
         for (int i = 0; i < rss.qpCount; i++) {
           // DST ctrl QP pre-posts ctrlNumPrepost recv WRs; ensure max_recv_wr is large enough

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3237,17 +3237,18 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
   static ErrResult CreateQueuePair(ConfigOptions const& cfg,
                                    struct ibv_pd*       pd,
                                    struct ibv_cq*       cq,
-                                   struct ibv_qp*&      qp)
+                                   struct ibv_qp*&      qp,
+                                   int                  maxRecvWr = -1)
   {
     // Set queue pair attributes
     struct ibv_qp_init_attr attr = {};
-    attr.qp_type          = IBV_QPT_RC;                  // Set type to reliable connection
-    attr.send_cq          = cq;                          // Send completion queue
-    attr.recv_cq          = cq;                          // Recv completion queue
-    attr.cap.max_send_wr  = cfg.nic.maxSendWorkReq;      // Max send work requests
-    attr.cap.max_recv_wr  = cfg.nic.maxRecvWorkReq;      // Max recv work requests
-    attr.cap.max_send_sge = 1;                           // Max send scatter-gather entries
-    attr.cap.max_recv_sge = 1;                           // Max recv scatter-gather entries
+    attr.qp_type          = IBV_QPT_RC;                                              // Set type to reliable connection
+    attr.send_cq          = cq;                                                      // Send completion queue
+    attr.recv_cq          = cq;                                                      // Recv completion queue
+    attr.cap.max_send_wr  = cfg.nic.maxSendWorkReq;                                  // Max send work requests
+    attr.cap.max_recv_wr  = (maxRecvWr >= 0) ? maxRecvWr : cfg.nic.maxRecvWorkReq;  // Max recv work requests
+    attr.cap.max_send_sge = 1;                                                       // Max send scatter-gather entries
+    attr.cap.max_recv_sge = 1;                                                       // Max recv scatter-gather entries
 
     qp = ibv_create_qp(pd, &attr);
     if (qp == NULL)
@@ -3561,13 +3562,17 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       rss.sendWorkRequests.resize(rss.qpCount);
     }
 
-    // Create control (FIFO) QPs when fifoTrafficClass differs from trafficClass
+    // Create control (FIFO) QPs when fifoTrafficClass is non-zero.
+    // Compute numPrepost here so dst ctrl QPs are created with enough max_recv_wr capacity.
+    int ctrlNumPrepost = cfg.general.numWarmups +
+                         std::max(1, std::abs(cfg.general.numIterations)) + 5;
     if (cfg.nic.fifoTrafficClass != 0) {
       if (GetRank() == srcMemRank) {
         IBV_PTR_CALL(rss.srcCtrlCompQueue, ibv_create_cq,
                      rss.srcContext, cfg.nic.queueSize, NULL, NULL, 0);
         rss.srcCtrlQueuePairs.resize(rss.qpCount);
         for (int i = 0; i < rss.qpCount; i++) {
+          // SRC ctrl QP only posts sends, so use default max_recv_wr
           ERR_CHECK(CreateQueuePair(cfg, rss.srcProtect, rss.srcCtrlCompQueue, rss.srcCtrlQueuePairs[i]));
           ERR_CHECK(InitQueuePair(rss.srcCtrlQueuePairs[i], port, rdmaAccessFlags));
         }
@@ -3577,7 +3582,9 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
                      rss.dstContext, cfg.nic.queueSize, NULL, NULL, 0);
         rss.dstCtrlQueuePairs.resize(rss.qpCount);
         for (int i = 0; i < rss.qpCount; i++) {
-          ERR_CHECK(CreateQueuePair(cfg, rss.dstProtect, rss.dstCtrlCompQueue, rss.dstCtrlQueuePairs[i]));
+          // DST ctrl QP pre-posts ctrlNumPrepost recv WRs; ensure max_recv_wr is large enough
+          ERR_CHECK(CreateQueuePair(cfg, rss.dstProtect, rss.dstCtrlCompQueue, rss.dstCtrlQueuePairs[i],
+                                    ctrlNumPrepost));
           ERR_CHECK(InitQueuePair(rss.dstCtrlQueuePairs[i], port, rdmaAccessFlags));
         }
       }
@@ -3768,16 +3775,14 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 
       // DST rank pre-posts recv WRs for all expected iterations so no per-iteration
       // coordination (barrier) is needed between executor and non-executor ranks.
-      // numWarmups uses negative iteration indices; total sends = numWarmups + numIterations.
-      int numPrepost = cfg.general.numWarmups +
-                       std::max(1, std::abs(cfg.general.numIterations)) + 5;
+      // ctrlNumPrepost was computed above and matches the max_recv_wr used when creating ctrl QPs.
       if (GetRank() == dstMemRank) {
         ibv_recv_wr ctrlRecvWr = {};
         ctrlRecvWr.sg_list = nullptr;
         ctrlRecvWr.num_sge = 0;
         ibv_recv_wr* badRecvWr;
         for (int i = 0; i < rss.qpCount; i++) {
-          for (int n = 0; n < numPrepost; n++) {
+          for (int n = 0; n < ctrlNumPrepost; n++) {
             ibv_recv_wr wr = ctrlRecvWr;
             int err = ibv_post_recv(rss.dstCtrlQueuePairs[i], &wr, &badRecvWr);
             if (err)

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -2756,7 +2756,6 @@ namespace {
     vector<ibv_qp*>            srcCtrlQueuePairs; ///< Control QPs on SRC NIC (FIFO TC)
     vector<ibv_qp*>            dstCtrlQueuePairs; ///< Control QPs on DST NIC (FIFO TC)
     ibv_send_wr                ctrlSendWr;        ///< Send WR for ctrl signal (zero-byte inline, reused per iteration)
-    ibv_recv_wr                ctrlRecvWr;        ///< Recv WR for ctrl signal (reused per iteration)
     ibv_mr*                    srcMemRegion;      ///< Memory region for SRC
     ibv_mr*                    dstMemRegion;      ///< Memory region for DST
     int                        srcDmabufFd;       ///< DMA-BUF file descriptor for SRC (if using dmabuf)
@@ -3563,7 +3562,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
 
     // Create control (FIFO) QPs when fifoTrafficClass differs from trafficClass
-    if (cfg.nic.fifoTrafficClass != cfg.nic.trafficClass) {
+    if (cfg.nic.fifoTrafficClass != 0) {
       if (GetRank() == srcMemRank) {
         IBV_PTR_CALL(rss.srcCtrlCompQueue, ibv_create_cq,
                      rss.srcContext, cfg.nic.queueSize, NULL, NULL, 0);
@@ -3710,7 +3709,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
 
     // Exchange ctrl QP numbers and connect them with fifoTrafficClass
-    if (cfg.nic.fifoTrafficClass != cfg.nic.trafficClass) {
+    if (cfg.nic.fifoTrafficClass != 0) {
       ConnInfo srcCtrlInfo = {}, dstCtrlInfo = {};
       for (int i = 0; i < rss.qpCount; i++) {
         if (GetRank() == srcMemRank) {
@@ -3760,16 +3759,33 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
                   dstMemRank, i, dstCtrlResult.rtrFailed ? "RTR" : "RTS"};
       }
 
-      // Pre-build reusable ctrl send/recv WRs (zero-byte inline, posted once per iteration)
+      // Pre-build reusable ctrl send WR (zero-byte inline IBV_WR_SEND, posted once per iteration)
       rss.ctrlSendWr            = {};
       rss.ctrlSendWr.sg_list    = nullptr;
       rss.ctrlSendWr.num_sge    = 0;
       rss.ctrlSendWr.opcode     = IBV_WR_SEND;
       rss.ctrlSendWr.send_flags = IBV_SEND_SIGNALED | IBV_SEND_INLINE;
 
-      rss.ctrlRecvWr            = {};
-      rss.ctrlRecvWr.sg_list    = nullptr;
-      rss.ctrlRecvWr.num_sge    = 0;
+      // DST rank pre-posts recv WRs for all expected iterations so no per-iteration
+      // coordination (barrier) is needed between executor and non-executor ranks.
+      // numWarmups uses negative iteration indices; total sends = numWarmups + numIterations.
+      int numPrepost = cfg.general.numWarmups +
+                       std::max(1, std::abs(cfg.general.numIterations)) + 5;
+      if (GetRank() == dstMemRank) {
+        ibv_recv_wr ctrlRecvWr = {};
+        ctrlRecvWr.sg_list = nullptr;
+        ctrlRecvWr.num_sge = 0;
+        ibv_recv_wr* badRecvWr;
+        for (int i = 0; i < rss.qpCount; i++) {
+          for (int n = 0; n < numPrepost; n++) {
+            ibv_recv_wr wr = ctrlRecvWr;
+            int err = ibv_post_recv(rss.dstCtrlQueuePairs[i], &wr, &badRecvWr);
+            if (err)
+              return {ERR_FATAL, "Transfer %d: ibv_post_recv pre-post on ctrl QP %d failed (%s)",
+                      rss.transferIdx, i, strerror(err)};
+          }
+        }
+      }
     }
 
     return ERR_NONE;
@@ -4762,56 +4778,26 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
                                       int           const  exeIndex,
                                       TransferResources&   rss)
   {
-    // Ping-pong control path: receiver arms recv, both sync, sender fires zero-byte signal
-    // on ctrl QPs (stamped with fifoTrafficClass), then data transfer proceeds as normal.
-    if (cfg.nic.fifoTrafficClass != cfg.nic.trafficClass) {
-      // [1] Receiver arms one recv WR per ctrl QP before the barrier
-      if (!rss.srcIsExeNic) {
-        ibv_recv_wr* badRecvWr;
-        for (int qpIdx = 0; qpIdx < rss.qpCount; qpIdx++) {
-          ibv_recv_wr wr = rss.ctrlRecvWr;   // copy: wr.next must be null
-          int err = ibv_post_recv(rss.dstCtrlQueuePairs[qpIdx], &wr, &badRecvWr);
-          if (err)
-            return {ERR_FATAL, "Transfer %d: ibv_post_recv on ctrl QP %d failed (%s)",
-                    rss.transferIdx, qpIdx, strerror(err)};
-        }
+    // Ctrl path: executor (src) fires one zero-byte inline IBV_WR_SEND per ctrl QP.
+    // Recv WRs are pre-posted on the dst side during setup, so no barrier is needed.
+    if (cfg.nic.fifoTrafficClass != 0 && rss.srcIsExeNic) {
+      ibv_send_wr* badSendWr;
+      for (int qpIdx = 0; qpIdx < rss.qpCount; qpIdx++) {
+        int err = ibv_post_send(rss.srcCtrlQueuePairs[qpIdx], &rss.ctrlSendWr, &badSendWr);
+        if (err)
+          return {ERR_FATAL, "Transfer %d: ibv_post_send on ctrl QP %d failed (%s)",
+                  rss.transferIdx, qpIdx, strerror(err)};
       }
-
-      // [2] Barrier — guarantees receiver has armed recv before sender fires
-      System::Get().Barrier();
-
-      // [3] Sender fires one zero-byte inline IBV_WR_SEND per ctrl QP
-      if (rss.srcIsExeNic) {
-        ibv_send_wr* badSendWr;
-        for (int qpIdx = 0; qpIdx < rss.qpCount; qpIdx++) {
-          int err = ibv_post_send(rss.srcCtrlQueuePairs[qpIdx], &rss.ctrlSendWr, &badSendWr);
-          if (err)
-            return {ERR_FATAL, "Transfer %d: ibv_post_send on ctrl QP %d failed (%s)",
-                    rss.transferIdx, qpIdx, strerror(err)};
-        }
-        // [4] Sender polls ctrl CQ for send completions
-        for (int qpIdx = 0; qpIdx < rss.qpCount; qpIdx++) {
-          ibv_wc wc;
-          while (ibv_poll_cq(rss.srcCtrlCompQueue, 1, &wc) == 0) {}
-          if (wc.status != IBV_WC_SUCCESS)
-            return {ERR_FATAL, "Transfer %d: ctrl send CQ error on QP %d [status %d]",
-                    rss.transferIdx, qpIdx, wc.status};
-        }
-      }
-
-      // [5] Receiver polls ctrl CQ — confirms signal arrived
-      if (!rss.srcIsExeNic) {
-        for (int qpIdx = 0; qpIdx < rss.qpCount; qpIdx++) {
-          ibv_wc wc;
-          while (ibv_poll_cq(rss.dstCtrlCompQueue, 1, &wc) == 0) {}
-          if (wc.status != IBV_WC_SUCCESS)
-            return {ERR_FATAL, "Transfer %d: ctrl recv CQ error on QP %d [status %d]",
-                    rss.transferIdx, qpIdx, wc.status};
-        }
+      for (int qpIdx = 0; qpIdx < rss.qpCount; qpIdx++) {
+        ibv_wc wc;
+        while (ibv_poll_cq(rss.srcCtrlCompQueue, 1, &wc) == 0) {}
+        if (wc.status != IBV_WC_SUCCESS)
+          return {ERR_FATAL, "Transfer %d: ctrl send CQ error on QP %d [status %d]",
+                  rss.transferIdx, qpIdx, wc.status};
       }
     }
 
-    // [6] Data path — unchanged: post all RDMA send WRs (stamped with trafficClass)
+    // Data path — unchanged: post all RDMA send WRs (stamped with trafficClass)
     ibv_send_wr* badWorkReq;
     for (int qpIndex = 0; qpIndex < rss.qpCount; qpIndex++) {
       size_t numChunks = rss.sendWorkRequests[qpIndex].size();

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -3564,8 +3564,10 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 
     // Create control (FIFO) QPs when fifoTrafficClass is non-zero.
     // Compute numPrepost here so dst ctrl QPs are created with enough max_recv_wr capacity.
-    int ctrlNumPrepost = cfg.general.numWarmups +
-                         std::max(1, std::abs(cfg.general.numIterations)) + 5;
+    int ctrlNumPrepost = (cfg.general.numWarmups +
+                         std::max(1, std::abs(cfg.general.numIterations))) *
+                         std::max(1, cfg.general.numSubIterations);
+
     if (cfg.nic.fifoTrafficClass != 0) {
       if (GetRank() == srcMemRank) {
         IBV_PTR_CALL(rss.srcCtrlCompQueue, ibv_create_cq,


### PR DESCRIPTION
## Motivation

We can configure network switches to steer traffic to different priority queues based on DSCP values. Like in the related PR #315 which we added the env var `NIC_TRAFFIC_CLASS` to allow marking the bulk data QP traffic. With that we used a single traffic class for both data and control paths, which means control/signaling traffic competes in the same queue as large data transfers, which has a potential to causing head-of-line blocking at larger scale, when there are victim flow which caused a lot of ranks to compete to send back the control path while the same same traffic class is congested. 

Reference in the section "[Receiver-driven traffic admission](https://engineering.fb.com/2024/08/05/data-center-engineering/roce-network-distributed-ai-training-at-scale)", because of that NCCL/RCCL addresses this with `NCCL_IB_FIFO_TC` which separates the traffic class for its control QPs. 

This PR adds the `NIC_TRAFFIC_CLASS_FIFO` env var to TransferBench, which is the NCCL/RCCL equivalent of `NCCL_IB_FIFO_TC`.

## Technical Details

We introduce a new env var: `NIC_TRAFFIC_CLASS_FIFO` which sets the GRH traffic_class for a 0-byte signaling message per ctrl QP, which separate from the data QPs, defined by `NIC_TRAFFIC_CLASS` (introduced in #315). 
Each `ExecuteNicTransfer()` call fires one zero-byte inline IBV_WR_SEND per ctrl QP, which goes on the wire with the specified DSCP, then polls for completion before the data send, and `NIC_TRAFFIC_CLASS_FIFO=0` (default) is a no-op: no ctrl QPs are created, no overhead per iteration

## Test Plan

I verified the DSCP value set for QoS on the NIC to confirm:
ack_dscp=46 (TC=184, TC = DSCP << 2)
data_dscp=24 (TC=96, TC = DSCP << 2)
Then I confirm on the (SONiC) switch ports the right DSCP-TC are mapped, and the interfaces are using the right qos-map profile
```
sonic-cli
show qos map dscp-tc
show running-configuration interface Eth
```
Then I reset the counters for those interfaces
```
clear counters interface Eth 1/18
show queue counters interface Eth 1/18
```
then use show queue counters on leaf switch(es) that shows ctrl packets land on the correct priority queue and no drops on either queue and bandwidth on the data not being affected

I verified on the smc300x cluster (8x MI300X, RoCE NICs) that without `NIC_TRAFFIC_CLASS_FIFO`, the control traffic went on same priority/queue as data QPs.
```
make clean && make GPU_TARGETS=native SINGLE_KERNEL=1 MPI_PATH=/usr/lib/x86_64-linux-gnu/openmpi
NIC_TRAFFIC_CLASS=96 \
NUM_ITERATIONS=5 \
NUM_WARMUPS=2 \
mpirun -np 2 ./TransferBench nicp2p
```
With NIC_TRAFFIC_CLASS_FIFO: ctrl traffic steered to separate queue (DSCP=46/TC=184)
```
NIC_TRAFFIC_CLASS=96 \
NIC_TRAFFIC_CLASS_FIFO=184 \
NUM_ITERATIONS=5 \
NUM_WARMUPS=2 \
mpirun -np 2 ./TransferBench nicp2p
```

## Test Result

Verified on smc300x cluster (8x MI300X, ionic RoCE NICs, leaf switch with RoCE QoS profile):
- Without `NIC_TRAFFIC_CLASS_FIFO`: all traffic (ctrl + data) lands on the same switch queue
- With `NIC_TRAFFIC_CLASS_FIFO=184` (DSCP 46): ctrl packets steered to the correct priority queue, data packets remain on their queue; zero drops on both; data bandwidth unaffected

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
