### PR TITLE
TransferBench v1.69.01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Documentation for TransferBench is available at
 [https://rocm.docs.amd.com/projects/TransferBench](https://rocm.docs.amd.com/projects/TransferBench).
 
+## v1.69.01
+### Added
+- Added support for ABI change introduced in amd-smi 27.0.0 (ROCm 10.0)
+
 ## v1.69.00
 ### Added
 - Added support for `ALWAYS_VALIDATE=-1` to disable validation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,8 @@ set(ENV{ROCM_PATH} "${ROCM_PATH}")
 # TransferBench project definitions
 #==================================================================================================
 set(TRANSFERBENCH_VERSION_MAJOR 1)
-set(TRANSFERBENCH_VERSION_MINOR 67)
-set(TRANSFERBENCH_VERSION_PATCH_FALLBACK "00")
+set(TRANSFERBENCH_VERSION_MINOR 69)
+set(TRANSFERBENCH_VERSION_PATCH_FALLBACK "01")
 
 # Auto-compute patch from git: count commits since the last v<MAJOR>.<MINOR>.* tag.
 # Falls back to TRANSFERBENCH_VERSION_PATCH_FALLBACK when git is unavailable,
@@ -411,8 +411,6 @@ else()
             amdsmi_get_processor_handle_from_bdf(bdf, &h);
             amdsmi_fabric_info_t fi;
             amdsmi_get_gpu_fabric_info(h, &fi);
-            (void)fi.fabric_info.fabric_version.v1.ppod_id;
-            (void)fi.fabric_info.fabric_version.v1.vpod_id;
             return 0;
           }" AMDSMI_HAS_FABRIC)
         cmake_pop_check_state()

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ ifeq ($(filter clean,$(MAKECMDGOALS)),)
     endif
     GPU_TARGETS_FLAGS = $(foreach target,$(GPU_TARGETS),"--offload-arch=$(target)")
     $(info Compiling for $(GPU_TARGETS) architecture(s). Can modify this by setting GPU_TARGETS)
-    CXXFLAGS = -I. -I$(ROCM_PATH)/include -I$(ROCM_PATH)/include/hip -I$(ROCM_PATH)/include/hsa
+    CXXFLAGS = -std=c++17 -I. -I$(ROCM_PATH)/include -I$(ROCM_PATH)/include/hip -I$(ROCM_PATH)/include/hsa
     HIPLDFLAGS= -lnuma -L$(ROCM_PATH)/lib -lhsa-runtime64 -lamdhip64
     HIPFLAGS = -Wall -x hip -D__HIP_PLATFORM_AMD__ -D__HIPCC__ $(GPU_TARGETS_FLAGS)
     ifneq ($(strip $(ROCM_DEVICE_LIB_PATH)),)
@@ -224,8 +224,6 @@ ifeq ($(filter clean,$(MAKECMDGOALS)),)
                   '  amdsmi_get_processor_handle_from_bdf(bdf, &h);' \
                   '  amdsmi_fabric_info_t fi;' \
                   '  amdsmi_get_gpu_fabric_info(h, &fi);' \
-                  '  (void)fi.fabric_info.fabric_version.v1.ppod_id;' \
-                  '  (void)fi.fabric_info.fabric_version.v1.vpod_id;' \
                   '  return 0;' \
                   '}' | \
                 $(CXX) -I$(ROCM_PATH)/include -x c++ - \

--- a/src/client/EnvVars.hpp
+++ b/src/client/EnvVars.hpp
@@ -44,7 +44,7 @@ THE SOFTWARE.
 #include <random>
 #include <time.h>
 
-#define CLIENT_VERSION "00"
+#define CLIENT_VERSION "01"
 
 #include "TransferBench.hpp"
 using namespace TransferBench;

--- a/src/header/TransferBench.hpp
+++ b/src/header/TransferBench.hpp
@@ -52,7 +52,9 @@ THE SOFTWARE.
 #include <sys/socket.h>
 #include <sys/utsname.h>
 #include <thread>
+#include <type_traits>
 #include <unistd.h>
+#include <utility>
 #include <vector>
 
 #include "IbvDynLoad.hpp"
@@ -793,6 +795,26 @@ namespace TransferBench
 // Helper functions ('hidden' in anonymous namespace)
 //========================================================================================
 namespace {
+
+#ifdef AMD_SMI_ENABLED
+template <typename T, typename = void>
+struct AmdSmiFabricInfoIsFlat : std::false_type {};
+
+template <typename T>
+struct AmdSmiFabricInfoIsFlat<T, std::void_t<decltype(std::declval<const T&>().fabric_info.v1)>>
+    : std::true_type {};
+
+template <typename T>
+const auto& AmdSmiFabricInfoV1(const T& info)
+{
+  if constexpr (AmdSmiFabricInfoIsFlat<T>::value) {
+    return info.fabric_info.v1;      // New layout (amd-smi 27+): fabric_info.v1
+  } else {
+    return info.fabric_info.fabric_version.v1;  // Old layout (pre-27): fabric_info.fabric_version.v1
+  }
+}
+
+#endif
 
 // Constants
 //========================================================================================
@@ -7287,9 +7309,9 @@ namespace {
         if (err == AMDSMI_STATUS_SUCCESS) {
           // NOTE: vpod_id is a uint32_t but System holds it as an int64_t to allow for
           //       vpodId == -1 to represent no pod present
-          memcpy(ppodId, &fabricInfo.fabric_info.fabric_version.v1.ppod_id,
-                 sizeof(fabricInfo.fabric_info.fabric_version.v1.ppod_id));
-          vpodId = fabricInfo.fabric_info.fabric_version.v1.vpod_id;
+          const auto& fabricV1 = AmdSmiFabricInfoV1(fabricInfo);
+          memcpy(ppodId, fabricV1.ppod_id, sizeof(fabricV1.ppod_id));
+          vpodId = fabricV1.vpod_id;
         } else if (verbose) {
           const char *errString = NULL;
           amdsmi_status_code_to_string(err, &errString);


### PR DESCRIPTION
## Motivation

Emergency push to support amd-smi 27 fabric layout.
amd-smi 27.0.0 flattens the fabric v1 payload while preserving its binary layout. Select the payload accessor from the header shape so pod discovery builds with both nested pre-27 and flattened 27+ declarations.

## Technical Details

- Keep the Makefile/CMake build probes layout-independent
- Modify Makefile to use C++17 for compile-time dispatch.
- Bump minor version to 1.69.01

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
