### PR TITLE
Adding a hipDeviceSynchronize after input hipMemcpy

### DIFF
--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -5951,6 +5951,7 @@ static bool IsConfiguredGid(union ibv_gid const& gid)
             }
             ERR_APPEND(hipMemcpy(resource->srcMem[srcIdx] + initOffset, srcReference[srcIdx].data(), resource->numBytes,
                                  hipMemcpyDefault), errResults);
+            ERR_APPEND(hipDeviceSynchronize(), errResults);
           }
         }
       }


### PR DESCRIPTION
## Motivation
hipMemcpy isn't actually blocking, which means we require a hipDeviceSynchronize() to ensure that it finishes before any Transfers start.