### PR TITLE
[debug] option to disable validation

### DIFF
--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -588,7 +588,7 @@ public:
     return defaultValue;
   }
 
-  // Validates ALWAYS_VALIDATE is one of the supported modes (-1/0/1); warns and clamps otherwise
+  // Clamps ALWAYS_VALIDATE to a supported mode (-1/0/1), warning on invalid input
   static int NormalizeValidateMode(int value)
   {
     if (value < -1 || value > 1) {

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -79,7 +79,7 @@ public:
   int useInteractive;                // Pause for user-input before starting transfer loop
 
   // Data options
-  int alwaysValidate;                // 0 = disable validation, 1 = validate once after all iterations, 2 = validate after each iteration
+  int alwaysValidate;                // -1 = disable validation, 0 = validate once after all iterations, 1 = validate after each iteration
   int blockBytes;                    // Each subexecutor, except the last, gets a multiple of this many bytes to copy
   int byteOffset;                    // Byte-offset for memory allocations
   vector<float> fillPattern;         // Pattern of floats used to fill source data
@@ -149,7 +149,7 @@ public:
     else if (archName == "gfx942") defaultGfxUnroll = 4;
     else if (archName == "gfx950") defaultGfxUnroll = 4;
 
-    alwaysValidate    = GetEnvVar("ALWAYS_VALIDATE"     , 1);
+    alwaysValidate    = GetEnvVar("ALWAYS_VALIDATE"     , 0);
     blockBytes        = GetEnvVar("BLOCK_BYTES"         , 256);
     byteOffset        = GetEnvVar("BYTE_OFFSET"         , 0);
     fillCompress      = GetEnvVarArray("FILL_COMPRESS"  , {});
@@ -352,7 +352,7 @@ public:
   {
     printf("Environment variables (client):\n");
     printf("======================\n");
-    printf(" ALWAYS_VALIDATE     - Data validation mode: 0=disabled, 1=validate once after all iterations (default), 2=validate after each iteration\n");
+    printf(" ALWAYS_VALIDATE     - Data validation mode: -1=disabled, 0=validate once after all iterations (default), 1=validate after each iteration\n");
     printf(" BLOCK_BYTES         - Controls granularity of how work is divided across subExecutors\n");
     printf(" BYTE_OFFSET         - Initial byte-offset for memory allocations.  Must be multiple of 4\n");
     printf(" CU_MASK             - CU mask for streams. Can specify ranges e.g '5,10-12,14'\n");
@@ -454,8 +454,8 @@ public:
     if (hideEnv) return;
 
     Print("ALWAYS_VALIDATE", alwaysValidate,
-          "Validation %s", (alwaysValidate == 0 ? "disabled" :
-                            alwaysValidate == 2 ? "after each iteration" : "after all iterations"));
+          "Validation %s", (alwaysValidate < 0 ? "disabled" :
+                            alwaysValidate == 1 ? "after each iteration" : "after all iterations"));
     Print("BLOCK_BYTES", blockBytes,
           "Each CU gets a mulitple of %d bytes to copy", blockBytes);
     Print("BYTE_OFFSET", byteOffset,

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -79,7 +79,7 @@ public:
   int useInteractive;                // Pause for user-input before starting transfer loop
 
   // Data options
-  int alwaysValidate;                // -1 = disable validation, 0 = validate once after all iterations, 1 = validate after each iteration
+  int alwaysValidate;                // <0 = disable validation, 0 = validate once after all iterations, >0 = validate after each iteration
   int blockBytes;                    // Each subexecutor, except the last, gets a multiple of this many bytes to copy
   int byteOffset;                    // Byte-offset for memory allocations
   vector<float> fillPattern;         // Pattern of floats used to fill source data
@@ -149,7 +149,7 @@ public:
     else if (archName == "gfx942") defaultGfxUnroll = 4;
     else if (archName == "gfx950") defaultGfxUnroll = 4;
 
-    alwaysValidate    = NormalizeValidateMode(GetEnvVar("ALWAYS_VALIDATE", 0));
+    alwaysValidate    = GetEnvVar("ALWAYS_VALIDATE", 0);
     blockBytes        = GetEnvVar("BLOCK_BYTES"         , 256);
     byteOffset        = GetEnvVar("BYTE_OFFSET"         , 0);
     fillCompress      = GetEnvVarArray("FILL_COMPRESS"  , {});
@@ -352,7 +352,7 @@ public:
   {
     printf("Environment variables (client):\n");
     printf("======================\n");
-    printf(" ALWAYS_VALIDATE     - Data validation mode: -1=disabled, 0=validate once after all iterations (default), 1=validate after each iteration\n");
+    printf(" ALWAYS_VALIDATE     - Data validation mode: <0=disabled, 0=validate once after all iterations (default), >0=validate after each iteration\n");
     printf(" BLOCK_BYTES         - Controls granularity of how work is divided across subExecutors\n");
     printf(" BYTE_OFFSET         - Initial byte-offset for memory allocations.  Must be multiple of 4\n");
     printf(" CU_MASK             - CU mask for streams. Can specify ranges e.g '5,10-12,14'\n");
@@ -455,7 +455,7 @@ public:
 
     Print("ALWAYS_VALIDATE", alwaysValidate,
           "Validation %s", (alwaysValidate < 0 ? "disabled" :
-                            alwaysValidate == 1 ? "after each iteration" : "after all iterations"));
+                            alwaysValidate > 0 ? "after each iteration" : "after all iterations"));
     Print("BLOCK_BYTES", blockBytes,
           "Each CU gets a mulitple of %d bytes to copy", blockBytes);
     Print("BYTE_OFFSET", byteOffset,
@@ -586,18 +586,6 @@ public:
       return val;
     }
     return defaultValue;
-  }
-
-  // Clamps ALWAYS_VALIDATE to a supported mode (-1/0/1), warning on invalid input
-  static int NormalizeValidateMode(int value)
-  {
-    if (value < -1 || value > 1) {
-      int clamped = (value < -1) ? -1 : 1;
-      printf("[WARN] ALWAYS_VALIDATE=%d is invalid; expected -1 (disabled), 0 (validate at end), "
-             "or 1 (validate each iteration). Clamping to %d\n", value, clamped);
-      value = clamped;
-    }
-    return value;
   }
 
   // Returns comma-split tokens for varname, or an empty optional if unset/empty (use default).

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -149,7 +149,7 @@ public:
     else if (archName == "gfx942") defaultGfxUnroll = 4;
     else if (archName == "gfx950") defaultGfxUnroll = 4;
 
-    alwaysValidate    = GetEnvVar("ALWAYS_VALIDATE"     , 0);
+    alwaysValidate    = NormalizeValidateMode(GetEnvVar("ALWAYS_VALIDATE", 0));
     blockBytes        = GetEnvVar("BLOCK_BYTES"         , 256);
     byteOffset        = GetEnvVar("BYTE_OFFSET"         , 0);
     fillCompress      = GetEnvVarArray("FILL_COMPRESS"  , {});
@@ -586,6 +586,18 @@ public:
       return val;
     }
     return defaultValue;
+  }
+
+  // Validates ALWAYS_VALIDATE is one of the supported modes (-1/0/1); warns and clamps otherwise
+  static int NormalizeValidateMode(int value)
+  {
+    if (value < -1 || value > 1) {
+      int clamped = (value < -1) ? -1 : 1;
+      printf("[WARN] ALWAYS_VALIDATE=%d is invalid; expected -1 (disabled), 0 (validate at end), "
+             "or 1 (validate each iteration). Clamping to %d\n", value, clamped);
+      value = clamped;
+    }
+    return value;
   }
 
   // Returns comma-split tokens for varname, or an empty optional if unset/empty (use default).

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -79,7 +79,7 @@ public:
   int useInteractive;                // Pause for user-input before starting transfer loop
 
   // Data options
-  int alwaysValidate;                // Validate after each iteration instead of once after all iterations
+  int alwaysValidate;                // 0 = disable validation, 1 = validate once after all iterations, 2 = validate after each iteration
   int blockBytes;                    // Each subexecutor, except the last, gets a multiple of this many bytes to copy
   int byteOffset;                    // Byte-offset for memory allocations
   vector<float> fillPattern;         // Pattern of floats used to fill source data
@@ -149,7 +149,7 @@ public:
     else if (archName == "gfx942") defaultGfxUnroll = 4;
     else if (archName == "gfx950") defaultGfxUnroll = 4;
 
-    alwaysValidate    = GetEnvVar("ALWAYS_VALIDATE"     , 0);
+    alwaysValidate    = GetEnvVar("ALWAYS_VALIDATE"     , 1);
     blockBytes        = GetEnvVar("BLOCK_BYTES"         , 256);
     byteOffset        = GetEnvVar("BYTE_OFFSET"         , 0);
     fillCompress      = GetEnvVarArray("FILL_COMPRESS"  , {});
@@ -352,7 +352,7 @@ public:
   {
     printf("Environment variables (client):\n");
     printf("======================\n");
-    printf(" ALWAYS_VALIDATE     - Validate after each iteration instead of once after all iterations\n");
+    printf(" ALWAYS_VALIDATE     - Data validation mode: 0=disabled, 1=validate once after all iterations (default), 2=validate after each iteration\n");
     printf(" BLOCK_BYTES         - Controls granularity of how work is divided across subExecutors\n");
     printf(" BYTE_OFFSET         - Initial byte-offset for memory allocations.  Must be multiple of 4\n");
     printf(" CU_MASK             - CU mask for streams. Can specify ranges e.g '5,10-12,14'\n");
@@ -454,7 +454,8 @@ public:
     if (hideEnv) return;
 
     Print("ALWAYS_VALIDATE", alwaysValidate,
-          "Validating after %s", (alwaysValidate ? "each iteration" : "all iterations"));
+          "Validation %s", (alwaysValidate == 0 ? "disabled" :
+                            alwaysValidate == 2 ? "after each iteration" : "after all iterations"));
     Print("BLOCK_BYTES", blockBytes,
           "Each CU gets a mulitple of %d bytes to copy", blockBytes);
     Print("BYTE_OFFSET", byteOffset,

--- a/src/client/Presets/SmokeTest.hpp
+++ b/src/client/Presets/SmokeTest.hpp
@@ -211,7 +211,7 @@ int SmokeTestPreset(EnvVars&          ev,
   }
 
   // Modify defaults unless they were set
-  ev.alwaysValidate = EnvVars::NormalizeValidateMode(EnvVars::GetEnvVar("ALWAYS_VALIDATE", 1));
+  ev.alwaysValidate = EnvVars::GetEnvVar("ALWAYS_VALIDATE", 1);
   ev.numIterations  = EnvVars::GetEnvVar("NUM_ITERATIONS",  2);
   ev.numWarmups     = EnvVars::GetEnvVar("NUM_WARMUPS",     0);
 

--- a/src/client/Presets/SmokeTest.hpp
+++ b/src/client/Presets/SmokeTest.hpp
@@ -211,7 +211,7 @@ int SmokeTestPreset(EnvVars&          ev,
   }
 
   // Modify defaults unless they were set
-  ev.alwaysValidate = EnvVars::GetEnvVar("ALWAYS_VALIDATE", 1);
+  ev.alwaysValidate = EnvVars::NormalizeValidateMode(EnvVars::GetEnvVar("ALWAYS_VALIDATE", 1));
   ev.numIterations  = EnvVars::GetEnvVar("NUM_ITERATIONS",  2);
   ev.numWarmups     = EnvVars::GetEnvVar("NUM_WARMUPS",     0);
 

--- a/src/client/Presets/SmokeTest.hpp
+++ b/src/client/Presets/SmokeTest.hpp
@@ -211,7 +211,7 @@ int SmokeTestPreset(EnvVars&          ev,
   }
 
   // Modify defaults unless they were set
-  ev.alwaysValidate = EnvVars::GetEnvVar("ALWAYS_VALIDATE", 1);
+  ev.alwaysValidate = EnvVars::GetEnvVar("ALWAYS_VALIDATE", 2);
   ev.numIterations  = EnvVars::GetEnvVar("NUM_ITERATIONS",  2);
   ev.numWarmups     = EnvVars::GetEnvVar("NUM_WARMUPS",     0);
 

--- a/src/client/Presets/SmokeTest.hpp
+++ b/src/client/Presets/SmokeTest.hpp
@@ -211,7 +211,7 @@ int SmokeTestPreset(EnvVars&          ev,
   }
 
   // Modify defaults unless they were set
-  ev.alwaysValidate = EnvVars::GetEnvVar("ALWAYS_VALIDATE", 2);
+  ev.alwaysValidate = EnvVars::GetEnvVar("ALWAYS_VALIDATE", 1);
   ev.numIterations  = EnvVars::GetEnvVar("NUM_ITERATIONS",  2);
   ev.numWarmups     = EnvVars::GetEnvVar("NUM_WARMUPS",     0);
 

--- a/src/client/Utilities.hpp
+++ b/src/client/Utilities.hpp
@@ -551,6 +551,8 @@ namespace TransferBench::Utils
     if (!RankDoesOutput()) return;
 
     if (!ev.outputToCsv) printf("Test %d:\n", testNum);
+    if (ev.alwaysValidate < 0 && !ev.outputToCsv)
+      printf("Validation disabled (ALWAYS_VALIDATE < 0)\n");
 
     bool isMultiRank = TransferBench::GetNumRanks() > 1;
 

--- a/src/client/Utilities.hpp
+++ b/src/client/Utilities.hpp
@@ -551,7 +551,7 @@ namespace TransferBench::Utils
     if (!RankDoesOutput()) return;
 
     if (!ev.outputToCsv) printf("Test %d:\n", testNum);
-    if (ev.alwaysValidate < 0 && !ev.outputToCsv)
+    if (ev.alwaysValidate < 0 && !ev.outputToCsv && !ev.useInteractive)
       printf("Validation disabled (ALWAYS_VALIDATE < 0)\n");
 
     bool isMultiRank = TransferBench::GetNumRanks() > 1;

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -217,7 +217,7 @@ namespace TransferBench
    */
   struct DataOptions
   {
-    int           alwaysValidate   = 1;         ///< 0 = disable validation, 1 = validate once at end, 2 = validate after each iteration
+    int           alwaysValidate   = 0;         ///< -1 = disable validation, 0 = validate once at end, 1 = validate after each iteration
     int           blockBytes       = 256;       ///< Each subexecutor works on a multiple of this many bytes
     int           byteOffset       = 0;         ///< Byte-offset for memory allocations
     vector<float> fillPattern      = {};        ///< Pattern of floats used to fill source data
@@ -6012,7 +6012,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       auto cpuDelta = std::chrono::high_resolution_clock::now() - cpuStart;
       double deltaSec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() / cfg.general.numSubIterations;
 
-      if (cfg.data.alwaysValidate == 2) {
+      if (cfg.data.alwaysValidate == 1) {
         ERR_APPEND(ValidateAllTransfers(cfg, transfers, transferResources, dstReference, outputBuffer),
                    errResults);
       }
@@ -6024,9 +6024,9 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
 
     // Pause for interactive mode - validation is a separate stage triggered by user input.
-    // Only for mode 1 (validate at end); mode 2 already validates inline each iteration,
-    // and mode 0 disables validation entirely.
-    if (cfg.general.useInteractive && cfg.data.alwaysValidate == 1) {
+    // Only for mode 0 (validate at end); mode 1 already validates inline each iteration,
+    // and mode -1 disables validation entirely.
+    if (cfg.general.useInteractive && cfg.data.alwaysValidate == 0) {
       if (localRank == 0) {
         System::Get().Log("Transfers complete. Hit <Enter> to run validation: ");
         fflush(stdout);
@@ -6088,7 +6088,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
 
     // Validate results
-    if (cfg.data.alwaysValidate == 1) {
+    if (cfg.data.alwaysValidate == 0) {
       ERR_APPEND(ValidateAllTransfers(cfg, transfers, transferResources, dstReference, outputBuffer),
                  errResults);
     }

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -6029,23 +6029,32 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       }
     }
 
-    // Interactive per-transfer validation display (skipped when validation disabled). Actual
-    // validation is done by ValidateAllTransfers (mode 0) or inline each iteration (mode >0);
-    // this only displays.
+    // Interactive per-transfer PASS/FAIL display (skipped when validation disabled). This does its
+    // own comparison pass to show results; authoritative error reporting still comes from
+    // ValidateAllTransfers (mode 0) or the inline per-iteration validation (mode >0).
     if (cfg.general.useInteractive && cfg.data.alwaysValidate >= 0) {
+      bool inputOk = true;
       if (localRank == 0) {
         if (cfg.data.alwaysValidate == 0) {
           System::Get().Log("Transfers complete. Hit <Enter> to run validation: ");
           fflush(stdout);
           if (getchar() == EOF) {
             System::Get().Log("[ERROR] Unexpected EOF while waiting for input\n");
-            exit(1);
+            inputOk = false;
+          } else {
+            System::Get().Log("\nValidation results:\n");
           }
-          System::Get().Log("\nValidation results:\n");
         } else {
           System::Get().Log("Transfers complete.\nValidation results:\n");
         }
+      }
 
+      // Coordinate any EOF abort so no rank is left waiting at the Barrier below
+      System::Get().Broadcast(0, sizeof(inputOk), &inputOk);
+      if (!inputOk)
+        ERR_APPEND((ErrResult{ERR_FATAL, "Unexpected EOF while waiting for interactive input"}), errResults);
+
+      if (localRank == 0) {
         size_t initOffset = cfg.data.byteOffset / sizeof(float);
         int numPass = 0, numFail = 0;
         for (auto rss : transferResources) {

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -6025,9 +6025,13 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
 
     // Pause for interactive mode - validation is a separate stage triggered by user input.
     // Only for mode 0 (validate at end); mode 1 already validates inline each iteration,
-    // and mode -1 disables validation entirely.
+    // and mode -1 disables validation entirely. When the interactive stage validates a rank's
+    // local destinations here, the end-of-run ValidateAllTransfers is skipped for that rank to
+    // avoid validating twice.
+    bool interactiveValidated = false;
     if (cfg.general.useInteractive && cfg.data.alwaysValidate == 0) {
       if (localRank == 0) {
+        interactiveValidated = true;
         System::Get().Log("Transfers complete. Hit <Enter> to run validation: ");
         fflush(stdout);
         if (scanf("%*c") != 0) {
@@ -6069,12 +6073,18 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
               size_t firstErr = 0;
               for (; firstErr < N; firstErr++)
                 if (output[firstErr] != expected[firstErr]) break;
-              if (firstErr < N)
+              if (firstErr < N) {
                 System::Get().Log("  DST[%d]=FAIL(first mismatch idx=%zu exp=%.5f got=%.5f)",
                                   dstIdx, firstErr, expected[firstErr], output[firstErr]);
-              else
+                errResults.push_back({ERR_FATAL,
+                  "Transfer %d: Unexpected mismatch at index %lu of destination %d on rank %d: Expected %10.5f Actual: %10.5f",
+                  transferIdx, firstErr, dstIdx, t.dsts[dstIdx].memRank, expected[firstErr], output[firstErr]});
+              } else {
                 System::Get().Log("  DST[%d]=FAIL(bitwise mismatch, no float-level diff found)",
                                   dstIdx);
+                errResults.push_back({ERR_FATAL,
+                  "Transfer %d: Unexpected output mismatch for destination %d", transferIdx, dstIdx});
+              }
               transferOk = false;
             }
           }
@@ -6087,8 +6097,8 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       System::Get().Barrier();
     }
 
-    // Validate results
-    if (cfg.data.alwaysValidate == 0) {
+    // Validate results (skip on ranks already validated by the interactive stage above)
+    if (cfg.data.alwaysValidate == 0 && !interactiveValidated) {
       ERR_APPEND(ValidateAllTransfers(cfg, transfers, transferResources, dstReference, outputBuffer),
                  errResults);
     }

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -6034,8 +6034,8 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
         interactiveValidated = true;
         System::Get().Log("Transfers complete. Hit <Enter> to run validation: ");
         fflush(stdout);
-        if (scanf("%*c") != 0) {
-          System::Get().Log("[ERROR] Unexpected input\n");
+        if (getchar() == EOF) {
+          System::Get().Log("[ERROR] Unexpected EOF while waiting for input\n");
           exit(1);
         }
         System::Get().Log("\nValidation results:\n");

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -6043,7 +6043,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
           }
           System::Get().Log("\nValidation results:\n");
         } else {
-          System::Get().Log("Validation results:\n");
+          System::Get().Log("Transfers complete.\nValidation results:\n");
         }
 
         size_t initOffset = cfg.data.byteOffset / sizeof(float);
@@ -6094,6 +6094,10 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
         System::Get().Log("  Summary: %d PASS  %d FAIL\n", numPass, numFail);
         fflush(stdout);
       }
+      System::Get().Barrier();
+    } else if (cfg.general.useInteractive) {
+      if (localRank == 0)
+        System::Get().Log("Transfers complete. Validation disabled (ALWAYS_VALIDATE < 0)\n");
       System::Get().Barrier();
     }
 

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -6023,10 +6023,18 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       }
     }
 
-    // Pause for interactive mode - run validation and show per-transfer result before prompt
-    if (cfg.general.useInteractive) {
+    // Pause for interactive mode - validation is a separate stage triggered by user input.
+    // Only for mode 1 (validate at end); mode 2 already validates inline each iteration,
+    // and mode 0 disables validation entirely.
+    if (cfg.general.useInteractive && cfg.data.alwaysValidate == 1) {
       if (localRank == 0) {
-        System::Get().Log("Transfers complete. Validation results:\n");
+        System::Get().Log("Transfers complete. Hit <Enter> to run validation: ");
+        fflush(stdout);
+        if (scanf("%*c") != 0) {
+          System::Get().Log("[ERROR] Unexpected input\n");
+          exit(1);
+        }
+        System::Get().Log("\nValidation results:\n");
 
         size_t initOffset = cfg.data.byteOffset / sizeof(float);
         int numPass = 0, numFail = 0;
@@ -6074,13 +6082,6 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
           if (anyLocalDst) { if (transferOk) ++numPass; else ++numFail; }
         }
         System::Get().Log("  Summary: %d PASS  %d FAIL\n", numPass, numFail);
-        System::Get().Log("Hit <Enter> to continue: ");
-        fflush(stdout);
-        if (scanf("%*c") != 0)  {
-          System::Get().Log("[ERROR] Unexpected input\n");
-          exit(1);
-        }
-        System::Get().Log("\n");
         fflush(stdout);
       }
       System::Get().Barrier();

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -217,7 +217,7 @@ namespace TransferBench
    */
   struct DataOptions
   {
-    int           alwaysValidate   = 0;         ///< Validate after each iteration instead of once at end
+    int           alwaysValidate   = 1;         ///< 0 = disable validation, 1 = validate once at end, 2 = validate after each iteration
     int           blockBytes       = 256;       ///< Each subexecutor works on a multiple of this many bytes
     int           byteOffset       = 0;         ///< Byte-offset for memory allocations
     vector<float> fillPattern      = {};        ///< Pattern of floats used to fill source data
@@ -6012,7 +6012,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       auto cpuDelta = std::chrono::high_resolution_clock::now() - cpuStart;
       double deltaSec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() / cfg.general.numSubIterations;
 
-      if (cfg.data.alwaysValidate) {
+      if (cfg.data.alwaysValidate == 2) {
         ERR_APPEND(ValidateAllTransfers(cfg, transfers, transferResources, dstReference, outputBuffer),
                    errResults);
       }
@@ -6087,7 +6087,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
     }
 
     // Validate results
-    if (!cfg.data.alwaysValidate) {
+    if (cfg.data.alwaysValidate == 1) {
       ERR_APPEND(ValidateAllTransfers(cfg, transfers, transferResources, dstReference, outputBuffer),
                  errResults);
     }

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -6023,15 +6023,10 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       }
     }
 
-    // Show per-transfer validation results in interactive mode (skipped for mode -1, disabled).
-    // For mode 0 (validate at end) this stage is the validation path: it is gated behind an
-    // <Enter> keypress, records failures into errResults, and lets the end-of-run
-    // ValidateAllTransfers be skipped for the rank to avoid validating twice.
-    // For mode 1 (validate each iteration) validation already ran inline; this stage only
-    // displays the results and does not require an <Enter> keypress.
+    // Interactive per-transfer validation display (skipped for mode -1)
     bool interactiveValidated = false;
     if (cfg.general.useInteractive && cfg.data.alwaysValidate != -1) {
-      // Mode 0 uses this stage as the authoritative validation path
+      // Mode 0 validates here (<Enter>-gated); mode 1 already validated inline, only display
       bool const isValidationPath = (cfg.data.alwaysValidate == 0);
       if (localRank == 0) {
         if (isValidationPath) {

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -217,7 +217,7 @@ namespace TransferBench
    */
   struct DataOptions
   {
-    int           alwaysValidate   = 0;         ///< -1 = disable validation, 0 = validate once at end, 1 = validate after each iteration
+    int           alwaysValidate   = 0;         ///< <0 = disable validation, 0 = validate once at end, >0 = validate after each iteration
     int           blockBytes       = 256;       ///< Each subexecutor works on a multiple of this many bytes
     int           byteOffset       = 0;         ///< Byte-offset for memory allocations
     vector<float> fillPattern      = {};        ///< Pattern of floats used to fill source data
@@ -5878,24 +5878,30 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       }
     }
 
-    // Prepare reference src/dst arrays - only once for largest size
+    // Prepare reference src/dst arrays - only once for largest size.
+    // dstReference (expected results) is only needed when validation is enabled.
+    bool const validateEnabled = (cfg.data.alwaysValidate >= 0);
     size_t maxN = maxNumBytes / sizeof(float);
-    vector<float> outputBuffer(maxN);
-    vector<vector<float>> dstReference(maxNumSrcs + 1, vector<float>(maxN));
+    vector<float> outputBuffer(validateEnabled ? maxN : 0);
+    vector<vector<float>> dstReference;
     {
       size_t initOffset = cfg.data.byteOffset / sizeof(float);
       vector<vector<float>> srcReference(maxNumSrcs, vector<float>(maxN));
-      memset(dstReference[0].data(), MEMSET_CHAR, maxNumBytes);
 
+      if (validateEnabled) {
+        dstReference.assign(maxNumSrcs + 1, vector<float>(maxN));
+        memset(dstReference[0].data(), MEMSET_CHAR, maxNumBytes);
+      }
       for (int numSrcs = 0; numSrcs < maxNumSrcs; numSrcs++) {
         PrepareReference(cfg, srcReference[numSrcs], numSrcs);
-        for (int i = 0; i < maxN; i++) {
-          dstReference[numSrcs+1][i] = (numSrcs == 0 ? 0 : dstReference[numSrcs][i]) + srcReference[numSrcs][i];
-        }
+        if (validateEnabled)
+          for (int i = 0; i < maxN; i++)
+            dstReference[numSrcs+1][i] = (numSrcs == 0 ? 0 : dstReference[numSrcs][i]) + srcReference[numSrcs][i];
       }
       // Release un-used partial sums
-      for (int numSrcs = 0; numSrcs < minNumSrcs; numSrcs++)
-        dstReference[numSrcs].clear();
+      if (validateEnabled)
+        for (int numSrcs = 0; numSrcs < minNumSrcs; numSrcs++)
+          dstReference[numSrcs].clear();
 
       // Initialize all src memory buffers (if on local rank)
       bool const verbose = System::Get().IsVerbose();
@@ -6012,7 +6018,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       auto cpuDelta = std::chrono::high_resolution_clock::now() - cpuStart;
       double deltaSec = std::chrono::duration_cast<std::chrono::duration<double>>(cpuDelta).count() / cfg.general.numSubIterations;
 
-      if (cfg.data.alwaysValidate == 1) {
+      if (cfg.data.alwaysValidate > 0) {
         ERR_APPEND(ValidateAllTransfers(cfg, transfers, transferResources, dstReference, outputBuffer),
                    errResults);
       }
@@ -6023,14 +6029,12 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       }
     }
 
-    // Interactive per-transfer validation display (skipped for mode -1)
-    bool interactiveValidated = false;
-    if (cfg.general.useInteractive && cfg.data.alwaysValidate != -1) {
-      // Mode 0 validates here (<Enter>-gated); mode 1 already validated inline, only display
-      bool const isValidationPath = (cfg.data.alwaysValidate == 0);
+    // Interactive per-transfer validation display (skipped when validation disabled). Actual
+    // validation is done by ValidateAllTransfers (mode 0) or inline each iteration (mode >0);
+    // this only displays.
+    if (cfg.general.useInteractive && cfg.data.alwaysValidate >= 0) {
       if (localRank == 0) {
-        if (isValidationPath) {
-          interactiveValidated = true;
+        if (cfg.data.alwaysValidate == 0) {
           System::Get().Log("Transfers complete. Hit <Enter> to run validation: ");
           fflush(stdout);
           if (getchar() == EOF) {
@@ -6075,20 +6079,12 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
               size_t firstErr = 0;
               for (; firstErr < N; firstErr++)
                 if (output[firstErr] != expected[firstErr]) break;
-              if (firstErr < N) {
+              if (firstErr < N)
                 System::Get().Log("  DST[%d]=FAIL(first mismatch idx=%zu exp=%.5f got=%.5f)",
                                   dstIdx, firstErr, expected[firstErr], output[firstErr]);
-                if (isValidationPath)
-                  errResults.push_back({ERR_FATAL,
-                    "Transfer %d: Unexpected mismatch at index %lu of destination %d on rank %d: Expected %10.5f Actual: %10.5f",
-                    transferIdx, firstErr, dstIdx, t.dsts[dstIdx].memRank, expected[firstErr], output[firstErr]});
-              } else {
+              else
                 System::Get().Log("  DST[%d]=FAIL(bitwise mismatch, no float-level diff found)",
                                   dstIdx);
-                if (isValidationPath)
-                  errResults.push_back({ERR_FATAL,
-                    "Transfer %d: Unexpected output mismatch for destination %d", transferIdx, dstIdx});
-              }
               transferOk = false;
             }
           }
@@ -6101,8 +6097,8 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       System::Get().Barrier();
     }
 
-    // Validate results (skip on ranks already validated by the interactive stage above)
-    if (cfg.data.alwaysValidate == 0 && !interactiveValidated) {
+    // Validate results
+    if (cfg.data.alwaysValidate == 0) {
       ERR_APPEND(ValidateAllTransfers(cfg, transfers, transferResources, dstReference, outputBuffer),
                  errResults);
     }

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -6023,22 +6023,29 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
       }
     }
 
-    // Pause for interactive mode - validation is a separate stage triggered by user input.
-    // Only for mode 0 (validate at end); mode 1 already validates inline each iteration,
-    // and mode -1 disables validation entirely. When the interactive stage validates a rank's
-    // local destinations here, the end-of-run ValidateAllTransfers is skipped for that rank to
-    // avoid validating twice.
+    // Show per-transfer validation results in interactive mode (skipped for mode -1, disabled).
+    // For mode 0 (validate at end) this stage is the validation path: it is gated behind an
+    // <Enter> keypress, records failures into errResults, and lets the end-of-run
+    // ValidateAllTransfers be skipped for the rank to avoid validating twice.
+    // For mode 1 (validate each iteration) validation already ran inline; this stage only
+    // displays the results and does not require an <Enter> keypress.
     bool interactiveValidated = false;
-    if (cfg.general.useInteractive && cfg.data.alwaysValidate == 0) {
+    if (cfg.general.useInteractive && cfg.data.alwaysValidate != -1) {
+      // Mode 0 uses this stage as the authoritative validation path
+      bool const isValidationPath = (cfg.data.alwaysValidate == 0);
       if (localRank == 0) {
-        interactiveValidated = true;
-        System::Get().Log("Transfers complete. Hit <Enter> to run validation: ");
-        fflush(stdout);
-        if (getchar() == EOF) {
-          System::Get().Log("[ERROR] Unexpected EOF while waiting for input\n");
-          exit(1);
+        if (isValidationPath) {
+          interactiveValidated = true;
+          System::Get().Log("Transfers complete. Hit <Enter> to run validation: ");
+          fflush(stdout);
+          if (getchar() == EOF) {
+            System::Get().Log("[ERROR] Unexpected EOF while waiting for input\n");
+            exit(1);
+          }
+          System::Get().Log("\nValidation results:\n");
+        } else {
+          System::Get().Log("Validation results:\n");
         }
-        System::Get().Log("\nValidation results:\n");
 
         size_t initOffset = cfg.data.byteOffset / sizeof(float);
         int numPass = 0, numFail = 0;
@@ -6076,14 +6083,16 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
               if (firstErr < N) {
                 System::Get().Log("  DST[%d]=FAIL(first mismatch idx=%zu exp=%.5f got=%.5f)",
                                   dstIdx, firstErr, expected[firstErr], output[firstErr]);
-                errResults.push_back({ERR_FATAL,
-                  "Transfer %d: Unexpected mismatch at index %lu of destination %d on rank %d: Expected %10.5f Actual: %10.5f",
-                  transferIdx, firstErr, dstIdx, t.dsts[dstIdx].memRank, expected[firstErr], output[firstErr]});
+                if (isValidationPath)
+                  errResults.push_back({ERR_FATAL,
+                    "Transfer %d: Unexpected mismatch at index %lu of destination %d on rank %d: Expected %10.5f Actual: %10.5f",
+                    transferIdx, firstErr, dstIdx, t.dsts[dstIdx].memRank, expected[firstErr], output[firstErr]});
               } else {
                 System::Get().Log("  DST[%d]=FAIL(bitwise mismatch, no float-level diff found)",
                                   dstIdx);
-                errResults.push_back({ERR_FATAL,
-                  "Transfer %d: Unexpected output mismatch for destination %d", transferIdx, dstIdx});
+                if (isValidationPath)
+                  errResults.push_back({ERR_FATAL,
+                    "Transfer %d: Unexpected output mismatch for destination %d", transferIdx, dstIdx});
               }
               transferOk = false;
             }


### PR DESCRIPTION
## Motivation

Adds a performance debug option that disables validation, so only the initialization and actual transfers execute.

Previously, `ALWAYS_VALIDATE` was a boolean (0 = validate once at the end, 1 = validate every iteration), with no way to skip validation entirely. This makes it difficult to isolate pure transfer/initialization cost from validation overhead.

## Technical Details

Adds a "disable" option to `ALWAYS_VALIDATE` while preserving the existing 0/1 behavior (backward compatible):

- `ALWAYS_VALIDATE=-1` — validation **disabled** (init + transfers only)
- `ALWAYS_VALIDATE=0` — validate **once at the end** (default, unchanged)
- `ALWAYS_VALIDATE=1` — validate **after each iteration** (unchanged)

Changes:
- `src/header/TransferBench.hpp`: per-iteration validation gated on `== 1`; end-of-run validation gated on `== 0`; disabled when `== -1`.
- `src/client/EnvVars.hpp`: updated field comment, help text, and runtime print description for the three modes.
- `src/client/Presets/SmokeTest.hpp`: continues to default to `1` (validate each iteration).
- Interactive mode (`USE_INTERACTIVE=1`): validation is now a separate stage requiring an `<Enter>` keypress rather than running as part of the transfer stage. It respects `ALWAYS_VALIDATE` — skipped for `-1`, `<Enter>`-gated for `0`, and skipped for `1` (which already validates inline each iteration).

## Test Plan

- Built with `make clean && make -j`.
- Ran `./TransferBench cmdline 1K "1 1 g0 d0 g1"` across `ALWAYS_VALIDATE={-1,0,1}` and `USE_INTERACTIVE={0,1}`.

## Test Result

- `ALWAYS_VALIDATE=-1` — no validation output; only init + transfers execute (including under `USE_INTERACTIVE=1`). Confirmed with `AMD_LOG_LEVEL` that there's no CopyDeviceToHost at the end.
- `ALWAYS_VALIDATE=0` (default) — single validation at end; in interactive mode it waits for `<Enter>` before validating and printing PASS/FAIL results.
- `ALWAYS_VALIDATE=1` — validates each iteration inline; no extra Enter-gated stage in interactive mode.
- All transfers reported `PASS`; builds clean with no new warnings.
 
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
