### PR TITLE
Fixing GFX Executor missing threadfence_system from v1.67

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Documentation for TransferBench is available at
 [https://rocm.docs.amd.com/projects/TransferBench](https://rocm.docs.amd.com/projects/TransferBench).
 
+## v1.68.00
+### Fixed
+- Improper draining of writes introduced in v1.67 that impacts GFX executor timing
+- Potential timing bug when running GFX Executor in warp-subexecutor mode with small data sizes
+
 ## v1.67.00
 ### Added
 - Added NIC_TRAFFIC_CLASS to set the DSCP/traffic class byte in the RoCE GRH for QPs (RoCE only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ Documentation for TransferBench is available at
 
 ## v1.68.00
 ### Fixed
-- Improper draining of writes introduced in v1.67 that impacts GFX executor timing
+- Improper draining of writes that could artificially inflate transfer timing
 - Potential timing bug when running GFX Executor in warp-subexecutor mode with small data sizes
+- Keeping subiteration threads in sync per subiteration
 
 ## v1.67.00
 ### Added

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -92,7 +92,7 @@ namespace TransferBench
   using std::set;
   using std::vector;
 
-  constexpr char VERSION[] = "1.67";
+  constexpr char VERSION[] = "1.68";
 
   /**
    * Enumeration of supported Executor types
@@ -5040,6 +5040,9 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       if (++subIterations == numSubIterations) break;
     }
 
+    // Drain every thread's writes out to system scope
+    __threadfence_system();
+
     // Wait for all threads to finish
     if (seType == 1) {
       // For warp-level, sync within warp only
@@ -5216,6 +5219,9 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       // Allows for numSubiterations == 0 to run infinitely
       if (++subIterations == numSubIterations) break;
     }
+
+    // Drain every thread's writes out to system scope
+    __threadfence_system();
 
     // Wait for all threads to finish
     if (seType == 1) {
@@ -5400,8 +5406,8 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
                                   int           const  exeIndex,
                                   ExeInfo&             exeInfo)
   {
-    auto cpuStart = std::chrono::high_resolution_clock::now();
     ERR_CHECK(hipSetDevice(exeIndex));
+    auto cpuStart = std::chrono::high_resolution_clock::now();
 
     int xccDim = exeInfo.useSubIndices ? exeInfo.numSubIndices : 1;
 
@@ -5459,12 +5465,14 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
           std::set<std::pair<int, int>> CUs;
 
           for (auto subExecIdx : rss.subExecIdx) {
-            minStartCycle = std::min(minStartCycle, exeInfo.subExecParamGpu[subExecIdx].startCycle);
-            maxStopCycle  = std::max(maxStopCycle,  exeInfo.subExecParamGpu[subExecIdx].stopCycle);
-            if (cfg.general.recordPerIteration) {
-              CUs.insert(std::make_pair(exeInfo.subExecParamGpu[subExecIdx].xccId,
-                                        GetId(exeInfo.subExecParamGpu[subExecIdx].hwId)));
-            }
+	    if (exeInfo.subExecParamCpu[subExecIdx].N != 0) {
+	      minStartCycle = std::min(minStartCycle, exeInfo.subExecParamGpu[subExecIdx].startCycle);
+	      maxStopCycle  = std::max(maxStopCycle,  exeInfo.subExecParamGpu[subExecIdx].stopCycle);
+	      if (cfg.general.recordPerIteration) {
+		CUs.insert(std::make_pair(exeInfo.subExecParamGpu[subExecIdx].xccId,
+					  GetId(exeInfo.subExecParamGpu[subExecIdx].hwId)));
+	      }
+	    }
           }
 
           double deltaMsec = (maxStopCycle - minStartCycle) / (double)(exeInfo.wallClockRate);

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -5036,24 +5036,25 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
           }
         }
       }
+
+      // Drain every thread's writes out to system scope
+      __threadfence_system();
+
+      // Wait for all threads to finish this subiteration
+      if (seType == 1) {
+        // For warp-level, sync within warp only
+#if defined(__HIP_PLATFORM_AMD__) && (HIP_VERSION_MAJOR < 7)
+        __builtin_amdgcn_wave_barrier();
+#else
+        __syncwarp();
+#endif
+      } else {
+        // For threadblock-level, sync all threads
+        __syncthreads();
+      }
+
       // Allows for numSubiterations == 0 to run infinitely
       if (++subIterations == numSubIterations) break;
-    }
-
-    // Drain every thread's writes out to system scope
-    __threadfence_system();
-
-    // Wait for all threads to finish
-    if (seType == 1) {
-      // For warp-level, sync within warp only
-#if defined(__HIP_PLATFORM_AMD__) && (HIP_VERSION_MAJOR < 7)
-      __builtin_amdgcn_wave_barrier();
-#else
-      __syncwarp();
-#endif
-    } else {
-      // For threadblock-level, sync all threads
-      __syncthreads();
     }
 
     if (shouldRecordTiming) {
@@ -5216,25 +5217,25 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
           }
         }
       }
+
+      // Drain every thread's writes out to system scope
+      __threadfence_system();
+
+      // Wait for all threads to finish this subiteration
+      if (seType == 1) {
+        // For warp-level, sync within warp only
+#if defined(__HIP_PLATFORM_AMD__) && (HIP_VERSION_MAJOR < 7)
+        __builtin_amdgcn_wave_barrier();
+#else
+        __syncwarp();
+#endif
+      } else {
+        // For threadblock-level, sync all threads
+        __syncthreads();
+      }
+
       // Allows for numSubiterations == 0 to run infinitely
       if (++subIterations == numSubIterations) break;
-    }
-
-    // Drain every thread's writes out to system scope
-    __threadfence_system();
-
-    // Wait for all threads to finish
-    if (seType == 1) {
-      // For warp-level, sync within warp only
-#if defined(__HIP_PLATFORM_AMD__) && (HIP_VERSION_MAJOR < 7)
-      __builtin_amdgcn_wave_barrier();
-#else
-
-      __syncwarp();
-#endif
-    } else {
-      // For threadblock-level, sync all threads
-      __syncthreads();
     }
 
     if (shouldRecordTiming) {
@@ -5406,8 +5407,8 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
                                   int           const  exeIndex,
                                   ExeInfo&             exeInfo)
   {
-    ERR_CHECK(hipSetDevice(exeIndex));
     auto cpuStart = std::chrono::high_resolution_clock::now();
+    ERR_CHECK(hipSetDevice(exeIndex));
 
     int xccDim = exeInfo.useSubIndices ? exeInfo.numSubIndices : 1;
 
@@ -5465,14 +5466,14 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
           std::set<std::pair<int, int>> CUs;
 
           for (auto subExecIdx : rss.subExecIdx) {
-	    if (exeInfo.subExecParamCpu[subExecIdx].N != 0) {
-	      minStartCycle = std::min(minStartCycle, exeInfo.subExecParamGpu[subExecIdx].startCycle);
-	      maxStopCycle  = std::max(maxStopCycle,  exeInfo.subExecParamGpu[subExecIdx].stopCycle);
-	      if (cfg.general.recordPerIteration) {
-		CUs.insert(std::make_pair(exeInfo.subExecParamGpu[subExecIdx].xccId,
-					  GetId(exeInfo.subExecParamGpu[subExecIdx].hwId)));
-	      }
-	    }
+            if (exeInfo.subExecParamCpu[subExecIdx].N != 0) {
+              minStartCycle = std::min(minStartCycle, exeInfo.subExecParamGpu[subExecIdx].startCycle);
+              maxStopCycle  = std::max(maxStopCycle,  exeInfo.subExecParamGpu[subExecIdx].stopCycle);
+              if (cfg.general.recordPerIteration) {
+                CUs.insert(std::make_pair(exeInfo.subExecParamGpu[subExecIdx].xccId,
+                                          GetId(exeInfo.subExecParamGpu[subExecIdx].hwId)));
+              }
+            }
           }
 
           double deltaMsec = (maxStopCycle - minStartCycle) / (double)(exeInfo.wallClockRate);


### PR DESCRIPTION
The threadfence_system prior to timestamp collection in v1.67 was accidentally removed which could cause artificially inflated Transfer times because stop timestamp could be collected prior to all writes being drained.  This should not have impacted GFX Executor times.